### PR TITLE
packages: remove luci-app-openvpn

### DIFF
--- a/config/luci.conf
+++ b/config/luci.conf
@@ -20,7 +20,6 @@ CONFIG_PACKAGE_luci-theme-bootstrap=y
 CONFIG_PACKAGE_rpcd-mod-luci=y
 CONFIG_PACKAGE_luci-app-adblock=y
 CONFIG_PACKAGE_luci-app-mwan3=y
-CONFIG_PACKAGE_luci-app-openvpn=y
 CONFIG_PACKAGE_luci-app-wireguard=y
 CONFIG_PACKAGE_luci-proto-3g=y
 CONFIG_PACKAGE_luci-proto-bonding=y


### PR DESCRIPTION
luci-app-openvpn is an old app dependant on luci-compat.
