### PR TITLE
ns-storage: support partition configuration

### DIFF
--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -3100,11 +3100,20 @@ Response example:
 {
   "devices": [
     {
-      "name": "sda",
-      "size": "1G",
-      "path": "/dev/sda",
-      "model": "QEMU HARDDISK",
-      "vendor": "QEMU"
+      "name": "vdb",
+      "size": 1073741824,
+      "path": "/dev/vdb",
+      "type": "disk",
+      "model": null,
+      "vendor": "0x1af4"
+    },
+    {
+      "name": "vda",
+      "size": 968899584,
+      "path": "/dev/vda",
+      "type": "partition",
+      "model": null,
+      "vendor": null
     }
   ]
 }
@@ -3116,7 +3125,7 @@ Please note that model and vendor could be empty on some hardware.
 
 Configure the device to be used as extra data storage:
 ```
-api-cli ns.storage add-storage --data '{"device": "/dev/sdb"}'
+api-cli ns.storage add-storage --data '{"device": "/dev/sdb", "type": "disk"}'
 ```
 
 Successful response example:

--- a/packages/ns-api/files/ns.storage
+++ b/packages/ns-api/files/ns.storage
@@ -22,7 +22,7 @@ def run(cmd):
 
 def list_devices():
     devices = []
-    p = subprocess.run(["/usr/bin/lsblk", "--json", "--output-all"], check=True, capture_output=True, text=True)
+    p = subprocess.run(["/usr/bin/lsblk", "--json", "-b", "--output-all"], check=True, capture_output=True, text=True)
     data = json.loads(p.stdout)
     for device in data["blockdevices"]:
         if device['type'] == 'disk':
@@ -33,51 +33,105 @@ def list_devices():
                         if mount is not None:
                             mounted = True
             if not mounted and not device['ro']:
-                item = {"name": device['name'], "size": device["size"], "path": device["path"], "model": None, "vendor": None}
+                item = {"name": device['name'], "size": int(device["size"]), "path": device["path"], "type": "disk", "model": None, "vendor": None}
                 if device["model"] is not None:
                     item["model"] = device["model"].strip()
+                else:
+                    item["model"] = device.get("tran")
                 if device["vendor"] is not None:
                     item["vendor"] = device["vendor"].strip()
                 devices.append(item)
+    try:
+        p = subprocess.run(["/usr/libexec/ns-storage-has-free-space"], check=True, capture_output=True, text=True)
+        device = json.loads(p.stdout)
+        item = {"name": device['name'], "size": device["size"], "path": device["path"], "type": "partition", "model": None, "vendor": None}
+        devices.append(item)
+    except:
+        pass
+
     return {"devices": devices}
 
 
 def get_configuration():
     u = EUci()
+    os_device = ''
+    try:
+        proc = subprocess.run("mount | grep /boot | uniq | awk '{print $1}'", shell=True, check=True, capture_output=True, text=True)
+        os_device = proc.stdout.strip()[:-1]
+    except:
+        return utils.generic_error("os_device_not_found")
+
     ret = {"name": None, "size": None, "path": None, "model": None, "vendor": None}
     try:
         info = u.get_all("fstab", "ns_data")
-        p = subprocess.run(["/usr/bin/lsblk", "--json", "--output-all"], check=True, capture_output=True, text=True)
+        p = subprocess.run(["/usr/bin/lsblk", "--json", "-b", "--output-all"], check=True, capture_output=True, text=True)
         data = json.loads(p.stdout)
         cur = None
         for device in data["blockdevices"]:
             if 'children' in device:
                 for child in device['children']:
                     if child['uuid'] == info["uuid"]:
-                        cur = device
+                        #print(f'{os_device} vs {child["path"]}')
+                        if os_device == device['path']:
+                            cur = child
+                        else:
+                            cur = device
         if cur:
             ret["name"] = cur['name']
             ret["size"] = cur["size"]
             ret["path"] = cur["path"]
+            ret["type"] = cur["type"]
             if cur["model"] is not None:
                 ret["model"] = cur["model"].strip()
+            else:
+                ret["model"] = cur.get("tran")
             if cur["vendor"] is not None:
                 ret["vendor"] = cur["vendor"].strip()
     except:
         pass
     return ret
 
