### PR TITLE
OpenSSH fix: disable listening on port 22

### DIFF
--- a/packages/openssh/Config.in
+++ b/packages/openssh/Config.in
@@ -1,0 +1,12 @@
+if PACKAGE_openssh-server
+
+config OPENSSH_LIBFIDO2
+	bool
+	default y
+	prompt "Include libfido2 support in openssh-server"
+	help
+		OpenSSH version 8.2 added two new ssh authentication methods,
+		namely `ecdsa_sk` and `ed25519_sk`. These two methods make use
+		of hardware keys that implement the FIDO and FIDO2 protocols.
+		In order to use these two types, libfido2 is required.
+endif

--- a/packages/openssh/Makefile
+++ b/packages/openssh/Makefile
@@ -1,0 +1,273 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=openssh
+PKG_VERSION:=9.5p1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
+		https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/
+PKG_HASH:=f026e7b79ba7fb540f75182af96dc8a8f1db395f922bbc9f6ca603672686086b
+
+PKG_LICENSE:=BSD ISC
+PKG_LICENSE_FILES:=LICENCE
+PKG_CPE_ID:=cpe:/a:openssh:openssh
+
+PKG_REMOVE_FILES:=
+PKG_CONFIG_DEPENDS := \
+	CONFIG_OPENSSH_LIBFIDO2
+
+PKG_BUILD_DEPENDS += OPENSSH_LIBFIDO2:libfido2
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/openssh/Default
+	SECTION:=net
+	CATEGORY:=Network
+	DEPENDS:=
+	TITLE:=OpenSSH
+	MAINTAINER:=Peter Wagner <tripolar@gmx.at>
+	URL:=https://www.openssh.com/
+	SUBMENU:=SSH
+endef
+
+define Package/openssh-moduli
+	$(call Package/openssh/Default)
+	DEPENDS+= +openssh-keygen
+	TITLE+= moduli file
+endef
+
+define Package/openssh-moduli/description
+OpenSSH server moduli file.
+endef
+
+define Package/openssh-client
+	$(call Package/openssh/Default)
+	DEPENDS+= +libopenssl +zlib
+	TITLE+= client
+	ALTERNATIVES:=\
+		200:/usr/bin/ssh:/usr/libexec/ssh-openssh \
+		200:/usr/bin/scp:/usr/libexec/scp-openssh
+endef
+
+define Package/openssh-client/description
+OpenSSH client.
+endef
+
+define Package/openssh-client/conffiles
+/etc/ssh/ssh_config
+endef
+
+define Package/openssh-client-utils
+	$(call Package/openssh/Default)
+	DEPENDS+= +libopenssl +zlib +openssh-client +openssh-keygen
+	TITLE+= client utilities
+endef
+
+define Package/openssh-client-utils/description
+OpenSSH client utilities.
+endef
+
+define Package/openssh-keygen
+	$(call Package/openssh/Default)
+	DEPENDS+= +libopenssl +zlib
+	TITLE+= keygen
+endef
+
+define Package/openssh-keygen/description
+OpenSSH keygen.
+endef
+
+define Package/openssh-server
+	$(call Package/openssh/Default)
+	DEPENDS+= +libopenssl +zlib +openssh-keygen +OPENSSH_LIBFIDO2:libfido2
+	TITLE+= server
+	USERID:=sshd=22:sshd=22
+	VARIANT:=without-pam
+endef
+
+define Package/openssh-server/config
+	source "$(SOURCE)/Config.in"
+endef
+
+define Package/openssh-server/description
+OpenSSH server.
+endef
+
+define Package/openssh-server/conffiles
+/etc/ssh/sshd_config
+/etc/ssh/sshd_config.d/
+/etc/ssh/ssh_host_ed25519_key
+/etc/ssh/ssh_host_ed25519_key.pub
+/etc/ssh/ssh_host_rsa_key
+/etc/ssh/ssh_host_rsa_key.pub
+/root/.ssh/authorized_keys
+endef
+
+define Package/openssh-server-pam
+	$(call Package/openssh/Default)
+	DEPENDS+= +libopenssl +zlib +libpthread +openssh-keygen +libpam
+	TITLE+= server (with PAM support)
+	VARIANT:=with-pam
+	USERID:=sshd=22:sshd=22
+endef
+
+define Package/openssh-server-pam/description
+OpenSSH server (with PAM support).
+endef
+
+define Package/openssh-server-pam/conffiles
+/etc/pam.d/sshd
+/etc/security/access-sshd-local.conf
+$(Package/openssh-server/conffiles)
+endef
+
+define Package/openssh-sftp-client
+	$(call Package/openssh/Default)
+	TITLE+= SFTP client
+endef
+
+define Package/openssh-sftp-client/description
+OpenSSH SFTP client.
+endef
+
+define Package/openssh-sftp-server
+	$(call Package/openssh/Default)
+	TITLE+= SFTP server
+endef
+
+define Package/openssh-sftp-server/description
+OpenSSH SFTP server.
+endef
+
+define Package/openssh-sftp-avahi-service
+	$(call Package/openssh/Default)
+	TITLE+= (SFTP Avahi service)
+	DEPENDS:=+openssh-sftp-server +avahi-daemon
+endef
+
+define Package/openssh-sftp-avahi-service/description
+ This package contains the service definition for announcing
+ SFTP support via mDNS/DNS-SD.
+endef
+
+define Package/openssh-sftp-avahi-service/conffiles
+/etc/avahi/services/sftp-ssh.service
+endef
+
+CONFIGURE_ARGS += \
+	--sysconfdir=/etc/ssh \
+	--with-privsep-user=sshd \
+	--with-privsep-path=/var/empty \
+	--disable-strip \
+	--disable-etc-default-login \
+	--disable-lastlog \
+	--disable-utmp \
+	--disable-utmpx \
+	--disable-wtmp \
+	--disable-wtmpx \
+	--without-bsd-auth \
+	--without-kerberos5 \
+	--with-stackprotect \
+	--with$(if $(CONFIG_OPENSSL_ENGINE),,out)-ssl-engine \
+	--with$(if $(CONFIG_OPENSSH_LIBFIDO2),,out)-security-key-builtin
+	
+ifeq ($(BUILD_VARIANT),with-pam)
+CONFIGURE_ARGS += \
+	--with-pam
+else
+CONFIGURE_ARGS += \
+	--without-pam
+endif
+
+CONFIGURE_VARS += LD="$(TARGET_CC)" PATH_PASSWD_PROG="/bin/passwd"
+
+ifeq ($(BUILD_VARIANT),with-pam)
+TARGET_LDFLAGS += -lpthread
+endif
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		STRIP_OPT="" \
+		all install
+endef
+
+define Package/openssh-moduli/install
+	install -d -m0700 $(1)/etc/ssh
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/ssh/moduli $(1)/etc/ssh/
+endef
+
+define Package/openssh-client/install
+	install -d -m0700 $(1)/etc/ssh
+	$(CP) $(PKG_INSTALL_DIR)/etc/ssh/ssh_config $(1)/etc/ssh/
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ssh $(1)/usr/libexec/ssh-openssh
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/scp $(1)/usr/libexec/scp-openssh
+endef
+
+define Package/openssh-client-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(foreach bin,add agent keyscan keysign,$(PKG_BUILD_DIR)/ssh-$(bin)) $(1)/usr/bin/
+endef
+
+define Package/openssh-keygen/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ssh-keygen $(1)/usr/bin/
+endef
+
+define Package/openssh-server/install
+	install -d -m0700 $(1)/etc/ssh $(1)/etc/ssh/sshd_config.d
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/ssh/sshd_config $(1)/etc/ssh/
+	sed -r -i 's,^#(HostKey /etc/ssh/ssh_host_(rsa|ed25519)_key)$$$$,\1,' $(1)/etc/ssh/sshd_config
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/sshd.init $(1)/etc/init.d/sshd
+	$(INSTALL_DIR) $(1)/lib/preinit
+	$(INSTALL_BIN) ./files/sshd.failsafe $(1)/lib/preinit/99_10_failsafe_sshd
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/sshd $(1)/usr/sbin/
+endef
+
+define Package/openssh-server-pam/install
+	$(call Package/openssh-server/install,$(1))
+	sed -i 's,#PasswordAuthentication yes,PasswordAuthentication no,g' $(1)/etc/ssh/sshd_config
+	sed -i 's,#UsePAM no,UsePAM yes,g' $(1)/etc/ssh/sshd_config
+	$(INSTALL_DIR) $(1)/etc/pam.d
+	$(INSTALL_DATA) ./files/sshd.pam $(1)/etc/pam.d/sshd
+	$(INSTALL_DIR) $(1)/etc/security
+	$(INSTALL_DATA) ./files/sshd.pam-access $(1)/etc/security/access-sshd-local.conf
+endef
+
+define Package/openssh-sftp-client/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sftp $(1)/usr/bin/
+endef
+
+define Package/openssh-sftp-server/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/sftp-server $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/libexec
+	ln -sf ../lib/sftp-server $(1)/usr/libexec/sftp-server
+endef
+
+define Package/openssh-sftp-avahi-service/install
+	$(INSTALL_DIR) $(1)/etc/avahi/services
+	$(INSTALL_DATA) ./files/sftp-ssh.service $(1)/etc/avahi/services/
+endef
+
+$(eval $(call BuildPackage,openssh-client))
+$(eval $(call BuildPackage,openssh-moduli))
+$(eval $(call BuildPackage,openssh-client-utils))
+$(eval $(call BuildPackage,openssh-keygen))
+$(eval $(call BuildPackage,openssh-server))
+$(eval $(call BuildPackage,openssh-server-pam))
+$(eval $(call BuildPackage,openssh-sftp-client))
+$(eval $(call BuildPackage,openssh-sftp-server))
+$(eval $(call BuildPackage,openssh-sftp-avahi-service))

