### PR TITLE
ns-api-server: download from nethsecurity-api repo

### DIFF
--- a/packages/ns-api-server/Makefile
+++ b/packages/ns-api-server/Makefile
@@ -9,8 +9,9 @@ PKG_NAME:=ns-api-server
 PKG_VERSION:=0.0.2
 PKG_RELEASE:=1
  
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/nethserver/ns-api-server/tar.gz/$(PKG_VERSION)?
+PKG_SOURCE:=ns-api-server-$(PKG_VERSION).tar.gz
+PKG_BUILD_DIR=$(BUILD_DIR)/nethsecurity-api-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://codeload.github.com/nethserver/nethsecurity-api/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=skip
 
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>
@@ -20,7 +21,7 @@ PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
-GO_PKG:=github.com/NethServer/ns-api-server
+GO_PKG:=github.com/NethServer/nethsecurity-api
 
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/golang/golang-package.mk
@@ -43,7 +44,7 @@ define Package/ns-api-server/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/ns-api-server.initd $(1)/etc/init.d/ns-api-server
 	$(INSTALL_DIR) $(1)/usr/sbin/
-	$(INSTALL_BIN) $(GO_PKG_BUILD_DIR)/bin/ns-api-server $(1)/usr/sbin/
+	$(INSTALL_BIN) $(GO_PKG_BUILD_DIR)/bin/nethsecurity-api $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_CONF) files/ns-api-server.keep $(1)/lib/upgrade/keep.d/ns-api-server
 endef

--- a/packages/ns-api-server/files/ns-api-server.initd
+++ b/packages/ns-api-server/files/ns-api-server.initd
@@ -7,7 +7,7 @@
 
 START=90
 USE_PROCD=1
-PROG=/usr/sbin/ns-api-server
+PROG=/usr/sbin/nethsecurity-api
 
 WORK_DIR=/var/run/ns-api-server
 TOKENS_DIR=${WORK_DIR}/tokens


### PR DESCRIPTION
Repository should be renamed to contain controller and stand-alone APIs.