### PR TITLE
User databases

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -125,6 +125,8 @@ define Package/ns-api/install
 	$(INSTALL_DATA) ./files/ns.reverseproxy.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_BIN) ./files/ns.devices $(1)/usr/libexec/rpcd/
 	$(INSTALL_DATA) ./files/ns.devices.json $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_BIN) ./files/ns.users $(1)/usr/libexec/rpcd/
+	$(INSTALL_DATA) ./files/ns.users.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_CONF) files/msmtp.keep $(1)/lib/upgrade/keep.d/msmtp
 	$(LN) /usr/bin/msmtp $(1)/usr/sbin/sendmail

--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -4202,17 +4202,55 @@ Response example:
 {
   "databases": [
     {
-      "id": "main",
+      "name": "main",
       "type": "local",
       "description": "Main local database"
     },
     {
-      "id": "ns7",
+      "name": "ns7",
       "type": "ldap",
       "description": "OpenLDAP NS7",
-      "schema": "rfc2307"
+      "schema": "rfc2307",
+      "uri": "ldap://192.168.100.2"
     }
   ]
+}
+```
+
+### get-database
+
+Retrieve all configuration of the given database:
+```
+api-cli ns.users get-database --data '{"name": "main"}'
+```
+
+Response example for a local database:
+```json
+{
+  "database": {
+    "description": "Main local database",
+    "name": "main",
+    "type": "local"
+  }
+}
+```
+
+Response example for a ldap database:
+```json
+{
+  "database": {
+    "uri": "ldap://192.168.100.234",
+    "schema": "rfc2307",
+    "base_dn": "dc=directoy,dc=nh",
+    "user_dn": "ou=People,dc=directory,dc=nh",
+    "user_attr": "uid",
+    "user_cn": "cn",
+    "start_tls": "0",
+    "tls_reqcert": "never",
+    "description": "OpenLDAP NS7",
+    "name": "ns7",
+    "type": "ldap"
+  }
 }
 ```
 

--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -4136,260 +4136,318 @@ Invalid configuration response:
 }
 ```
 
-## ns.devices
+## ns.users
 
-Manages network devices and interfaces.
+### list-users
 
-### list-devices
-
-List configured and unconfigured network interfaces and devices, organized by zone.
-
-```bash
-api-cli ns.devices list-devices
+List configured users
+```
+api-cli ns.users list-users --data '{"database": "main"}'
 ```
 
-Response example:
-
+Response example for a local database:
 ```json
 {
-  "devices_by_zone": [
-    { "name": "lan", "devices": ["br-lan"] },
-    { "name": "wan", "devices": ["eth1"] },
-    { "name": "unassigned", "devices": ["eth2", "eth3"] }
-  ],
-  "all_devices": [
+  "users": [
     {
-      "ipaddrs": [
-        { "address": "192.168.122.144/24", "broadcast": "192.168.122.255" }
-      ],
-      "ip6addrs": [{ "address": "fe80::5054:ff:fe5b:1506/64" }],
-      "link_type": "ether",
-      "mac": "52:54:00:5b:15:06",
-      "mtu": 1500,
-      "name": "eth1",
-      "up": true,
-      "stats": {
-        "collisions": 0,
-        "multicast": 0,
-        "rx_bytes": 12253535,
-        "rx_dropped": 0,
-        "rx_errors": 0,
-        "rx_packets": 119400,
-        "tx_bytes": 66034,
-        "tx_dropped": 0,
-        "tx_errors": 0,
-        "tx_packets": 665
-      },
-      "speed": 1000
-    },
-    {
-      "name": "br-lan",
-      "type": "bridge",
-      "ports": ["eth0"],
-      ".name": "cfg020f15",
-      ".type": "device",
-      "ipaddrs": [
-        { "address": "192.168.122.30/24", "broadcast": "192.168.122.255" }
-      ],
-      "ip6addrs": [{ "address": "fe80::5054:ff:fe28:d273/64" }],
-      "link_type": "ether",
-      "mac": "52:54:00:28:d2:73",
-      "mtu": 1500,
-      "up": true,
-      "stats": {
-        ...
-      },
-      "speed": -1
-    },
-    ...
+      "local": true,
+      "database": "main",
+      "name": "user",
+      "password": "$6$nu00HaYNNF/rxGV4$nWpG3j5ydXy6anlK1x0DjNDN3PGC78YSxUvgEiFaW/3mWjyWP62iTp+IdBf7tynQueHl4zBBD+9JN3Ws+HMT7w==",
+      "description": "User",
+      "id": "ns_652b6c80"
+    }
   ]
 }
 ```
 
-### configure-device
-
-Create or configure an unconfigured device, or edit its configuration. What happens exactly in the configuration process depends on the input parameters. Anyway, as a rule of thumb the configuration of a device executes one or more of the following steps:
-- creation of a network interface
-- association of the device to the newly created interface
-- configuration of some attributes of the network interface
-- association of the network interface to a firewall zone
-
-Required parameters:
-
-- The set of other required parameters depends on the specific device configuration
-
-All parameters:
-
-- `interface_name`: network interface name to assign to the device
-- `device_name`: name of the device to create
-- `device_type`: can be `physical` or `logical`
-- `protocol`: can be `static`, `dhcp`, `dhcpv6` or `pppoe`
-- `zone`: can be any configured firwall zone name, e.g. `lan`, `wan`...
-- `logical_type`: can be `bridge` or `bond`
-- `interface_to_edit`: name of the network interface to edit
-- `ip4_address`: an IPv4 address in CIDR notation (e.g. 10.20.30.40/24)
-- `ip4_gateway`: an IPv4 gateway
-- `ip4_mtu`: IPv4 maximum transmission unit
-- `ip6_enabled`: `True` to enable IPv6, `False` otherwise
-- `ip6_address`: an IPv4 address in CIDR notation (e.g. 2001:db8:0:1:1:1:1:1/64)
-- `ip6_gateway`: an IPv6 gateway
-- `ip6_mtu`: IPv6 maximum transmission unit
-- `attached_devices`: when configuring a bridge or a bond, it's the list of slave devices, e.g. `["eth0", "eth1"]`
-- `bonding_policy`: when configuring a bond, can be any of `balance-rr`, `active-backup`, `balance-xor`, `broadcast`, `802.3ad`, `balance-tlb`, `balance-alb`
-- `bond_primary_device`: when configuring a bond, name of the primary device
-- `pppoe_username`: PPPoE username
-- `pppoe_password`: PPPoE password
-- `dhcp_client_id`: Client ID to send when requesting DHCP
-- `dhcp_vendor_class`: Vendor class to send when requesting DHCP
-- `dhcp_hostname_to_send`: Hostname to send when requesting DHCP, can be `deviceHostname`, `doNotSendHostname` or `customHostname`
-- `dhcp_custom_hostname`: Custom hostname to use when `dhcp_hostname_to_send = customHostname`
-
-```bash
-api-cli ns.devices configure-device --data '{"device_type": "physical", "interface_name": "myiface", "protocol": "static", "zone": "lan", "ip6_enabled": false, "device_name": "eth2", "ip4_address": "10.20.30.40/24"}'
-```
-
-Response example:
-
+Response example for a remote LDAP database:
 ```json
 {
-   "message": "success"
+  "users": [
+    {
+      "name": "admin",
+      "description": "admin",
+      "local": false,
+      "database": "ns7",
+      "id": "admin"
+    },
+    {
+      "name": "pluto",
+      "description": "Pluto Rossi",
+      "local": false,
+      "database": "ns7",
+      "openpvn_ipaddr": "1.2.3.4",
+      "openvpn_enabled": "1",
+      "id": "pluto"
+    }
+  ]
 }
 ```
 
-### unconfigure-device
+May raise the following validation errors:
+- db_not_found
 
-Remove a device to an unconfigured state by deleting the associated network interface and other data created during the configuration process.
+### list-databases
 
-Required parameters:
-
-- `iface_name`: name of the interface associated to the device to unconfigure
-
-```bash
-api-cli ns.devices unconfigure-device --data '{"iface_name": "myiface"}'
+List configured user databases
 ```
-Response example:
-
-```json
-{
-   "message": "success"
-}
-```
-
-### create-alias-interface
-
-Create an alias interface in order to associate multiple IPv4/IPv6 addresses to a network interface.
-
-Required parameters:
-
-- `alias_iface_name`: name of the alias interface
-- `parent_iface_name`: name of the parent network interface (the one we need to add IP addresses to)
-
-Optional parameters:
-
-- `ip4_addresses`: list of IPv4 addresses in CIDR notation
-- `ip6_addresses`: list of IPv6 addresses in CIDR notation
-
-At least one of `ip4_addresses` and `ip6_addresses` are required.
-
-```bash
-api-cli ns.devices create-alias-interface --data '{"alias_iface_name": "al_myiface", "parent_iface_name": "myiface", "ip4_addresses": ["11.22.33.44/24"], "ip6_addresses": []}'
+api-cli ns.users list-databases
 ```
 
 Response example:
-
 ```json
 {
-   "message": "success"
+  "databases": [
+    {
+      "id": "main",
+      "type": "local",
+      "description": "Main local database"
+    },
+    {
+      "id": "ns7",
+      "type": "ldap",
+      "description": "OpenLDAP NS7",
+      "schema": "rfc2307"
+    }
+  ]
 }
 ```
 
-### edit-alias-interface
+### add-ldap-database
 
-Edit the list of IPv4/IPv6 addresses of an alias interface.
-
-Required parameters:
-
-- `alias_iface_name`: name of the alias interface to edit
-- `parent_iface_name`: name of the parent network interface
-
-Optional parameters:
-
-- `ip4_addresses`: list of IPv4 addresses in CIDR notation
-- `ip6_addresses`: list of IPv6 addresses in CIDR notation
-
-At least one of `ip4_addresses` and `ip6_addresses` are required.
-
-```bash
-api-cli ns.devices edit-alias-interface --data '{"alias_iface_name": "al_myiface", "parent_iface_name": "myiface", "ip4_addresses": ["11.22.33.44/24", "55.66.77.88/24"], "ip6_addresses": []}'
+Add new remote LDAP database:
+```
+api cli ns.users add-ldap-database --data '{"name": "ns7", "uri": "ldap://192.168.100.234", "schema": "rfc2307", "base_dn": "dc=directoy,dc=nh", "user_dn": "ou=People,dc=directory,dc=nh", "user_attr": "uid", "user_cn": "cn", "start_tls": false, "tls_reqcert": "never", "description": "OpenLDAP NS7"}'
 ```
 
 Response example:
