### PR TITLE
ns-api: better param handling on ns.dpireport

### DIFF
--- a/packages/ns-api/files/ns.dpireport
+++ b/packages/ns-api/files/ns.dpireport
@@ -30,8 +30,10 @@ def summary(year, month, day):
     hours = dict()
     for i in range(24):
         hours[f'{i:02}'] = 0
-    ret = {"total": 0, "clients": {}, "hours": hours, "names": {}, "protocol": {}, "host": {}, "application": {}}
-
+    ret = {"total": 0, "clients": {}, "hours": {"h": hours}, "names": {}, "protocol": {}, "host": {}, "application": {}}
+    # prepenad leading zero, if needed
+    month = f'{int(month):02}'
+    day = f'{int(day):02}'
     for client_f in glob.glob(f'/var/run/dpireport/{year}/{month}/{day}/*'):
         client = client_f.removeprefix(f'/var/run/dpireport/{year}/{month}/{day}/')
         cdetails = details(year, month, day, client)


### PR DESCRIPTION
Month and day are always padded with 0.
The API is now more robust and accept also input
parameters day and month without the leading zero.