### PR TITLE
Changes to DPI api

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-api
-PKG_VERSION:=0.0.8
+PKG_VERSION:=0.0.9
 PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-api-$(PKG_VERSION)

--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -2051,7 +2051,8 @@ Example response:
     {
       "config-name": "ns_3869dc35",
       "enabled": true,
-      "interface": "eth4",
+      "device": "eth4",
+      "interface": "GREEN_1",
       "action": "block",
       "criteria": [
         {
@@ -2100,13 +2101,13 @@ Example response:
 Add DPI rule:
 
 ```bash
-api-cli ns.dpi add-rule --data '{"enabled": false, "interface": "eth4", "applications": [], "protocols": ["HTTP/S"]}'
+api-cli ns.dpi add-rule --data '{"enabled": false, "device": "eth4", "applications": [], "protocols": ["HTTP/S"]}'
 ```
 
 Rundown of required parameters:
 
 - `enabled`: `true` or `false`
-- `interface`: device name, e.g. `eth4`
+- `device`: device name, e.g. `eth4`
 - `applications`: list of application names, e.g. `["netify.spotify", "netify.adobe"]`, refer to `list-applications`
   api.
 - `protocols`: list of protocol names, e.g. `["HTTP/S"]`, refer to `list-applications` api.
@@ -2144,13 +2145,13 @@ Example response:
 Edit DPI rule:
 
 ```bash
-api-cli ns.dpi edit-rule --data '{"config-name": "ns_f1c6e9e0", "enabled": true, "interface": "eth4", "applications": ["netify.spotify", "netify.adobe"], "protocols": []}'
+api-cli ns.dpi edit-rule --data '{"config-name": "ns_f1c6e9e0", "enabled": true, "device": "eth4", "applications": ["netify.spotify", "netify.adobe"], "protocols": []}'
 ```
 
 Rundown of required parameters:
 - `config-name`: rule name, refer to `list-rules` api.
 - `enabled`: `true` or `false`
-- `interface`: device name, e.g. `eth4`
+- `device`: device name, e.g. `eth4`
 - `applications`: list of application names, e.g. `["netify.spotify", "netify.adobe"]`, refer to `list-applications`
   api.
 - `protocols`: list of protocol names, e.g. `["HTTP/S"]`, refer to `list-applications` api.

--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -2164,6 +2164,31 @@ Example response:
 }
 ```
 
+### list-devices
+
+List available devices to be added to DPI rules:
+
+```bash
+api-cli ns.dpi list-devices
+```
+
+Example response:
+
+```json
+{
+  "values": [
+    {
+      "interface": "GREEN_1",
+      "device": "eth0"
+    },
+    {
+      "interface": "GREEN_2",
+      "device": "eth4"
+    }
+  ]
+}
+```
+
 ## ns.flashstart
 
 Manage Flashstart service configuration.

--- a/packages/ns-api/files/ns.dpi
+++ b/packages/ns-api/files/ns.dpi
@@ -23,7 +23,7 @@ if cmd == 'list':
         'list-rules': {},
         'add-rule': {
             'enabled': False,
-            'interface': 'str',
+            'device': 'str',
             'applications': 'str',
             'protocols': 'str'
         },
@@ -33,7 +33,7 @@ if cmd == 'list':
         'edit-rule': {
             'config-name': 'str',
             'enabled': False,
-            'interface': 'str',
+            'device': 'str',
             'applications': 'str',
             'protocols': 'str'
         }
@@ -50,7 +50,7 @@ elif cmd == 'call':
             print(json.dumps({'values': dpi.list_rules(e_uci)}))
         elif action == 'add-rule':
             data = json.JSONDecoder().decode(sys.stdin.read())
-            dpi.add_rule(e_uci, data['enabled'], data['interface'], 'block', data['applications'], data['protocols'])
+            dpi.add_rule(e_uci, data['enabled'], data['device'], 'block', data['applications'], data['protocols'])
             print(json.dumps({'message': 'success'}))
         elif action == 'delete-rule':
             data = json.JSONDecoder().decode(sys.stdin.read())
@@ -58,7 +58,7 @@ elif cmd == 'call':
             print(json.dumps({'message': 'success'}))
         elif action == 'edit-rule':
             data = json.JSONDecoder().decode(sys.stdin.read())
-            dpi.edit_rule(e_uci, data['config-name'], data['enabled'], data['interface'], 'block', data['applications'],
+            dpi.edit_rule(e_uci, data['config-name'], data['enabled'], data['device'], 'block', data['applications'],
                           data['protocols'])
             print(json.dumps({'message': 'success'}))
     except KeyError as e:

--- a/packages/ns-api/files/ns.dpi
+++ b/packages/ns-api/files/ns.dpi
@@ -36,7 +36,8 @@ if cmd == 'list':
             'device': 'str',
             'applications': 'str',
             'protocols': 'str'
-        }
+        },
+        'list-devices': {}
     }))
 elif cmd == 'call':
     action = sys.argv[2]
@@ -61,6 +62,8 @@ elif cmd == 'call':
             dpi.edit_rule(e_uci, data['config-name'], data['enabled'], data['device'], 'block', data['applications'],
                           data['protocols'])
             print(json.dumps({'message': 'success'}))
+        elif action == 'list-devices':
+            print(json.dumps({'values': dpi.list_devices(e_uci)}))
     except KeyError as e:
         print(json.dumps(utils.validation_error(e.args[0], 'required')))
     except json.JSONDecodeError:

--- a/packages/ns-dpi/files/dpi-config
+++ b/packages/ns-dpi/files/dpi-config
@@ -117,7 +117,7 @@ for section in u.get_all('dpi'):
 
     config["actions"][f"rule{rcount}"] = {
         "enabled": rule['enabled'] == '1',
-        "interface": rule.get('interface', '*'),
+        "interface": rule.get('device', '*'),
         "criteria": criteria,
         "targets": [rule['action']],
         "exemptions": rule.get('exemption', [])

--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=python3-nethsec
-PKG_VERSION:=0.0.7
+PKG_VERSION:=0.0.8
 PKG_RELEASE:=1
  
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>


### PR DESCRIPTION
- renamed DPI parameter `interface` to `device`, removing every doubt that would have come up regards of what this field was supposed to contain
- added `list-devices` api and examples

Requiring `python3-nethsec:0.0.8` to work, please wait for NethServer/python3-nethsec#13 to be merged and tagged.