-
 ```json
-{
-   "message": "success"
-}
+{"result": "success"}
 ```
 
-### delete-alias-interface
+May raise the following validation errors:
+- db_already_exists
 
-Delete an alias interface and remove the associated IPv4/IPv6 addresses from the parent interface.
+### edit-ldap-database
 
-Required parameters:
-
-- `alias_iface_name`: name of the alias interface to edit
-- `parent_iface_name`: name of the parent network interface
-
-```bash
-api-cli ns.devices delete-alias-interface --data '{"alias_iface_name": "al_myiface", "parent_iface_name": "myiface"}'
+Edit a remote LDAP database:
+```
+api-cli ns.users add-ldap-database --data '{"name": "ns7", "uri": "ldap://192.168.100.234", "schema": "rfc2307", "base_dn": "dc=directoy,dc=nh", "user_dn": "ou=People,dc=directory,dc=nh", "user_attr": "uid", "user_cn": "cn", "start_tls": false, "tls_reqcert": "never", "description": "OpenLDAP NS7"}'
 ```
 
 Response example:
-
 ```json
-{
-   "message": "success"
-}
+{"result": "success"}
 ```
 
-### create-vlan-device
+May raise the following validation errors:
+- db_not_found
 
-Create a VLAN device.
+### delete-ldap-database
 
-Required parameters:
-
-- `vlan_type`: can be `8021q` or `8021ad`
-- `base_device_name`: name of the network device to create the VLAN on
-- `vlan_id`: VLAN ID, must be a positive integer
-
-```bash
-api-cli ns.devices create-vlan-device --data '{"vlan_type": "8021q", "base_device_name": "eth3", "vlan_id": 5}'
+Delete a remote LDAP databse:
+```
+api-cli ns.users delete-ldap-database --data '{"name": "ns7"}'
 ```
 
 Response example:
-
 ```json
-{
-   "message": "success"
-}
+{"result": "success"}
 ```
 
-### delete-device
+May raise the following validation errors:
+- db_not_found
 
-Delete a device from `network` database.
+### test-ldap
 