+def add_storage(device, dtype):
+    if dtype == "partition":
+        try:
+            subprocess.run(["/usr/libexec/ns-storage-has-free-space"], check=True, capture_output=True)
+        except Exception as e:
+            print(e, file=sys.stderr)
+            return utils.generic_error("no_free_space")
+        try:
+            p = subprocess.run("/usr/libexec/ns-storage-setup-partition", check=True, capture_output=True, text=True)
+            device = json.loads(p.stdout)['device']
+        except Exception as e:
+            print(e, file=sys.stderr)
+            return utils.generic_error("setup_partition_failed")
+    elif dtype == "disk":
+        try:
+            p = subprocess.run(["/usr/libexec/ns-storage-setup-disk", device], check=True, capture_output=True)
+            device = json.loads(p.stdout)['device']
+        except Exception as e:
+            print(e, file=sys.stderr)
+            return utils.generic_error("disk_setup_failed")
+    else:
+        return utils.validation_error("type", "bad_device_type", dtype)
+
+    try:
+        subprocess.run(["/usr/sbin/add-storage", device], check=True, capture_output=True)
+    except Exception as e:
+        print(e, file=sys.stderr)
+        return utils.generic_error("failed_to_add_storage")
+    return {"result": "success"}
+
 cmd = sys.argv[1]
 
 if cmd == 'list':
-    print(json.dumps({"list-devices": {}, "add-storage": {"device": "/dev/sdb"}, "remove-storage": {}, "get-configuration": {}}))
+    print(json.dumps({"list-devices": {}, "add-storage": {"device": "/dev/sdb", "type": "disk"}, "remove-storage": {}, "get-configuration": {}}))
 elif cmd == 'call':
     action = sys.argv[2]
     if action == "list-devices":
         ret = list_devices()
     elif action == "add-storage":
         args = json.loads(sys.stdin.read())
-        ret = run(f"/usr/sbin/add-storage {args['device']}")
+        ret = add_storage(args.get('device'), args.get('type', 'disk'))
     elif action == "remove-storage":
         ret = run("/usr/sbin/remove-storage")
     elif action == "get-configuration":

--- a/packages/ns-storage/Makefile
+++ b/packages/ns-storage/Makefile
@@ -55,8 +55,12 @@ define Package/ns-storage/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/etc/logrotate.d
+	$(INSTALL_DIR) $(1)/usr/libexec
 	$(INSTALL_DIR) $(1)/usr/libexec/sync-data
 	$(INSTALL_BIN) ./files/add-storage $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/ns-storage-setup-partition $(1)/usr/libexec
+	$(INSTALL_BIN) ./files/ns-storage-setup-disk $(1)/usr/libexec
+	$(INSTALL_BIN) ./files/ns-storage-has-free-space $(1)/usr/libexec
 	$(INSTALL_BIN) ./files/remove-storage $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/rotate-messages $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/sync-data $(1)/usr/sbin

--- a/packages/ns-storage/README.md
+++ b/packages/ns-storage/README.md
@@ -15,26 +15,61 @@ Features:
 
 ## Add a data storage
 
+It is possible to use either a partition on the main disk where the operating system is installed or a new disk as additional storage.
+
+The procedure is divided into two parts:
+
+- configure the disk or partition
+- mount the device and setup the system
+
+### New disk
+
 Before starting the configuration, attach a disk device to the machine.
-You can find the attached device name inside `/var/log/messages`.
+You can find the attached device name inside `/var/log/messages`, let's assume the device is named `/dev/sdb`.
 
 To prepare the disk, execute:
 ```
-add-storage <device>
+/usr/libexec/ns-storage-setup-disk /dev/sdb
 ```
 
 The script will prepare the device by:
 
 - erasing all partitions and existing data on the device
 - creating a single partition using the ext4 filesystem
-- mounting the storage at `/mnt/data`
 
