### PR TITLE
patches: restart rsyslog on timezone change

### DIFF
--- a/patches/package/base-files/010-restart_systemd.patch
+++ b/patches/package/base-files/010-restart_systemd.patch
@@ -1,0 +1,14 @@
+diff -Naur base-files.ori/files/etc/init.d/system base-files/files/etc/init.d/system
+--- base-files.ori/files/etc/init.d/system	2023-08-11 08:51:46.833625045 +0000
++++ base-files/files/etc/init.d/system	2023-08-11 08:56:38.824734040 +0000
+@@ -28,6 +28,9 @@
+ 
+ 	# apply timezone to kernel
+ 	hwclock -u --systz
++
++	# apply timezone to rsyslog
++	/etc/init.d/rsyslog restart
+ }
+ 
+ reload_service() {
+


### PR DESCRIPTION
See https://trello.com/c/nzx9A1kZ/86-restart-rsyslogd-after-tz-change