-Required parameters:
-
-- `device_name`: name of the network device to delete
-
-```bash
-api-cli ns.devices delete-device --data '{"device_name": "eth3.5"}'
+Test LDAP connection, it returns the list of users:
+```
+api-cli ns.users test-ldap --data '{"uri": "ldap://192.168.100.234", "base_dn": "dc=directoy,dc=nh", "user_dn": "ou=People,dc=directory,dc=nh", "user_attr": "uid", "user_cn": "cn", "start_tls": false, "tls_reqcert": "never"}'
 ```
 
 Response example:
-
 ```json
 {
-   "message": "success"
+  "users": [
+    {
+      "name": "admin",
+      "description": "admin"
+    },
+    {
+      "name": "pluto",
+      "description": "Pluto Rossi"
+    }
+  ]
 }
 ```
+
+### get-ldap-defaults
+
+Retrieve opinionated LDAP defaults for given database:
+```
+api-cli ns.users get-ldap-defaults --data '{"uri": "ldap://ldap.example.com", "schema": "rfc2307"}'
+```
+
+Response example:
+```json
+{
+  "defaults": {
+    "base_dn": "dc=example,dc=com",
+    "user_dn": "ou=People,dc=example,dc=com",
+    "user_attr": "uid",
+    "user_cn": "cn"
+  }
+}
+```
+
+### add-local-database
+
+Create a local user database:
+```
+api-cli ns.users add-local-database --data '{"name": "local2", "description": "Local users"}''
+```
+
+Response example:
+```json
+{"result": "success"}
+```
+
+May raise the following validation errors:
+- db_already_exists
+
+### edit-local-database
+
+Edit a local user database:
+```
+api-cli ns.users add-local-database --data '{"name": "local2", "description": "Local users 2"}''
+```
+
+Response example:
+```json
+{"result": "success"}
+```
+
+May raise the following validation errors:
+- db_not_found
+
+### delete-local-database
+
+Delete the local user database and all its users and groups:
+```
+api-cli ns.users delete-local-database --data '{"name": "local2"}''
+```
+
+Response example:
+```json
+{"result": "success"}
+```
+
+May raise the following validation errors:
+- db_not_found
+
+### add-local-user
+
+Add a user to the local database:
+```
+api-cli ns.users add-local-user --data '{"name": "john", "password": "P4**$w0rd", "description": "John Doe", "database": "main", "extra": {"openvpn_enabled": "0"}}'
+```
+
+Response example:
+```json
+{"id": "ns_0d0e8762"}
+```
+
+Extra fields will be added to user object.
+
+May raise the following validation errors:
+- user_already_exists
+- db_not_local
+
+### edit-local-user
+
+Change an existing user inside the local database:
+```
+api-cli ns.users edit-local-user --data '{"name": "john", "password": "P4**$w0rd", "description": "John Doe", "database": "main", "extra": {"openvpn_ipaddr": "1.2.3.4"}}'
+```
+
+To remove an existing extra option, just pass the `extra` field without that specific option.
+As an example, the above call removes the `openvpn_enabled` option from the user and add the `openvpn_ipaddr` option.
+
+Response example:
+```json
+{"id": "ns_0d0e8762"}
+```
+
+May raise the following validation errors:
+- user_not_found
+- db_not_local
+
+### delete-local-user
+
+Delete a user from a local database:
+```
+api-cli ns.users delete-local-user --data '{"name": "john", "database": "main"}'
+```
+
+Response example:
+```json
+{"result": "success"}
+```
+
+May raise the following validation errors:
+- user_not_found
+- db_not_local
+
+### add-remote-user
+
+Add a user to the remote database:
+```
+api-cli ns.users add-remote-user --data '{"name": "john", "database": "main", "extra": {"openvpn_enabled": "0"}}'
+```
+
+Response example:
+```json
+{"id": "ns_427824b1"}
+```
+
+Extra fields will be added to user object.
+
+May raise the following validation errors:
+- user_already_exists
+- db_not_remote
+
+### edit-remote-user
+
+Change an existing remoteuser:
+```
+api-cli ns.users edit-remote-user --data '{"name": "john", "database": "main", "extra": {"openvpn_ipaddr": "1.2.3.4"}}'
+```
+
+To remove an existing extra option, just pass the `extra` field without that specific option.
+As an example, the above call removes the `openvpn_enabled` option from the user and add the `openvpn_ipaddr` option.
+
+Response example:
+```json
+{"id": "ns_427824b1"}
+```
+
+May raise the following validation errors:
+- user_not_found
+- db_not_remote
+
+### delete-remote-user
+
+Delete an existing user from a remote LDAP database:
+```
+api-cli ns.users delete-remote-user --data '{"name": "john", "database": "main"}'
+```
+
+Response example:
+```json
+{"result": "success"}
+```
+
+May raise the following validation errors:
+- user_not_found
+- db_not_remote

--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -4169,6 +4169,7 @@ Response example for a remote LDAP database:
       "name": "admin",
       "description": "admin",
       "local": false,
+      "admin": true,
       "database": "ns7",
       "id": "admin"
     },
@@ -4176,6 +4177,7 @@ Response example for a remote LDAP database:
       "name": "pluto",
       "description": "Pluto Rossi",
       "local": false,
+      "admin": false,
       "database": "ns7",
       "openpvn_ipaddr": "1.2.3.4",
       "openvpn_enabled": "1",
@@ -4451,3 +4453,27 @@ Response example:
 May raise the following validation errors:
 - user_not_found
 - db_not_remote
+
+## set-admin
+
+Make a local user an admin. The admin can login to the UI:
+```
+api-cli ns.users set-admin --data '{"name": "pluto", "database": "main"}'
+```
+
+Response example:
+```json
+{"id": "ns_bc8c1aa1"}
+```
+
+## remove-admin
+
+Remove the admin role from  a local user:
+```
+api-cli ns.users set-admin --data '{"name": "pluto"}'
+```
+
+Response example:
+```json
+{"result": "success"}
+```

--- a/packages/ns-api/files/ns.account
+++ b/packages/ns-api/files/ns.account
@@ -10,7 +10,7 @@ import subprocess
 import sys
 
 from euci import EUci
-from nethsec import utils
+from nethsec import utils, users
 
 cmd = sys.argv[1]
 
@@ -27,20 +27,28 @@ elif cmd == 'call':
     if action == 'set-password':
         try:
             data = json.JSONDecoder().decode(sys.stdin.read())
-            user_list = utils.get_all_by_type(e_uci, 'rpcd', 'login')
+            rpcd_user_list = utils.get_all_by_type(e_uci, 'rpcd', 'login')
+            user_list = utils.get_all_by_type(e_uci, 'users', 'user')
             # check if username is inside config
-            if data['username'] not in [user['username'] for user in user_list.values()]:
+            if data['username'] not in [user['username'] for user in rpcd_user_list.values()]:
                 raise utils.ValidationError('username', 'invalid', data['username'])
 
             # if user is not root, change rpcd config
             if data['username'] != 'root':
-                for user_key, user in user_list.items():
+                for user_key, user in rpcd_user_list.items():
+                    password_hash = users.shadow_password(data['password'])
                     if user['username'] == data['username']:
-                        password_hash = subprocess.run(['uhttpd', '-m', data['password']], check=True,
-                                                       capture_output=True)
-                        e_uci.set('rpcd', user_key, 'password', password_hash.stdout.decode('utf-8').strip('\n'))
+                        e_uci.set('rpcd', user_key, 'password', password_hash)
                         e_uci.save('rpcd')
                         e_uci.commit('rpcd')
+                        break
+                # sync password inside local users db
+                for user_key, user in user_list.items():
+                    is_local = users.get_database_type(e_uci, user['database']) == 'local'
+                    if user['name'] == data['username'] and is_local:
+                        e_uci.set('users', user_key, 'password', password_hash)
+                        e_uci.save('users')
+                        e_uci.commit('users')
                         break
 
             else:

--- a/packages/ns-api/files/ns.users
+++ b/packages/ns-api/files/ns.users
@@ -1,0 +1,98 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# Manage user databases
+
+import os
+import sys
+import json
+import subprocess
+from nethsec import utils, users
+from euci import EUci
+
+cmd = sys.argv[1]
+
+if cmd == 'list':
+    print(json.dumps({
+        "list_users": {"database": "main"},
+        "list-databases": {},
+
+        "add-local-database": {"name": "local", "description": "Local users"},
+        "edit-local-database": {"name": "local", "description": "Local users"},
+        "delete-local-database": {"name": "local"},
+        
+        "add-ldap-database": {"name": "ldap", "uri": "ldap://ldap.example.com", "schema": "rfc2307", "base_dn": "dc=example,dc=com", "user_dn": "ou=People,dc=example,dc=com", "user_attr": "uid", "user_cn": "cn", "start_tls": False, "tls_reqcert": "never", "description": "LDAP users"},
+        "edit-ldap-database": {"name": "ldap", "uri": "ldap://ldap.example.com", "schema": "rfc2307", "base_dn": "dc=example,dc=com", "user_dn": "ou=People,dc=example,dc=com", "user_attr": "uid", "user_cn": "cn", "start_tls": False, "tls_reqcert": "never", "description": "LDAP users"},
+        "delete-ldap-database": {"name": "ldap"},
+        "get-ldap-defaults": {"uri": "ldap://ldap.example.com", "schema": "rfc2307"},
+        "test-ldap": {"uri": "ldap://ldap.example.com", "user_dn": "ou=People,dc=example,dc=com", "user_attr": "uid", "user_cn": "cn", "start_tls": False, "tls_reqcert": "never"},
+
+        "add-local-user": {"name": "user", "password": "password", "description": "User", "database": "main"},
+        "edit-local-user": {"name": "user", "password": "password", "description": "User", "database": "main"},
+        "delete-local-user": {"name": "user", "database": "main"},
+    }))
+else:
+    action = sys.argv[2]
+    u = EUci()
+    try:
+        if action == "list-databases":
+            ret = {"databases": users.list_databases(u)}
+        else:
+            args = json.loads(sys.stdin.read())
+
+        if action == "list-users":
+            ret = {"users": users.list_users(u, args['database'])}
+        elif action == "add-local-database":
+            users.add_local_database(u, args['name'], args['description'])
+            ret = {"result": "success"}
+        elif action == "edit-local-database":
+            users.edit_local_database(u, args['name'], args['description'])
+            ret = {"result": "success"}
+        elif action == "delete-local-database":
+            users.delete_local_database(u, args['name'])
+            ret = {"result": "success"}
+
+        elif action == "add-ldap-database":
+            users.add_ldap_database(u, args['name'], args['uri'], args['schema'], args['base_dn'], args['user_dn'], args['user_attr'], args['user_cn'], args['start_tls'], args['tls_reqcert'], args['description'])
+            ret = {"result": "success"}
+        elif action == "edit-ldap-database":
+            users.edit_ldap_database(u, args['name'], args['uri'], args['schema'], args['base_dn'], args['user_dn'], args['user_attr'], args['user_cn'], args['start_tls'], args['tls_reqcert'], args['description'])
+            ret = {"result": "success"}
+        elif action == "delete-ldap-database":
+            users.delete_ldap_database(u, args['name'])
+            ret = {"result": "success"}
+        elif action == "get-ldap-defaults":
+            ret = {"defaults": users.get_ldap_defaults(args['uri'], args['schema'])}
+        elif action == "test-ldap":
+            ret = {"users": users.list_remote_users(args['uri'], args['user_dn'], args['user_attr'], args['user_cn'], args['start_tls'], args['tls_reqcert'])}
+
+        elif action == "add-local-user":
+            ret = {"id": users.add_local_user(u, args['name'], args['password'], args['description'], args['database'], args["extra"])}
+        elif action == "edit-local-user":
+            ret = {"id": users.edit_local_user(u, args['name'], args['password'], args['description'], args['database'], args["extra"])}
+        elif action == "delete-local-user":
+            users.delete_local_user(u, args['name'], args['database'])
+            ret = {"result": "success"}
+
+        elif action == "add-remote-user":
+            ret = {"id": users.add_remote_user(u, args['name'], args['database'], args["extra"])}
+        elif action == "edit-remote-user":
+            ret = {"id": users.edit_remote_user(u, args['name'], args['database'], args["extra"])}
+        elif action == "delete-remote-user":
+            users.delete_remote_user(u, args['name'], args['database'])
+            ret = {"result": "success"}
+
+        print(json.dumps(ret))
+
+    except KeyError as e:
+        print(json.dumps(utils.validation_error(e.args[0], 'required')))
+    except json.JSONDecodeError:
+        print(json.dumps(utils.generic_error("json given is invalid")))
+    except utils.ValidationError as e:
+        print(json.dumps(utils.validation_error(e.parameter, e.message, e.value)))
+    except ValueError as e:
+        print(json.dumps(utils.generic_error(e)))

--- a/packages/ns-api/files/ns.users
+++ b/packages/ns-api/files/ns.users
@@ -28,6 +28,7 @@ if cmd == 'list':
         "add-ldap-database": {"name": "ldap", "uri": "ldap://ldap.example.com", "schema": "rfc2307", "base_dn": "dc=example,dc=com", "user_dn": "ou=People,dc=example,dc=com", "user_attr": "uid", "user_cn": "cn", "start_tls": False, "tls_reqcert": "never", "description": "LDAP users"},
         "edit-ldap-database": {"name": "ldap", "uri": "ldap://ldap.example.com", "schema": "rfc2307", "base_dn": "dc=example,dc=com", "user_dn": "ou=People,dc=example,dc=com", "user_attr": "uid", "user_cn": "cn", "start_tls": False, "tls_reqcert": "never", "description": "LDAP users"},
         "delete-ldap-database": {"name": "ldap"},
+        "get-database": {"name": "ldap"},
         "get-ldap-defaults": {"uri": "ldap://ldap.example.com", "schema": "rfc2307"},
         "test-ldap": {"uri": "ldap://ldap.example.com", "user_dn": "ou=People,dc=example,dc=com", "user_attr": "uid", "user_cn": "cn", "start_tls": False, "tls_reqcert": "never"},
 
@@ -68,6 +69,8 @@ else:
         elif action == "delete-ldap-database":
             users.delete_ldap_database(u, args['name'])
             ret = {"result": "success"}
+        elif action == "get-database":
+            ret = {"database": users.get_database(u, args['name'])}
         elif action == "get-ldap-defaults":
             ret = {"defaults": users.get_ldap_defaults(args['uri'], args['schema'])}
         elif action == "test-ldap":

--- a/packages/ns-api/files/ns.users
+++ b/packages/ns-api/files/ns.users
@@ -34,6 +34,9 @@ if cmd == 'list':
         "add-local-user": {"name": "user", "password": "password", "description": "User", "database": "main"},
         "edit-local-user": {"name": "user", "password": "password", "description": "User", "database": "main"},
         "delete-local-user": {"name": "user", "database": "main"},
+
+        "set-admin": {"name": "user", "database": "main"},
+        "remove-admin": {"name": "user"},
     }))
 else:
     action = sys.argv[2]

--- a/packages/ns-api/files/ns.users
+++ b/packages/ns-api/files/ns.users
@@ -18,7 +18,7 @@ cmd = sys.argv[1]
 
 if cmd == 'list':
     print(json.dumps({
-        "list_users": {"database": "main"},
+        "list-users": {"database": "main"},
         "list-databases": {},
 
         "add-local-database": {"name": "local", "description": "Local users"},
@@ -84,6 +84,13 @@ else:
             ret = {"id": users.edit_remote_user(u, args['name'], args['database'], args["extra"])}
         elif action == "delete-remote-user":
             users.delete_remote_user(u, args['name'], args['database'])
+            ret = {"result": "success"}
+
+        elif action == "set-admin":
+            id = users.set_admin(u, args['name'], args['database'])
+            ret = {"id": id}
+        elif action == "remove-admin":
+            id = users.remove_admin(u, args['name'])
             ret = {"result": "success"}
 
         print(json.dumps(ret))

--- a/packages/ns-api/files/ns.users.json
+++ b/packages/ns-api/files/ns.users.json
@@ -1,0 +1,13 @@
+{
+  "user-manager": {
+    "description": "User manager",
+    "write": {},
+    "read": {
+      "ubus": {
+        "ns.users": [
+          "*"
+        ]
+      }
+    }
+  }
+}

--- a/packages/ns-dpi/files/dpi-config
+++ b/packages/ns-dpi/files/dpi-config
@@ -8,7 +8,7 @@
 from euci import EUci
 import json
 import subprocess
-from nethsec import utils
+from nethsec import utils, users
 
 def get_interface_ips(interface):
     ret = list()
@@ -28,13 +28,13 @@ def get_interface_ips(interface):
 
 def user_to_criteria(uci, user):
     criteria = []
-    (ipv4, ipv6) = utils.get_user_addresses(uci, user)
-    return entries_to_criteria(ipv4, ipv6, utils.get_user_macs(uci, user))
+    (ipv4, ipv6) = users.get_user_addresses(uci, user)
+    return entries_to_criteria(ipv4, ipv6, users.get_user_macs(uci, user))
 
 def group_to_criteria(uci, group):
     criteria = []
-    (ipv4, ipv6) = utils.get_group_addresses(uci, group)
-    return entries_to_criteria(ipv4, ipv6, utils.get_group_macs(uci, group))
+    (ipv4, ipv6) = users.get_group_addresses(uci, group)
+    return entries_to_criteria(ipv4, ipv6, users.get_group_macs(uci, group))
 
 def entries_to_criteria(ipv4, ipv6, macs):
     criteria = []

--- a/packages/ns-objects/Makefile
+++ b/packages/ns-objects/Makefile
@@ -39,8 +39,8 @@ endef
 
 define Package/ns-objects/install
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_DIR) $(1)/etc/uci-defaults
-	$(INSTALL_CONF) ./files/config $(1)/etc/config/objects
+	$(INSTALL_CONF) ./files/objects $(1)/etc/config/
+	$(INSTALL_CONF) ./files/users $(1)/etc/config/
 endef
  
 $(eval $(call BuildPackage,ns-objects))

--- a/packages/ns-objects/README.md
+++ b/packages/ns-objects/README.md
@@ -1,15 +1,167 @@
 # ns-objects
 
-This package manages the firewall objects.
+This package manages the firewall objects and users.
 
-Supported object types:
-- `user`
-- `group`
-- `host`
+# Users
 
-All objects are saved inside the `/etc/config/objects` UCI database.
+## Databases
 
-## Host
+The `/etc/config/users` UCI configuration manage manages the configuration of user databases.
+It implements 2 kind of database:
+
+- local UCI database
+- remote LDAP (OpenLDAP or Active Directory) database
+
+A local database has:
+- a name which is the UCI section name
+- type set to `local`
+- an optional `description` field
+
+Example:
+```
+config local 'main'
+	option description 'Local users database'
+```
+
+A remote ldap database has:
+- a name which is the UCI section name
+- type set to `ldap`
+- an optional `description` field
+
+It also has the following fields:
+- `uri`: LDAP URI
+- `tls_reqcert`: enable or disable certificate validation, see valid values for `TLS_REQCERT` inside [OpenLDAP documentation](https://www.openldap.org/doc/admin21/tls.html)
+- `base_dn`: LDAP base DN
+- `user_dn`: LDAP user DN; if not present, default is equal as `base_dn`
+- `user_attr`: user attribute to identify the user; usually is `cn` for Active Directory and `uid` for OpenLDAP
+- `starttls`: can be `0` or `1`, if set to `1` enable StartTLS
+
+OpenLDAP example:
+```
+config ldap 'ldap1'
+	option description 'Remote OpenLDAP server'
+	option uri 'ldaps://192.168.100.234'
+	option tls_reqcert 'never'
+	option base_dn 'dc=directory,dc=nh'
+	option user_dn 'ou=People,dc=directory,dc=nh'
+	option user_attr 'uid'
+	option starttls '0'
+	option schema 'rfc2307'
+```
+
+Active Directory example:
+```
+config ldap 'ad1'
+	option description 'Remote AD server'
+	option uri 'ldap://ad.nethserver.org'
+	option tls_reqcert 'always'
+	option base_dn 'dc=ad,dc=nethserver,dc=org'
+	option user_dn 'cn=users,dc=ad,dc=nethserver,dc=org'
+	option user_attr 'cn'
+	option starttls '0'
+	option schema 'ad'
+```
+
+## Users and groups
+
+A user is a dynamic entity representing a user with all physical and virtual devices belonging to a person like PCs, mobile phones or VPN road warrior accesses.
+The user can connect to local services like VPNs.
+
+A group is a dynamic entity representing a list of users.
+
+Users and groups are saved inside the `/etc/config/users` UCI configuration file with the following types:
+- `user` for users
+- `group` for groups
+
+User and group objects are identified by a random section name, but they both contain:
+- a field named `database` which is a reference to the associated database, like `main`
+- a special field named `name` which must be unique inside the associated database
+
+## Local users and groups
+
+Local users and groups are the ones associated to a database of type `local`.
+
+For local users, the `name` field must also meet the following requirements
+
+- have a maximum length of 12 characters (nft set name must be 16 characters or less, 4 chars are reserved for future use)
+
+The local `user` object can have the following non-mandatory options:
+
+- `description`: a longer label for the user, like "Name Surname"
+- `macaddr`: list of MAC addresses belonging to the user's devices
+- `ipaddr`: list of IP addresses
+- `domain`: list of DNS names resolved to IP address, each DNS name is a `domain` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#hostnames)
+- `host`: list of DHCP reservations resolved to IP addresses, each reservation is a `host` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp#static_leases)
+- `password`: shadow password hash, shadow format: `$<alg>$<salt>$<hash>`, where `alg` is always set to `6` (SHA-512)
+- `openvpn_ipaddr`: an OpenVPN RoadWarrior IP address reserved for the user
+
+The local `group` object can have the following non-mandatory options:
+
+- `description`: a longer label for the group, like "Tech people"
+- `user`: a list of `user` objects
+
+Example of local users:
+```
+config user 'ns_rand123'
+	option name "goofy"
+	option description 'Goofy Doe'
+	list macaddr '52:54:00:9d:3d:e5'
+	list ipaddr '192.168.100.23'
+	list domain 'ns_goofy_name'
+	list host 'ns_goofy_pc'
+
+config user 'ns_rand456'
+	option name "Daisy"
+	option label "Daisy White"
+	list ipaddr '192.168.100.22'
+	list ipaddr '2001:db8:3333:4444:5555:6666:7777:8888'
+```
+
+Example of local user with OpenVPN access and a reserved IP:
+```
+config user
+	option name "john"
+    option database "main"
+	option label "John Doe"
+	option openvpn_ipaddr "10.10.10.22"
+	option openvpn_enabled "1"
+	option password "$6$o5l7kWSclhvn5HM5$hRN60ONxiKnb1RZJP14M1oTXYICFS4G998tCasf04j7Gm60p5G9Jkmewqa0LKAcdWwiIijPwowSlA78wx/kP3Q=="
+```
+
+Example of a local group:
+```
+config group
+	option name 'vip'
+    option database "main"
+	option description 'Very Important People'
+	list user 'goofy'
+	list user 'daisy'
+```
+
+## Remote users
+
+Remote users and groups are the ones associated to a database of type `ldap`.
+Each user represent a users inside a remote LDAP database.
+
+The remote `user` object can have the following non-mandatory options:
+
+- `macaddr`: list of MAC addresses belonging to the user's devices
+- `ipaddr`: list of IP addresses
+- `domain`: list of DNS names resolved to IP address, each DNS name is a `domain` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#hostnames)
+- `host`: list of DHCP reservations resolved to IP addresses, each reservation is a `host` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp#static_leases)
+- `openvpn_ipaddr`: an OpenVPN RoadWarrior IP address reserved for the user
+- `openvpn_enabled`: can be `0` or `1`, if set to `0` the user can't authenticate itself inside OpenVPN
+
+Example of a remote user with OpenVPN access and a reserved IP:
+```
+config user
+	option name "john"
+	option database "ldap1"
+	option openvpn_ipaddr "10.10.10.22"
+	option openvpn_enabled "1"
+```
+
+# Hosts
 
 Objects of type `host` are used only as labels inside the UI to display details on firewall rules source and destinations.
 If the user changes the IP address of an host object, such change is not propagated to any configuration file.
@@ -19,143 +171,4 @@ Example of `/etc/config/objects`:
 config host 'myhost'
 	option description 'Myhost'
 	list ipaddr '192.168.100.24'
-```
-## Users
-
-The `/etc/config/users` UCI configuration manage manages the configuration of user databases.
-It implements 2 kind of database:
-
-- local UCI database
-- remote LDAP (OpenLDAP or Active Directory) database
-
-## Local users and groups
-
-A local user is a dynamic entity representing a user with all physical and virtual devices belonging to a person like PCs, mobile phones or VPN road warrior accesses.
-The user can connect to local services like VPNs.
-
-A local group is a dynamic entity representing a list of users.
-
-Local users and groups are saved inside the `/etc/config/users` UCI configuration file with the following types:
-- `local_user` for users
-- `local_group` for groups
-
-Usser and group objects are identified by a random section name, but they both contain a special field named `name`.
-
-The `name` field is mandatory and must:
-
-- be unique inside the local database
-- be a valid UCI id (it may contain only the characters `a-z`, `0-9` and `_`)
-- have a maximum length of 12 characters (nft set name must be 16 characters or less, 4 chars are reserved for future use)
-
-The `local_user` object can have the following non-mandatory options:
-
-- `description`: a longer label for the user, like "Name Surname"
-- `macaddr`: list of MAC addresses belonging to the user's devices
-- `ipaddr`: list of IP addresses
-- `domain`: list of DNS names resolved to IP address, each DNS name is a `domain` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#hostnames)
-- `host`: list of DHCP reservations resolved to IP addresses, each reservation is a `host` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp#static_leases)
-- `ovpn_ipaddr`: an OpenVPN Roadwarrior IP address reserved for the user
-- `ovpn_enabled`: can be `0` or `1`, if set to `0` the user can't authenticate itself inside OpenVPN
-- `password`: shadow password hash, shadow format: `$<alg>$<salt>$<hash>`
-
-The `local_group` object can have the following non-mandatory options:
-
-- `description`: a longer label for the group, like "Tech people"
-- `user`: a list of `user` objects
-
-Example of local users:
-```
-config local_user 'ns_rand123'
-	option name "goofy"
-	option description 'Goofy Doe'
-	list macaddr '52:54:00:9d:3d:e5'
-	list ipaddr '192.168.100.23'
-	list domain 'ns_goofy_name'
-	list host 'ns_goofy_pc'
-
-config local_user
-	option name "Daisy"
-	option label "Daisy White"
-	list ipaddr '192.168.100.22'
-	list ipaddr '2001:db8:3333:4444:5555:6666:7777:8888'
-```
-
-Example of local user with OpenVPN access and a reserved IP:
-```
-config local_user
-	option name "john"
-	option label "John Doe"
-	option ovpn_ipaddr "10.10.10.22"
-	option ovpn_enabled "1"
-	option password "$6$o5l7kWSclhvn5HM5$hRN60ONxiKnb1RZJP14M1oTXYICFS4G998tCasf04j7Gm60p5G9Jkmewqa0LKAcdWwiIijPwowSlA78wx/kP3Q=="
-```
-
-Example of a local group:
-```
-config local_group
-	option name 'vip'
-	option description 'Very Important People'
-	list user 'goofy'
-	list user 'daisy'```
-```
-
-## Remote LDAP database
-
-The LDAP configuration is saved to a `ldap` object inside `/etc/config/users` UCI configuration file with the following
-options:
-- `uri`: LDAP URI
-- `tls_reqcert`: enable or disable certificate validation, see valid values for `TLS_REQCERT` inside [OpenLDAP documentation](https://www.openldap.org/doc/admin21/tls.html)
-- `base_dn`: LDAP base DN
-- `user_dn`: LDAP user DN; if not present, default is equal as `base_dn`
-- `user_attr`: user attribute to identify the user; usually is `cn` for Active Directory and `uid` for OpenLDAP
-- `starttls`: can be `0` or `1`, if set to `1` enable StartTLS
-
-Setup the connection to a remote NethServer 7 LDAP:
-```
-uci set users.ns_ldap1=ldap
-uci set users.ns_ldap1.uri=ldaps://192.168.100.234
-uci set users.ns_ldap1.tls_reqcert=never
-uci set users.ns_ldap1.base_dn=dc=directory,dc=nh
-uci set users.ns_ldap1.user_dn=ou=People,dc=directory,dc=nh
-uci set users.ns_ldap1.user_attr=uid
-uci commit users
-```
-
-If the remote server is an Active Directory, use the following:
-```
-uci set users.ns_ldap1=ldap
-uci set users.ns_ldap1.uri=ldaps://ad.nethserver.org
-uci set users.ns_ldap1.tls_reqcert=never
-uci set users.ns_ldap1.base_dn=dc=ad,dc=nethserver,dc=org
-uci set users.ns_ldap1.user_dn=cn=users,dc=ad,dc=nethserver,dc=org
-uci set users.ns_ldap1.user_attr=cn
-uci commit users
-```
-
-## Remote users
-
-Remote users are saved inside the `/etc/config/users` UCI configuration file with the `remote_user` type.
-Each user represent a users inside a remote LDAP database.
-
-The following fields are mandatory for remote users:
-- `ldap`: the name of the remote LDAP database
-- `name`: the username of the remote user
-
-The `remote_user` object can have the following non-mandatory options:
-
-- `macaddr`: list of MAC addresses belonging to the user's devices
-- `ipaddr`: list of IP addresses
-- `domain`: list of DNS names resolved to IP address, each DNS name is a `domain` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#hostnames)
-- `host`: list of DHCP reservations resolved to IP addresses, each reservation is a `host` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp#static_leases)
-- `ovpn_ipaddr`: an OpenVPN Roadwarrior IP address reserved for the user
-- `ovpn_enabled`: can be `0` or `1`, if set to `0` the user can't authenticate itself inside OpenVPN
-
-
-Example of a remote user with OpenVPN access and a reserved IP:
-```
-config remote_user
-	option name "john"
-	option ovpn_ipaddr "10.10.10.22"
-	option ovpn_enabled "1"
-	option ldap "ns_ldap1"
 ```

--- a/packages/ns-objects/README.md
+++ b/packages/ns-objects/README.md
@@ -9,56 +9,6 @@ Supported object types:
 
 All objects are saved inside the `/etc/config/objects` UCI database.
 
-## User and groups
-
-A user is a dynamic entity representing all physical and virtual devices belonging to a person like PCs, mobile phones or VPN road warrior accesses.
-A group is a dynamic entity representing a list of users.
-
-The `user` and `group` object are identified by the section name.
-The section name must:
-
-- be unique
-- be a valid UCI id (it may contain only the characters `a-z`, `0-9` and `_`)
-- have a maximum length of 12 characters (nft set name must be 16 characters or less, 4 chars are reserved for future use)
-
-The `user` object can have the following non-mandatory options:
-
-- `name`: name of user
-- `description`: a longer label for the user
-- `macaddr`: list of MAC addresses belonging to the user's devices
-- `ipaddr`: list of IP addresses
-- `domain`: list of DNS names resolved to IP address, each DNS name is a `domain` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#hostnames)
-- `host`: list of DHCP reservations resolved to IP addresses, each reservation is a `host` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp#static_leases)
-- `vpn`: list of VPN users with an IP reservation, each VPN user is a `user` record inside [`openvpn` database](https://nethserver.github.io/nethsecurity/packages/ns-openvpn/#authentications-methods)
-
-The `group` object can have the following non-mandatory options:
-
-- `name`: name of group
-- `description`: a longer label for the group
-- `user`: a list of `user` objects
-
-Example of `/etc/config/objects`:
-```
-config user 'goofy'
-	option name "Goofy"
-	option description 'Goofy Doe'
-	list macaddr '52:54:00:9d:3d:e5'
-	list ipaddr '192.168.100.23'
-	list domain 'ns_goofy_name'
-	list host 'ns_goofy_pc'
-	list vpn 'goofy'
-
-config user 'daisy'
-	option name "Daisy"
-	list ipaddr '192.168.100.22'
-	list ipaddr '2001:db8:3333:4444:5555:6666:7777:8888'
-
-config group 'vip'
-	option description 'Very Important People'
-	list user 'goofy'
-	list user 'daisy'
-```
-
 ## Host
 
 Objects of type `host` are used only as labels inside the UI to display details on firewall rules source and destinations.
@@ -69,4 +19,143 @@ Example of `/etc/config/objects`:
 config host 'myhost'
 	option description 'Myhost'
 	list ipaddr '192.168.100.24'
+```
+## Users
+
+The `/etc/config/users` UCI configuration manage manages the configuration of user databases.
+It implements 2 kind of database:
+
+- local UCI database
+- remote LDAP (OpenLDAP or Active Directory) database
+
+## Local users and groups
+
+A local user is a dynamic entity representing a user with all physical and virtual devices belonging to a person like PCs, mobile phones or VPN road warrior accesses.
+The user can connect to local services like VPNs.
+
+A local group is a dynamic entity representing a list of users.
+
+Local users and groups are saved inside the `/etc/config/users` UCI configuration file with the following types:
+- `local_user` for users
+- `local_group` for groups
+
+Usser and group objects are identified by a random section name, but they both contain a special field named `name`.
+
+The `name` field is mandatory and must:
+
+- be unique inside the local database
+- be a valid UCI id (it may contain only the characters `a-z`, `0-9` and `_`)
+- have a maximum length of 12 characters (nft set name must be 16 characters or less, 4 chars are reserved for future use)
+
+The `local_user` object can have the following non-mandatory options:
+
+- `description`: a longer label for the user, like "Name Surname"
+- `macaddr`: list of MAC addresses belonging to the user's devices
+- `ipaddr`: list of IP addresses
+- `domain`: list of DNS names resolved to IP address, each DNS name is a `domain` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#hostnames)
+- `host`: list of DHCP reservations resolved to IP addresses, each reservation is a `host` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp#static_leases)
+- `ovpn_ipaddr`: an OpenVPN Roadwarrior IP address reserved for the user
+- `ovpn_enabled`: can be `0` or `1`, if set to `0` the user can't authenticate itself inside OpenVPN
+- `password`: shadow password hash, shadow format: `$<alg>$<salt>$<hash>`
+
+The `local_group` object can have the following non-mandatory options:
+
+- `description`: a longer label for the group, like "Tech people"
+- `user`: a list of `user` objects
+
+Example of local users:
+```
+config local_user 'ns_rand123'
+	option name "goofy"
+	option description 'Goofy Doe'
+	list macaddr '52:54:00:9d:3d:e5'
+	list ipaddr '192.168.100.23'
+	list domain 'ns_goofy_name'
+	list host 'ns_goofy_pc'
+
+config local_user
+	option name "Daisy"
+	option label "Daisy White"
+	list ipaddr '192.168.100.22'
+	list ipaddr '2001:db8:3333:4444:5555:6666:7777:8888'
+```
+
+Example of local user with OpenVPN access and a reserved IP:
+```
+config local_user
+	option name "john"
+	option label "John Doe"
+	option ovpn_ipaddr "10.10.10.22"
+	option ovpn_enabled "1"
+	option password "$6$o5l7kWSclhvn5HM5$hRN60ONxiKnb1RZJP14M1oTXYICFS4G998tCasf04j7Gm60p5G9Jkmewqa0LKAcdWwiIijPwowSlA78wx/kP3Q=="
+```
+
+Example of a local group:
+```
+config local_group
+	option name 'vip'
+	option description 'Very Important People'
+	list user 'goofy'
+	list user 'daisy'```
+```
+
+## Remote LDAP database
+
+The LDAP configuration is saved to a `ldap` object inside `/etc/config/users` UCI configuration file with the following
+options:
+- `uri`: LDAP URI
+- `tls_reqcert`: enable or disable certificate validation, see valid values for `TLS_REQCERT` inside [OpenLDAP documentation](https://www.openldap.org/doc/admin21/tls.html)
+- `base_dn`: LDAP base DN
+- `user_dn`: LDAP user DN; if not present, default is equal as `base_dn`
+- `user_attr`: user attribute to identify the user; usually is `cn` for Active Directory and `uid` for OpenLDAP
+- `starttls`: can be `0` or `1`, if set to `1` enable StartTLS
+
+Setup the connection to a remote NethServer 7 LDAP:
+```
+uci set users.ns_ldap1=ldap
+uci set users.ns_ldap1.uri=ldaps://192.168.100.234
+uci set users.ns_ldap1.tls_reqcert=never
+uci set users.ns_ldap1.base_dn=dc=directory,dc=nh
+uci set users.ns_ldap1.user_dn=ou=People,dc=directory,dc=nh
+uci set users.ns_ldap1.user_attr=uid
+uci commit users
+```
+
+If the remote server is an Active Directory, use the following:
+```
+uci set users.ns_ldap1=ldap
+uci set users.ns_ldap1.uri=ldaps://ad.nethserver.org
+uci set users.ns_ldap1.tls_reqcert=never
+uci set users.ns_ldap1.base_dn=dc=ad,dc=nethserver,dc=org
+uci set users.ns_ldap1.user_dn=cn=users,dc=ad,dc=nethserver,dc=org
+uci set users.ns_ldap1.user_attr=cn
+uci commit users
+```
+
+## Remote users
+
+Remote users are saved inside the `/etc/config/users` UCI configuration file with the `remote_user` type.
+Each user represent a users inside a remote LDAP database.
+
+The following fields are mandatory for remote users:
+- `ldap`: the name of the remote LDAP database
+- `name`: the username of the remote user
+
+The `remote_user` object can have the following non-mandatory options:
+
+- `macaddr`: list of MAC addresses belonging to the user's devices
+- `ipaddr`: list of IP addresses
+- `domain`: list of DNS names resolved to IP address, each DNS name is a `domain` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#hostnames)
+- `host`: list of DHCP reservations resolved to IP addresses, each reservation is a `host` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp#static_leases)
+- `ovpn_ipaddr`: an OpenVPN Roadwarrior IP address reserved for the user
+- `ovpn_enabled`: can be `0` or `1`, if set to `0` the user can't authenticate itself inside OpenVPN
+
+
+Example of a remote user with OpenVPN access and a reserved IP:
+```
+config remote_user
+	option name "john"
+	option ovpn_ipaddr "10.10.10.22"
+	option ovpn_enabled "1"
+	option ldap "ns_ldap1"
 ```

--- a/packages/ns-objects/README.md
+++ b/packages/ns-objects/README.md
@@ -34,6 +34,7 @@ It also has the following fields:
 - `base_dn`: LDAP base DN
 - `user_dn`: LDAP user DN; if not present, default is equal as `base_dn`
 - `user_attr`: user attribute to identify the user; usually is `cn` for Active Directory and `uid` for OpenLDAP
+- `user_cn`: user attribute that contains the user complete name
 - `starttls`: can be `0` or `1`, if set to `1` enable StartTLS
 
 OpenLDAP example:
@@ -45,6 +46,7 @@ config ldap 'ldap1'
 	option base_dn 'dc=directory,dc=nh'
 	option user_dn 'ou=People,dc=directory,dc=nh'
 	option user_attr 'uid'
+	option user_cn 'cn'
 	option starttls '0'
 	option schema 'rfc2307'
 ```
