### PR TITLE
ns-api: add ns.firewall API

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -62,6 +62,8 @@ define Package/ns-api/install
 	$(INSTALL_DATA) ./files/ns.ovpntunnel.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_BIN) ./files/ns.smtp $(1)/usr/libexec/rpcd/
 	$(INSTALL_DATA) ./files/ns.smtp.json $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_BIN) ./files/ns.firewall $(1)/usr/libexec/rpcd/
+	$(INSTALL_DATA) ./files/ns.firewall.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_CONF) files/msmtp.keep $(1)/lib/upgrade/keep.d/msmtp
 	$(LN) /usr/bin/msmtp $(1)/usr/sbin/sendmail

--- a/packages/ns-api/files/ns.firewall
+++ b/packages/ns-api/files/ns.firewall
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# List firewall rules
+
+import sys
+import json
+from euci import EUci
+from nethsec import utils
+
+def list_rules(param = ''):
+    u = EUci()
+    rules = utils.get_all_by_type(u, 'firewall', 'rule')
+    print(json.dumps({"rules": list(rules.values())}))
+
+cmd = sys.argv[1]
+
+if cmd == 'list':
+    print(json.dumps({"rules": {}}))
+elif cmd == 'call':
+    action = sys.argv[2]
+    if action == "rules":
+        list_rules()

--- a/packages/ns-api/files/ns.firewall.json
+++ b/packages/ns-api/files/ns.firewall.json
@@ -1,0 +1,14 @@
+{
+  "firewall-manager": {
+    "description": "Firewall manager",
+    "write": {},
+    "read": {
+      "ubus": {
+        "ns.firewall": [
+          "rules"
+        ]
+      }
+    }
+  }
+}
+

--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -14,7 +14,7 @@ PKG_LICENSE:=GPL-3.0-only
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/NethServer/python3-nethsec
-PKG_SOURCE_VERSION:=50675e6dea8922bc0d3c23edd046d80f3dd848b9
+PKG_SOURCE_VERSION:=98e28e9e21c2b814da626d7bfb71e52bcbc3409d
 
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
@@ -23,7 +23,7 @@ define Package/python3-nethsec
 	SECTION:=base
 	CATEGORY:=NethSecurity
 	TITLE:=NethSecurity python libraries
-	URL:=https://github.com/NethServer/nethsecurity-controller/
+	URL:=https://github.com/NethServer/python3-nethsec/
 	DEPENDS:=+python3-light +python3-uci
 	PKGARCH:=all
 endef


### PR DESCRIPTION
List firewall rules preserving order.
The default uci call returns a firewall object.
Firewall object do not preserve the order.