### PR TITLE
ns-dpi: add signature downloader

### DIFF
--- a/packages/ns-dpi/Makefile
+++ b/packages/ns-dpi/Makefile
@@ -30,6 +30,24 @@ define Package/ns-dpi/description
 	Traffic rules for network flows
 endef
 
+define Package/ns-dpi/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+  (. /etc/uci-defaults/20_dpi)
+  rm -f /etc/uci-defaults/20_dpi
+  /etc/init.d/cron restart
+fi
+exit 0
+endef
+
+define Package/ns-dpi/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	crontab -l | grep -v "/usr/sbin/dpi-update" | sort | uniq | crontab -
+fi
+exit 0
+endef
+
 # this is required, otherwise compile will fail
 define Build/Compile
 endef
@@ -44,7 +62,10 @@ define Package/ns-dpi/install
 	$(INSTALL_BIN) ./files/dpi-start $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/dpi-nft $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/dpi-config $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/dpi-update $(1)/usr/sbin/
 	$(INSTALL_CONF) ./files/20_dpi $(1)/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/usr/share/ns-plug/hooks/register
+	$(LN) /usr/sbin/dpi-update $(1)/usr/share/ns-plug/hooks/register/80dpi-update
 endef
 
 $(eval $(call BuildPackage,ns-dpi))

--- a/packages/ns-dpi/README.md
+++ b/packages/ns-dpi/README.md
@@ -109,7 +109,7 @@ netifyd -R -d -I br-lan -E eth1
 By default, netifyd is equipped to detect around 430 protocols and applications. With the inclusion of
 supplementary signatures, netifyd can extend its recognition capabilities to encompass over 1600 protocols and applications.
 
-Extra signatures are accessibile only from machine with a a valid Enterprise subscription.
+Extra signatures are accessible only from a machine with a valid subscription.
 A cron job will update DPI signatures during the night and upon machine registration.
 The download will be authenticated using a Nethesis proxy.
 

--- a/packages/ns-dpi/README.md
+++ b/packages/ns-dpi/README.md
@@ -103,3 +103,26 @@ If needed, start netifyd in debug mode:
 ```
 netifyd -R -d -I br-lan -E eth1
 ```
+
+## Supplementary signatures
+
+By default, netifyd is equipped to detect around 430 protocols and applications. With the inclusion of
+supplementary signatures, netifyd can extend its recognition capabilities to encompass over 1600 protocols and applications.
+
+Extra signatures are accessibile only from machine with a a valid Enterprise subscription.
+A cron job will update DPI signatures during the night and upon machine registration.
+The download will be authenticated using a Nethesis proxy.
+
+To force the update execute:
+```
+dpi-update
+```
+
+You can use a different proxy by overriding the `HOST` env variable.
+If the proxy is authenticated, use the `__USER__` and `__PASSWORD__` placeholders.
+The placeholders will be replaced with systemd id and secret from `ns-plug`.
+
+Example:
+```
+HOST=http://__USER__:__PASSWORD__@sp.gs.nethserver.net dpi-update
+```

--- a/packages/ns-dpi/files/20_dpi
+++ b/packages/ns-dpi/files/20_dpi
@@ -8,3 +8,5 @@ config main 'config'
 	option enabled '0'
 	option firewall_exemption '0'
 EOI
+
+crontab -l | grep -q '/usr/sbin/dpi-update' || echo '8 4 * * * sleep $(( RANDOM % 3600 )); /usr/sbin/dpi-update' >> /etc/crontabs/root

--- a/packages/ns-dpi/files/dpi-update
+++ b/packages/ns-dpi/files/dpi-update
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+#
+# DPI: download signatures
+#
+
+OUT_DIR=${OUT_DIR:-"/etc/netify.d"}
+HOST=${HOST:-"https://__USER__:__PASSWORD__@sp.nethesis.it"}
+TMP_DIR=${TMP_DIR:-"/tmp/signatures-download"}
+
+trap "rm -rf $TMP_DIR" EXIT SIGINT SIGTERM
+
+SYSTEM_SECRET=$(uci -q get ns-plug.config.secret)
+SYSTEM_ID=$(uci -q get ns-plug.config.system_id)
+
+if [ -z "$SYSTEM_SECRET" ] || [ -z "$SYSTEM_ID" ]; then
+    exit 0
+fi
+
+set -e
+mkdir -p "$TMP_DIR"
+
+version=$(netifyd --help 2>&1| grep "Netify Agent/" | cut -d'/' -f 2 | cut -d' ' -f1)
+options="settings_version=$version&settings_format=netifyd"
+curl_cmd='/usr/bin/curl -L -s -f -m 10'
+
+base_url=$(echo $HOST | sed -e "s/__USER__/$SYSTEM_ID/" -e "s/__PASSWORD__/$SYSTEM_SECRET/")
+
+$curl_cmd "$base_url/applications?$options" -o "$TMP_DIR/netify-apps.conf"
+$curl_cmd "$base_url/categories?$options" -o "$TMP_DIR/netify-categories.json"
+
+mv "$TMP_DIR/netify-apps.conf" "$OUT_DIR"
+mv "$TMP_DIR/netify-categories.json/" "$OUT_DIR"
+
+/etc/init.d/netifyd reload


### PR DESCRIPTION
Download dpi signatures for netifyd:
- every night
- upon machine registration

Signatures are downloaded using an authenticated proxy.
The machine must have a valid subscription to access the proxy.

Available test proxy server: `sp.gs.nethserver.net`
To test the download:
```
HOST=http://__USER__:__PASSWORD__@sp.gs.nethserver.net bash -x dpi-update
```