### PR TITLE
Basic alert implementation

### DIFF
--- a/packages/ns-plug/Makefile
+++ b/packages/ns-plug/Makefile
@@ -21,7 +21,7 @@ define Package/ns-plug
 	CATEGORY:=NethSecurity
 	TITLE:=NethSecurity controller client
 	URL:=https://github.com/NethServer/nethsecurity-controller/
-	DEPENDS:=+openvpn +lscpu +python3-nethsec
+	DEPENDS:=+openvpn +lscpu +python3-nethsec +python3-yaml
 	PKGARCH:=all
 endef
  

--- a/packages/ns-plug/Makefile
+++ b/packages/ns-plug/Makefile
@@ -65,6 +65,7 @@ define Package/ns-plug/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/etc/netdata
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_BIN) ./files/ns-plug.init $(1)/etc/init.d/ns-plug
 	$(INSTALL_BIN) ./files/ns-plug $(1)/usr/sbin/ns-plug
@@ -77,8 +78,12 @@ define Package/ns-plug/install
 	$(INSTALL_BIN) ./files/subscription-info $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/inventory $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/20_ns-plug $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/30_ns-plug_alerts $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/netadata_enable_alerts $(1)/usr/share/ns-plug/hooks/register
+	$(INSTALL_BIN) ./files/netadata_disable_alerts $(1)/usr/share/ns-plug/hooks/unregister
 	$(INSTALL_CONF) ./files/config $(1)/etc/config/ns-plug
 	$(INSTALL_CONF) files/ns-plug.keep $(1)/lib/upgrade/keep.d/ns-plug
+	$(INSTALL_CONF) files/health_alarm_notify.conf $(1)/etc/netdata
 endef
  
 $(eval $(call BuildPackage,ns-plug))

--- a/packages/ns-plug/Makefile
+++ b/packages/ns-plug/Makefile
@@ -67,6 +67,7 @@ define Package/ns-plug/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/etc/netdata
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
+	$(INSTALL_DIR) $(1)/usr/lib/netdata/python.d/
 	$(INSTALL_BIN) ./files/ns-plug.init $(1)/etc/init.d/ns-plug
 	$(INSTALL_BIN) ./files/ns-plug $(1)/usr/sbin/ns-plug
 	$(INSTALL_BIN) ./files/remote-backup $(1)/usr/sbin
@@ -84,6 +85,7 @@ define Package/ns-plug/install
 	$(INSTALL_CONF) ./files/config $(1)/etc/config/ns-plug
 	$(INSTALL_CONF) files/ns-plug.keep $(1)/lib/upgrade/keep.d/ns-plug
 	$(INSTALL_CONF) files/health_alarm_notify.conf $(1)/etc/netdata
+	$(INSTALL_DATA) files/mwan.chart.py $(1)/usr/lib/netdata/python.d/
 endef
  
 $(eval $(call BuildPackage,ns-plug))

