### PR TITLE
Remove wan6 from config/firewall 

### DIFF
--- a/files/etc/config/firewall
+++ b/files/etc/config/firewall
@@ -14,7 +14,6 @@ config zone 'ns_lan'
 config zone 'ns_wan'
 	option name		wan
 	list   network		'wan'
-	list   network		'wan6'
 	option input		REJECT
 	option output		ACCEPT
 	option forward		REJECT


### PR DESCRIPTION
"wan6" is not present anymore in a fresh installation