-Then, the system will be reconfigured as follow:
+### Parition on existing disk
+
+If the disk where the operating system is installed has unallocated space, it is possible to utilize this space as data storage.
+
+To check if the disk has free space, execute:
+```
+/usr/libexec/ns-storage-has-free-space
+```
+
+The script must exit with 0 and return the available space like:
+```
+{"name": "vda", "path": "/dev/vda", "size": 968899584}
+```
+
+In this case, proceed with the setup:
+```
+/usr/libexec/ns-storage-setup-partition
+```
+
+### Use the device
+
+Execute the `add-storage` script on the prepared device, like:
+```
+add-storage /dev/sda
+```
+
+The script will mount the storage at `/mnt/data` and configure
+the system as follow:
 
 - rsyslog will write logs also inside `/mnt/data/logs/messages` file
 - logrotate will rotate `/mnt/data/logs/messages` once a week (see `/etc/logrotate/data.conf` for more info)
 
-### Data sync customization
+## Data sync customization
 
 Every night the cron will run a script named `sync-data` to sync data from in-memory
 filesystems to persistent storage.

--- a/packages/ns-storage/files/add-storage
+++ b/packages/ns-storage/files/add-storage
@@ -1,59 +1,47 @@
 #!/bin/sh
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
+#
+# Setup the given device as persistent storage mounting it to /mnt/data
+# The device should already have a valid ext4 file system.
+#
+# Parameters:
+# - the device to use, like /dev/vda3
+
 set -e
 
-eerror()
-{
-    echo "ERROR: $1"
-    exit 1
-}
-
 device=$1
+if [ -z "$device" ]; then
+    exit 3
+fi
+
+if [ ! -e "$device" ]; then
+    exit 2
+fi
 mdir=/mnt/data
 
-[ -z "$device" ] && eerror "Device '$device' not found"
-[ ! -e "/sys/class/block/$(basename "$device")" ] && eerror "Device '$device' is not a block device"
-mount | grep -q "$device" && eerror "Device '$device' is already mounted"
-
-# cleanup partitions
-dd if=/dev/zero of="$device" bs=512 count=1 conv=notrunc 2>/dev/null
-echo -n "Initializing storage..."
-# create a single ext4 partition
-parted -s -a optimal "$device" mklabel gpt -- mkpart primary  1 -1 >/dev/null
-mkfs.ext4 -q -O ^has_journal -F "$device"1 >/dev/null
-echo "ok"
-
 # mount the device
-echo -n "Mounting the device..."
 mkdir -p "$mdir"
-mount "$device"1 "$mdir"
-echo "ok"
+mount "$device" "$mdir"
 
 # find uuid and create automount config
-echo -n "Configuring device auto-mount..."
 eval $(block info | grep "$device" | awk '{print $2}')
 uci set fstab.ns_data=mount
 uci set fstab.ns_data.target="$mdir"
 uci set fstab.ns_data.uuid="$UUID"
 uci set fstab.ns_data.enabled=1
 uci commit fstab
-echo "ok"
 
 # setup rsyslog to write log into the device
-echo -n "Configuring rsyslog..."
 mkdir -p "$mdir/log"
 uci set rsyslog.ns_data=selector
 uci set rsyslog.ns_data.source='*.*'
 uci set rsyslog.ns_data.destination="$mdir/log/messages"
 uci commit rsyslog
 /etc/init.d/rsyslog restart
-echo "ok"
 
-echo -n "Add sync-data cron job..."
 crontab -l | grep -q '/usr/sbin/sync-data' || echo '40 1 * * * /usr/sbin/sync-data' >> /etc/crontabs/root
 /etc/init.d/cron restart
-echo "ok"

--- a/packages/ns-storage/files/ns-storage-has-free-space
+++ b/packages/ns-storage/files/ns-storage-has-free-space
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# Check for free space on the OS partition
+# Parameters:
+#  - preserve, disk space to preserve for future use; optional, default to 100MiB
+
+set -e
+
+dev=$(mount | grep /boot | uniq | awk '{print $1}')
+dev=${dev::-1}
+preserve=${1:-100}
+
+pnum=$(lsblk ${dev} -o TYPE -n | grep part | wc -l)
+if [ "${pnum}" -gt 3 ]; then
+    # already partitioned, no free space
+    exit 3
+fi
+
+# find free space
+free_part=$(parted -s -m "${dev}" unit B print free 2>/dev/null | grep free)
+
+if [ -z "${free_part}" ]; then
+    # no free space
+    exit 4
+fi
+
+size=$(echo "${free_part}" | awk -F':' '{print $4}')
+size=${size::-1}
+
+# convert from MiB to B
+preserve=$(( preserve * 8388608 / 8 ))
+size=$(( size - preserve ))
+
+if [ "$size" -le 0 ]; then
+    # not enough free space
+    exit 5
+fi
+
+echo '{"name": "'$(basename $dev)'", "path": "'$dev'", "size": '$size'}'