@@ -58,6 +60,7 @@ config ldap 'ad1'
 	option base_dn 'dc=ad,dc=nethserver,dc=org'
 	option user_dn 'cn=users,dc=ad,dc=nethserver,dc=org'
 	option user_attr 'cn'
+	option user_cn 'cn'
 	option starttls '0'
 	option schema 'ad'
 ```
@@ -94,6 +97,7 @@ The local `user` object can have the following non-mandatory options:
 - `host`: list of DHCP reservations resolved to IP addresses, each reservation is a `host` record inside the [`dhcp` database](https://openwrt.org/docs/guide-user/base-system/dhcp#static_leases)
 - `password`: shadow password hash, shadow format: `$<alg>$<salt>$<hash>`, where `alg` is always set to `6` (SHA-512)
 - `openvpn_ipaddr`: an OpenVPN RoadWarrior IP address reserved for the user
+- `openvpn_enabled`: can be `0` or `1`, if set to `0` the user can't authenticate itself inside OpenVPN
 
 The local `group` object can have the following non-mandatory options:
 

--- a/packages/ns-objects/files/users
+++ b/packages/ns-objects/files/users
@@ -1,0 +1,2 @@
+config database 'main'
+	option description 'Local users'

--- a/packages/ns-openvpn/README.md
+++ b/packages/ns-openvpn/README.md
@@ -80,7 +80,7 @@ See [ns-objects](../ns-objects/) for more info.
 A client can connect to the server if:
 
 - there is a valid certificate inside with the same CN
-- the user has an entry inside the  `users` database and has the `openvpn_enabled` field set to `1`
+- the user is associated to the `ns_roadwarrior` server inside the `openvpn_instance` field and has the `openvpn_enabled` field set to `1` inside `users` database
 
 Certificates are saved inside `/etc/openvpn/<instance>/pki/` directory.
 
@@ -235,7 +235,7 @@ uci commit openvpn
 A client can connect to the server if:
 
 - there is a valid certificate inside with the same CN
-- the user has an entry inside the  `users` database and has the `openvpn_enabled` field set to `1`
+- the user belongs to the `ns_roadwarrior` server instance and is marked as enabled inside `openvpn` database
 - the user password can authenticate against remote LDAP server with provided password
 
 First setup LDAP connection (see previous chapter), then enable authentication against remote LDAP/AD:

--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=python3-nethsec
-PKG_VERSION:=0.0.19
+PKG_VERSION:=0.0.20
 PKG_RELEASE:=1
  
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>
@@ -26,7 +26,7 @@ define Package/python3-nethsec
 	CATEGORY:=NethSecurity
 	TITLE:=NethSecurity python libraries
 	URL:=https://github.com/NethServer/python3-nethsec/
-	DEPENDS:=+python3-light +python3-uci
+	DEPENDS:=+python3-uci +python3-passlib
 	PKGARCH:=all
 endef
  

--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=python3-nethsec
-PKG_VERSION:=0.0.20
+PKG_VERSION:=0.0.22
 PKG_RELEASE:=1
  
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>


### PR DESCRIPTION
User databases can be integrated with OpenVPN and, in the future, with Wireguard. 

Card: https://trello.com/c/uJW5AAwp/178-openvpn-rw

See also: https://github.com/NethServer/python3-nethsec/pull/23

TODO:
- [x] Objects
  - [x] create new user db
  - [x] change python3-nethsec utils to use the new database
  - [x] add new user section inside python3-nethsec
  - [x] use username option instead of section key
  - [x] use openvpn_ipaddr for VPN IP resolution
  - [x] verify if it's possible to link a normal user to a rpcd user to make it admin
  - [x] API: add and remove admin users
- [x] DPI:
  - [x]  use functions from users package (packages/ns-dpi/files/dpi-config)