--- a/packages/openssh/files/sftp-ssh.service
+++ b/packages/openssh/files/sftp-ssh.service
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+ <name replace-wildcards="yes">%h</name>
+  <service>
+   <type>_sftp-ssh._tcp</type>
+   <port>22</port>
+  </service>
+</service-group>

--- a/packages/openssh/files/sshd.failsafe
+++ b/packages/openssh/files/sshd.failsafe
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+failsafe_sshd () {
+
+	# if dropbear is executable it can handle failsafe
+	[ -x /usr/sbin/dropbear ] && return
+
+	sshd_tmpdir=/tmp/sshd
+	mkdir $sshd_tmpdir
+
+	for type in ed25519; do
+		key=$sshd_tmpdir/ssh_host_${type}_key
+		ssh-keygen -N '' -t ${type} -f ${key}
+	done
+
+	mkdir -m 0700 -p /var/empty
+
+	cat > $sshd_tmpdir/sshd_config <<EOF
+HostKey $sshd_tmpdir/ssh_host_ed25519_key
+PermitRootLogin	yes
+PermitEmptyPasswords yes
+EOF
+
+	/usr/sbin/sshd -f $sshd_tmpdir/sshd_config -E $sshd_tmpdir/sshd.log
+
+}
+
+boot_hook_add failsafe failsafe_sshd