--- a/packages/ns-storage/files/ns-storage-setup-disk
+++ b/packages/ns-storage/files/ns-storage-setup-disk
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+#
+# Create a single ext4 partition on the given device.
+# Paramters:
+# - device, like '/dev/sdb'
+#
+
+set -e
+
+eerror()
+{
+    echo "ERROR: $1"
+    exit 1
+}
+
+device=$1
+
+[ -z "$device" ] && eerror "Device '$device' not found"
+[ ! -e "/sys/class/block/$(basename "$device")" ] && eerror "Device '$device' is not a block device"
+mount | grep -q "$device" && eerror "Device '$device' is already mounted"
+
+# cleanup partitions
+dd if=/dev/zero of="$device" bs=512 count=1 conv=notrunc 2>/dev/null
+# create a single ext4 partition
+parted -s -a optimal "$device" mklabel gpt -- mkpart primary  1 -1 >/dev/null
+mkfs.ext4 -q -O ^has_journal -F "$device"1 >/dev/null
+echo '{"device": "'${device}1'"}'

--- a/packages/ns-storage/files/ns-storage-setup-partition
+++ b/packages/ns-storage/files/ns-storage-setup-partition
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# Check for free space on the OS disk and create a ext4 partition using the free space.
+# Parameters:
+#  - preserve, disk space to preserve for future use; optional, default to 100MiB
+
+set -e
+
+dev=$(mount | grep /boot | uniq | awk '{print $1}')
+dev=${dev::-1}
+preserve=${1:-100}
+
+# find free space
+free_part=$(parted -s -m $dev unit MiB print free 2>/dev/null | grep free)
+
+if [ -z "${free_part}" ]; then
+    # no free space
+    exit 3
+fi
+
+# find free space start and end
+start_current=$(echo $free_part | awk -F':' '{print $2}')
+end=$(echo $free_part | awk -F':' '{print $3}')
+# remove MB suffix
+start_new=${start_current::-3}
+# preserve some space for future use
+start_new=$((start_new + preserve))
+
+parted -s --fix -a optimal ${dev} unit MiB mkpart ext4 ${start_new}MiB 100%
+mkfs.ext4 -q -O ^has_journal -F "${dev}"3 >/dev/null
+echo '{"device": "'${dev}3'"}'

--- a/packages/ns-storage/files/remove-storage
+++ b/packages/ns-storage/files/remove-storage
@@ -1,29 +1,25 @@
 #!/bin/sh
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
 set -e
 
-echo -n "Removing auto-mount..."
+# Removing auto-mount
 uci delete fstab.ns_data
 uci commit fstab
-echo "ok"
 
-echo -n "Configuring rsyslog..."
+# Configuring rsyslog
 uci delete rsyslog.ns_data
 uci commit rsyslog
 /etc/init.d/rsyslog restart
-echo "ok"
 
-echo -n "Removing sync-data cron job..."
+# Removing sync-data cron job
 crontab -l | grep -v "/usr/sbin/sync-data" | sort | uniq | crontab -
 /etc/init.d/cron restart
-echo ok
 
-echo -n "Umounting data device..."
+# Umounting data device
 umount -f /mnt/data
 rm -rf /mnt/data
-echo "ok"


### PR DESCRIPTION
The package can now save data inside a partition
on the main disk.

Changes:
- the add-storage script now only setups the system
- disk initialization moved to ns-storage-setup-disk script
- added ns-storage-setup-partition script, it must be used only if ns-storage-has-free space exists with 0 code

Card: https://trello.com/c/Avg9egU1/251-log-on-a-dedicated-partition

See UI PR: https://github.com/NethServer/nethsecurity-ui/pull/135