### PR TITLE
Fix SSH error when authorized_keys file is empty

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -118,6 +118,8 @@ define Package/ns-api/install
 	$(INSTALL_DATA) ./files/ns.factoryreset.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_BIN) ./files/ns.update $(1)/usr/libexec/rpcd/
 	$(INSTALL_DATA) ./files/ns.update.json $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_BIN) ./files/ns.ssh $(1)/usr/libexec/rpcd/
+	$(INSTALL_DATA) ./files/ns.ssh.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_DATA) ./files/schedule-system-update $(1)/usr/libexec/ns-api/
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_CONF) files/msmtp.keep $(1)/lib/upgrade/keep.d/msmtp

--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -3418,3 +3418,19 @@ Response example:
 ```json
 {"result": "success"}
 ```
+
+## ns.ssh
+
+Read SSH keys
+
+### list-keys
+
+Return the content of `/etc/dropbear/authorized_keys` file:
+```
+api-cli ns.ssh list-keys
+```
+
+Output example:
+```json
+{'keys': '\nssh-rsa AAAAB3N...6m5 test@nethserver.org\n'}
+```

--- a/packages/ns-api/files/ns.ssh
+++ b/packages/ns-api/files/ns.ssh
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# Read SSH authorized keys
+
+import os
+import sys
+import json
+
+cmd = sys.argv[1]
+
+if cmd == 'list':
+    print(json.dumps({"list-keys": {}}))
+else:
+    action = sys.argv[2]
+    if action == "list-keys":
+        keys = '/etc/dropbear/authorized_keys'
+        if os.path.exists(keys):
+            with open(keys, 'r') as fp:
+                print({"keys": fp.read()})
+        else:
+            print({"keys": ""})
+

--- a/packages/ns-api/files/ns.ssh.json
+++ b/packages/ns-api/files/ns.ssh.json
@@ -1,0 +1,13 @@
+{
+  "ssh-manager": {
+    "description": "Read SSH keys",
+    "write": {},
+    "read": {
+      "ubus": {
+        "ns.ssh": [
+          "*"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Card: https://trello.com/c/ZymrMQnR/226-ssh-add-api-for-authorized-keys

See also: https://github.com/NethServer/nethsecurity-ui/pull/102