--- a/packages/openssh/files/sshd.init
+++ b/packages/openssh/files/sshd.init
@@ -1,0 +1,49 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006-2011 OpenWrt.org
+
+START=50
+STOP=50
+
+USE_PROCD=1
+PROG=/usr/sbin/sshd
+
+start_service() {
+	for type in rsa ed25519
+	do
+		# check for keys
+		key=/etc/ssh/ssh_host_${type}_key
+		[ ! -f $key ] && {
+			# generate missing keys
+			[ -x /usr/bin/ssh-keygen ] && {
+				/usr/bin/ssh-keygen -N '' -t $type -f $key 2>&- >&-
+			}
+		}
+	done
+	mkdir -m 0700 -p /var/empty
+
+	local lport=$(awk '/^Port / { print $2; exit }' /etc/ssh/sshd_config)
+	[ -z "$lport" ] && lport=22
+
+	procd_open_instance
+	procd_add_mdns "ssh" "tcp" "$lport"
+	procd_set_param command $PROG -D
+	procd_set_param respawn
+	procd_close_instance
+}
+
+reload_service() {
+	procd_send_signal sshd
+}
+
+shutdown() {
+	local pid
+
+	stop
+
+	# kill active clients
+	for pid in $(pidof sshd)
+	do
+		[ "$pid" = "$$" ] && continue
+		[ -e "/proc/$pid/stat" ] && kill $pid
+	done
+}