--- a/packages/ns-plug/README.md
+++ b/packages/ns-plug/README.md
@@ -105,3 +105,27 @@ Download the latest encrypted backup and restore it:
 echo <your_passphrase> > /etc/backup.pass
 remote-backup download $(remote-backup list | jq -r .[0].file) - | gpg --batch --passphrase-file /etc/backup.pass -d | sysupgrade -r -
 ```
+
+## Alerts
+
+All system alerts are handled by netdata, including those from the multiwan monitoring.
+Alerts are disabled by default and enabled only if the machine has a valid subscription.
+In this case, alerts are automatically sent to the remote server (either my.nethesis.it or my.nethserver.com) using a
+custom sender (`/etc/netdata/health_alarm_notify.conf`).
+Alerts are also logged to `/var/log/messages` and are visible within the netdata UI.
+
+Only the following alerts are sent to the remote system:
+
+- disk space occupation
+- WAN down events
+
+When an alert is resolved, netdata will also send a clear command to remote server.
+
+## mwan3 netdata plugin
+
+The `/usr/lib/netdata/python.d/mwan.chart.py` file implements a netdata plugin for mwan3.
+The plugin tracks the score of each WAN using mwan3track status directory.
+When a WAN reaches a score equal to 1, an alert is triggered.
+
+Please note that mwan3track minumum score is `0` which is mapped to `1` inside netdata,
+otherwise the `0` value is not plotted within the chart.

--- a/packages/ns-plug/files/30_ns-plug_alerts
+++ b/packages/ns-plug/files/30_ns-plug_alerts
@@ -32,3 +32,33 @@ do
         > $file
     fi
 done
+
+# Enable mwan chart
+sed -i 's/python.d = no/python.d = yes/' /etc/netdata/netdata.conf
+python_f="/etc/netdata/python.d.conf"
+if [ ! -f "$python_f" ]; then
+    cat << EOF > "$python_f"
+enabled: yes
+gc_run: yes
+gc_interval: 300
+apache_cache: no
+chrony: no
+example: no
+go_expvar: no
+gunicorn_log: no
+hpssa: no
+logind: no
+nginx_log: no
+EOF
+fi
+
+# Create mwan alert
+cat << EOF > /etc/netdata/health.d/mwan.conf
+template: wan_status
+    on: mwan.score
+lookup: min -1m foreach *
+ every: 1m
+  warn: \$this < 5
+  crit: \$this <= 1
+  info: The score of the WAN, 0 means down
+EOF

--- a/packages/ns-plug/files/30_ns-plug_alerts
+++ b/packages/ns-plug/files/30_ns-plug_alerts
@@ -11,7 +11,7 @@ template: disk_space_usage
 component: Disk
        os: linux freebsd
     hosts: *
- families: !/dev !/dev/* !/run !/run/* *
+ families: !/dev !/dev/* !/run !/run/* !/overlay *
      calc: \$used * 100 / (\$avail + \$used)
     units: %
     every: 1m

--- a/packages/ns-plug/files/30_ns-plug_alerts
+++ b/packages/ns-plug/files/30_ns-plug_alerts
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Custom disk alerts
+disks_f="/etc/netdata/health.d/disks.conf"
+if [ ! -f "$disks_f" ]; then
+    cat << EOF > "$disks_f"
+template: disk_space_usage
+       on: disk.space
+    class: Utilization
+     type: System
+component: Disk
+       os: linux freebsd
+    hosts: *
+ families: !/dev !/dev/* !/run !/run/* *
+     calc: \$used * 100 / (\$avail + \$used)
+    units: %
+    every: 1m
+     warn: \$this > ((\$status >= \$WARNING ) ? (80) : (90))
+     crit: \$this > ((\$status == \$CRITICAL) ? (90) : (98))
+    delay: up 1m down 15m multiplier 1.5 max 1h
+     info: disk $family space utilization
+       to: sysadmin
+EOF
+fi
+
+# Disable unwanted alerts
+files="cpu disks entropy ipc load memory net netfilter processes ram softnet tcp_conn tcp_listen tcp_mem tcp_orphans tcp_resets timex udp_errors"
+for f in $files
+do
+    file="/etc/netdata/health.d/${f}.conf"
+    if [ ! -f $file ]; then
+        > $file
+    fi
+done

--- a/packages/ns-plug/files/health_alarm_notify.conf
+++ b/packages/ns-plug/files/health_alarm_notify.conf
@@ -1,0 +1,74 @@
+# Configuration for alarm notifications
+
+SEND_EMAIL="NO"
+SEND_DYNATRACE="NO"
+SEND_STACKPULSE="NO"
+SEND_OPSGENIE="NO"
+SEND_HANGOUTS="NO"
+SEND_PUSHOVER="NO"
+SEND_PUSHBULLET="NO"
+SEND_TWILIO="NO"
+SEND_MESSAGEBIRD="NO"
+SEND_KAVENEGAR="NO"
+SEND_TELEGRAM="NO"
+SEND_SLACK="NO"
+SEND_MSTEAMS="NO"
+SEND_ROCKETCHAT="NO"
+SEND_ALERTA="NO"
+SEND_FLOCK="NO"
+SEND_DISCORD="NO"
+SEND_HIPCHAT="NO"
+SEND_KAFKA="NO"
+SEND_PD="NO"
+SEND_FLEEP="NO"
+SEND_IRC="NO"
+SEND_SYSLOG="NO"
+SEND_PROWL="NO"
+SEND_AWSSNS="NO"
+SEND_SMS="NO"
+SEND_MATRIX="NO"
+
+# Enable only syslog and custom notification
+use_fqdn='YES'
+SEND_SYSLOG="YES"
+SYSLOG_FACILITY=''
+DEFAULT_RECIPIENT_SYSLOG="sysadmin"
+
+SEND_CUSTOM="YES"
+DEFAULT_RECIPIENT_CUSTOM="sysadmin"
+
+# Send alerts to my.nethesis.it or my.nethserver.com
+custom_sender() {
+    lk=$(uci -q get ns-plug.config.system_id)
+    secret=$(uci -q get ns-plug.config.secret)
+    url=$(uci -q get ns-plug.config.alerts_url)"alerts/store"
+    alert_id=${name}
+    payload='{"lk": "'$lk'", "alert_id": "'$alert_id'", "status": "'$status'"}'
+    if [ "${status}" == "CRITICAL" ]; then
+        status="FAILURE"
+    elif [ "${status}" == "CLEAR" ]; then
+        status="OK"
+    fi
+
+    # map to old alerts, when possible
+    if [ "${chart}" == "disk_space._overlay" ] || [ "${chart}" == "disk_space._" ]; then
+        alert_id="df:root:percent_bytes:free"
+    elif [ "${chart}" == "disk_space._boot" ]; then
+        alert_id="df:boot:percent_bytes:free"
+    else
+        alert_id="${name}:${chart}"
+    fi
+
+    # send only if the machine is registered
+    if [ -z "${lk}" ] || [ -z "${secret}" ]; then
+        return
+    fi
+
+    # send to remote server
+    if [ "${status}" == "FAILURE" ] || [ "${status}" == "OK" ]; then
+        /usr/bin/logger -t DEBUG "$payload"
+        /usr/bin/curl -m 180 --retry 3 -L -s \
+             --header "Authorization: token ${secret}"  --header "Content-Type: application/json" --header "Accept: application/json"  \
+             --data-raw "${payload}" ${url}
+    fi
+}

--- a/packages/ns-plug/files/health_alarm_notify.conf
+++ b/packages/ns-plug/files/health_alarm_notify.conf
@@ -33,9 +33,11 @@ use_fqdn='YES'
 SEND_SYSLOG="YES"
 SYSLOG_FACILITY=''
 DEFAULT_RECIPIENT_SYSLOG="sysadmin"
-
 SEND_CUSTOM="YES"
 DEFAULT_RECIPIENT_CUSTOM="sysadmin"
+
+# Always generate clear events
+clear_alarm_always='YES'
 
 # Send alerts to my.nethesis.it or my.nethserver.com
 custom_sender() {
@@ -43,7 +45,6 @@ custom_sender() {
     secret=$(uci -q get ns-plug.config.secret)
     url=$(uci -q get ns-plug.config.alerts_url)"alerts/store"
     alert_id=${name}
-    payload='{"lk": "'$lk'", "alert_id": "'$alert_id'", "status": "'$status'"}'
     if [ "${status}" == "CRITICAL" ]; then
         status="FAILURE"
     elif [ "${status}" == "CLEAR" ]; then
@@ -58,6 +59,7 @@ custom_sender() {
     else
         alert_id="${name}:${chart}"
     fi
+    payload='{"lk": "'$lk'", "alert_id": "'$alert_id'", "status": "'$status'"}'
 
     # send only if the machine is registered
     if [ -z "${lk}" ] || [ -z "${secret}" ]; then
@@ -66,7 +68,6 @@ custom_sender() {
 
     # send to remote server
     if [ "${status}" == "FAILURE" ] || [ "${status}" == "OK" ]; then
-        /usr/bin/logger -t DEBUG "$payload"
         /usr/bin/curl -m 180 --retry 3 -L -s \
              --header "Authorization: token ${secret}"  --header "Content-Type: application/json" --header "Accept: application/json"  \
              --data-raw "${payload}" ${url}

--- a/packages/ns-plug/files/mwan.chart.py
+++ b/packages/ns-plug/files/mwan.chart.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Description: mwan3 python plugin
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import os
+
+from bases.FrameworkServices.SimpleService import SimpleService
+
+priority = 90000
+state_dir = "/var/run/mwan3track/"
+
+ORDER = [
+    'score',
+]
+
+charts = {
+    'score': {
+        'options': [None, 'WAN status', 'score', 'mwan tracking', 'mwan.score', 'line'],
+        'lines': []
+    }
+}
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        for dir in os.listdir(state_dir):
+            charts['score']['lines'].append([dir])
+        self.definitions = charts
+
+    @staticmethod
+    def check():
+        return os.path.isdir(state_dir)
+
+    def get_data(self):
+        data = dict()
+
+        for dir in os.listdir(state_dir):
+            file = state_dir + dir + "/SCORE"
+            with open(file) as f:
+                data[dir] = int(f.read().strip()) + 1
+
+        return data

--- a/packages/ns-plug/files/netadata_disable_alerts
+++ b/packages/ns-plug/files/netadata_disable_alerts
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Disable netdata alerts
+sed -i 's/enabled = yes/enabled = no/' /etc/netdata/netdata.conf
+/etc/init.d/netdata restart

--- a/packages/ns-plug/files/netadata_enable_alerts
+++ b/packages/ns-plug/files/netadata_enable_alerts
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Enable netdata alerts
+sed -i 's/enabled = no/enabled = yes/' /etc/netdata/netdata.conf
+/etc/init.d/netdata restart


### PR DESCRIPTION
Card: https://trello.com/c/j23JiwwU/183-alerts

Alert handling:
- netdata manages system alerts, including those from multiwan monitoring
- alerts are initially disabled and require a valid subscription for activation
- active alerts are sent to a remote server and logged in `/var/log/messages`
- specific alerts for disk space occupation and WAN down events are transmitted to the remote system.
- clear commands are sent to the remote server upon alert resolution.

mwan3 netdata plugin:
- the file `/usr/lib/netdata/python.d/mwan.chart.py` implements a netdata plugin for mwan3
- the plugin monitors the score of each WAN through the mwan3track status directory
- an alert is triggered when a WAN's score reaches 1
- the minimum mwan3track score is 0, mapped to 1 in netdata for chart plotting

netdata chart example:
![image](https://github.com/NethServer/nethsecurity/assets/804596/27ebad07-590d-4aa8-b5d6-5537d2f99ef8)
