### PR TITLE
OpenVPN: OTP authentication + client export improvements

### DIFF
--- a/otp.conf
+++ b/otp.conf
@@ -1,0 +1,2 @@
+CONFIG_PACKAGE_liboath=y
+CONFIG_PACKAGE_oath-toolkit=y

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -209,7 +209,6 @@ The `openvpn` script will import:
 - LDAP configuration for remote authentication
 
 The following NS7 features are still not migrated:
-- authentication certificate and One Time password (OTP)
 - mail notification
 
 Existing data from connection database are not imported.

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -87,6 +87,9 @@ if data['rw']['auth'] == 'password':
 elif data['rw']['auth'] == 'password-certificate':
     u.set("openvpn", iname, 'auth_user_pass_verify', f'{auth_script} via-env')
     u.set("openvpn", iname, 'script_security', '3')
+elif data['rw']['auth'] == 'certificate-otp':
+    u.set("openvpn", iname, 'auth_user_pass_verify', '/usr/libexec/ns-openvpn/openvpn-otp-auth via-env')
+    u.set("openvpn", iname, 'script_security', '3')
 
 # Create user entries
 for user in data["users"]:
@@ -96,7 +99,10 @@ for user in data["users"]:
     u.set("openvpn", sname, "instance", iname)
     u.set("openvpn", sname, "ipaddr", user["ipaddr"])
     u.set("openvpn", sname, "enabled", user["enabled"])
-    u.set("openvpn", sname, "password", user["password"])
+    if 'password' in user:
+        u.set("openvpn", sname, "password", user["password"])
+    if '2fa' in user:
+        u.set("openvpn", sname, "2fa", user["2fa"])
     save_cert(os.path.join(cert_dir, f'private/{sname}.key'), user['key'])
     save_cert(os.path.join(cert_dir, f'issued/{sname}.crt'), user['crt'])
 

--- a/packages/ns-openvpn/Makefile
+++ b/packages/ns-openvpn/Makefile
@@ -50,6 +50,7 @@ define Package/ns-openvpn/install
 	$(INSTALL_BIN) ./files/init-connections-db $(1)/usr/libexec/ns-openvpn/
 	$(INSTALL_BIN) ./files/openvpn-local-auth $(1)/usr/libexec/ns-openvpn/
 	$(INSTALL_BIN) ./files/openvpn-remote-auth $(1)/usr/libexec/ns-openvpn/
+	$(INSTALL_BIN) ./files/openvpn-otp-auth $(1)/usr/libexec/ns-openvpn/
 	$(INSTALL_BIN) ./files/01-check-status $(1)/usr/libexec/ns-openvpn/connect-scripts
 	$(INSTALL_BIN) ./files/10-static-lease $(1)/usr/libexec/ns-openvpn/connect-scripts
 	$(INSTALL_BIN) ./files/10-tunnel-iroute $(1)/usr/libexec/ns-openvpn/connect-scripts

--- a/packages/ns-openvpn/files/ns-openvpnrw-print-client
+++ b/packages/ns-openvpn/files/ns-openvpnrw-print-client
@@ -32,7 +32,12 @@ else:
     print("proto tcp-client")
 
 print(f"port {u.get('openvpn', instance, 'port')}")
-print(f"remote {socket.getfqdn()}")
+try:
+    remote = u.get_all("openvpn", instance, 'ns_public_ip')
+    for r in remote:
+        print(f"remote {r}")
+except:
+    print(f"remote {socket.getfqdn()}")
 
 print(f'<ca>{slurp(os.path.join(cert_dir, "ca.crt"))}</ca>')
 print(f'<cert>{slurp(os.path.join(cert_dir, f"issued/{user}.crt"))}</cert>')

--- a/packages/ns-openvpn/files/ns-openvpnrw-print-client
+++ b/packages/ns-openvpn/files/ns-openvpnrw-print-client
@@ -43,9 +43,9 @@ try:
 except:
     print(f"remote {socket.getfqdn()}")
 
-print(f'<ca>{slurp(os.path.join(cert_dir, "ca.crt"))}</ca>')
-print(f'<cert>{slurp(os.path.join(cert_dir, f"issued/{user}.crt"))}</cert>')
-print(f'<key>{slurp(os.path.join(cert_dir, f"private/{user}.key"))}</key>')
+print(f'<ca>\n{slurp(os.path.join(cert_dir, "ca.crt"))}\n</ca>')
+print(f'<cert>\n{slurp(os.path.join(cert_dir, f"issued/{user}.crt"))}\n</cert>')
+print(f'<key>\n{slurp(os.path.join(cert_dir, f"private/{user}.key"))}\n</key>')
 
 for option in ["auth", "digest"]:
     try:
@@ -60,3 +60,5 @@ print("persist-key")
 print("persist-tun")
 print("nobind")
 print("passtos")
+# allow compression protocol to be pushed by the server, default is disabled
+print("compress")

--- a/packages/ns-openvpn/files/ns-openvpnrw-print-client
+++ b/packages/ns-openvpn/files/ns-openvpnrw-print-client
@@ -31,6 +31,10 @@ if u.get("openvpn", instance, "proto") == "udp":
 else:
     print("proto tcp-client")
 
+if u.get("openvpn", instance, "auth_user_pass_verify", default=""):
+    print("auth-user-pass")
+    print("auth-nocache")
+
 print(f"port {u.get('openvpn', instance, 'port')}")
 try:
     remote = u.get_all("openvpn", instance, 'ns_public_ip')

--- a/packages/ns-openvpn/files/openvpn-otp-auth
+++ b/packages/ns-openvpn/files/openvpn-otp-auth
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# Used env variables:
+# - username
+# - password (this is the OTP)
+# - config
+
+. /lib/functions.sh
+cur_instance=$(echo $config | sed -e 's/openvpn\-//' -e 's/\.conf//')
+
+config_load 'openvpn'
+
+config_get enabled "$username" enabled 0
+config_get user_instance "$username" instance ''
+config_get secret "$username" 2fa ''
+
+if [ "$cur_instance" != "$user_instance" ]; then
+    exit 2
+fi
+
+if [ "$enabled" = "0" ]; then
+    exit 3
+fi
+
+if [ -z "$secret" ]; then
+    exit 4
+fi
+
+otp=$(/usr/bin/oathtool --totp=SHA1 "$secret")
+
+if [ "$otp" = "$password" ]; then
+    exit 0
+fi
+
+exit 1


### PR DESCRIPTION
TODO:

- [x] update ns-openvpn documentation
- [x] update ns-migration documentation
- [x] add oath-toolkit
- [x] change `ns-openvpnrw-print-client` to correctly set the auth script
- [x] `ns-openvpnrw-print-client` use ns_public_ip for remote
- [x]  `ns-openvpnrw-print-client` set `compress` option https://trello.com/c/HhuG5bx4/208-openvpn-rw-improve-management-of-compression-settings not required
- [x] release nethserver-firewall-migration
- [x] migration: export also Remote to ns_public_ip

See also:
- https://github.com/NethServer/nethserver-firewall-migration/commit/1b165f7fa81a615c21c0fbffd86632310dd40b64
- https://github.com/NethServer/nethserver-firewall-migration/commit/22593ce43356bbd42f60b0a345e292457b6e9737
- 