--- a/packages/openssh/files/sshd.init
+++ b/packages/openssh/files/sshd.init
@@ -1,9 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2011 OpenWrt.org
 
-START=50
-STOP=50
-
 USE_PROCD=1
 PROG=/usr/sbin/sshd
 

--- a/packages/openssh/files/sshd.pam
+++ b/packages/openssh/files/sshd.pam
@@ -1,0 +1,41 @@
+# PAM configuration for the Secure Shell service
+
+# Read environment variables from /etc/environment and
+# /etc/security/pam_env.conf.
+auth       required     pam_env.so
+
+# Skip Google Authenticator if logging in from the local network.
+# auth [success=1 default=ignore] pam_access.so accessfile=/etc/security/access-sshd-local.conf
+# Google Authenticator 2-step verification.
+# auth       requisite    pam_google_authenticator.so
+
+# Standard Un*x authentication.
+auth       include      common-auth
+
+# Disallow non-root logins when /etc/nologin exists.
+account    required     pam_nologin.so
+
+# Uncomment and edit /etc/security/access.conf if you need to set complex
+# access limits that are hard to express in sshd_config.
+# account    required     pam_access.so
+
+# Standard Un*x authorization.
+account    include      common-account
+
+# Standard Un*x session setup and teardown.
+session    include      common-session
+
+# Print the message of the day upon successful login.
+session    optional     pam_motd.so
+
+# Print the status of the user's mailbox upon successful login.
+session    optional     pam_mail.so standard noenv
+
+# Set up user limits from /etc/security/limits.conf.
+session    required     pam_limits.so
+
+# Set up SELinux capabilities (need modified pam)
+# session    required     pam_selinux.so multiple
+
+# Standard Un*x password updating.
+password   include      common-password

--- a/packages/openssh/files/sshd.pam-access
+++ b/packages/openssh/files/sshd.pam-access
@@ -1,0 +1,4 @@
+# Skip Google Authenticator for local network
+#+ : ALL : 192.168.1.0/24
++ : ALL : LOCAL
+- : ALL : ALL

--- a/packages/openssh/patches/900-sshd_config-include-dir.patch
+++ b/packages/openssh/patches/900-sshd_config-include-dir.patch
@@ -1,0 +1,11 @@
+--- a/sshd_config
++++ b/sshd_config
+@@ -10,6 +10,8 @@
+ # possible, but leave them commented.  Uncommented options override the
+ # default value.
+ 
++Include /etc/ssh/sshd_config.d/*.conf
++
+ #Port 22
+ #AddressFamily any
+ #ListenAddress 0.0.0.0


### PR DESCRIPTION
Card: https://trello.com/c/OFfbXifR/224-openssh-listening-on-port-22

Possible implementations:
- fork the package and disable the service
- change the port and create a crash loop: `echo  "Port 0" >> /etc/ssh/sshd_config.d/disable_default_port.conf`

This PR implements the first proposal