### PR TITLE
banIP: remove logd dependency

### DIFF
--- a/packages/banip/Makefile
+++ b/packages/banip/Makefile
@@ -16,7 +16,7 @@ define Package/banip
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=banIP blocks IPs via named nftables Sets
-	DEPENDS:=+jshn +jsonfilter +firewall4 +ca-bundle +logd +rpcd +rpcd-mod-rpcsys
+	DEPENDS:=+jshn +jsonfilter +firewall4 +ca-bundle +rpcd +rpcd-mod-rpcsys
 	PKGARCH:=all
 endef
 

--- a/packages/banip/files/banip.tpl
+++ b/packages/banip/files/banip.tpl
@@ -8,7 +8,7 @@ local banip_info report_info log_info system_info mail_text
 
 banip_info="$(/etc/init.d/banip status 2>/dev/null | awk '{NR=1;max=140;if(length($0)>max+1)while($0){if(NR==1){print substr($0,1,max)}else{print substr($0,1,max)}{$0=substr($0,max+1);NR=NR+1}}else print}')"
 report_info="$(cat ${ban_reportdir}/ban_report.txt 2>/dev/null)"
-log_info="$("${ban_logreadcmd}" -l 100 -e "banIP/" 2>/dev/null | awk '{NR=1;max=140;if(length($0)>max+1)while($0){if(NR==1){print substr($0,1,max)}else{print substr($0,1,max)}{$0=substr($0,max+1);NR=NR+1}}else print}')"
+log_info="$(tail -n 100 /var/log/messages | grep "banIP/" 2>/dev/null | awk '{NR=1;max=140;if(length($0)>max+1)while($0){if(NR==1){print substr($0,1,max)}else{print substr($0,1,max)}{$0=substr($0,max+1);NR=NR+1}}else print}')"
 system_info="$(
 	strings /etc/banner 2>/dev/null
 	ubus call system board | awk 'BEGIN{FS="[{}\"]"}{if($2=="kernel"||$2=="hostname"||$2=="system"||$2=="model"||$2=="description")printf "  + %-12s: %s\n",$2,$4}'


### PR DESCRIPTION
logd and rsyslogd cannot be used together: drop logd support and parse /var/log/messages to find failed authentications.