### PR TITLE
OpenVPN RW: multiple fixes

### DIFF
--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -82,15 +82,18 @@ def list_devices():
 
     for ovpn_dev in openvpn_config:
         if ovpn_dev.get('.name').startswith('ns_'):
+            # hide non-configurated vpn networks
+            if not ovpn_dev.get('ns_description'):
+                continue
             if ovpn_dev.get('ns_auth_mode', None):
                 # road warrior server
                 ovpn_rw = {'name': ovpn_dev.get('dev'), 'openvpn_rw': ovpn_dev, 'iface': {
-                    '.name': ovpn_dev['ns_description'], '.type': 'interface', 'device': ovpn_dev['dev']}}
+                    '.name': ovpn_dev.get('ns_description'), '.type': 'interface', 'device': ovpn_dev.get('dev')}}
                 openvpn_devices.append(ovpn_rw)
             else:
                 # openvpn tunnel
                 ovpn_tun = {'name': ovpn_dev.get('dev'), 'openvpn': ovpn_dev, 'iface': {
-                    '.name': ovpn_dev['ns_name'], '.type': 'interface', 'device': ovpn_dev['dev']}}
+                    '.name': ovpn_dev.get('ns_name'), '.type': 'interface', 'device': ovpn_dev.get('dev')}}
                 openvpn_devices.append(ovpn_tun)
 
     all_devices = merged_devices + ifaces_without_device + openvpn_devices

--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -221,6 +221,11 @@ def remove_instance(instance):
     if u.get("openvpn", instance, default=None) == None:
         return utils.validation_error("instance", "instance_not_found", instance)
 
+    db = u.get("openvpn", instance, "ns_user_db", default=None)
+    if db:
+        db_users = users.list_users(u, db)
+        for user in db_users:
+            delete_user(instance, user["name"])
     u.delete("openvpn", instance)
     u.save("openvpn")
     firewall.delete_linked_sections(u, f"openvpn/{instance}")

--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -205,7 +205,12 @@ def add_instance():
     u.set("openvpn", instance, 'tls_version_min','1.2')
     u.set("openvpn", instance, 'ns_auth_mode', 'certificate')
     u.set('openvpn', instance, 'ns_tag', ["automated"])
-    u.save('openvpn')
+
+    # commit everything, otherwise a future revert will break the configuration
+    # drawback: openvpn zone and network will be created even if the instance is not saved
+    u.commit('openvpn')
+    u.commit('firewall')
+    u.commit('network')
 
     # initialize pki
     try:

--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -86,14 +86,17 @@ def is_free_ip(ovpninstance, ip):
 
 def list_user_expirations(openvpninstance):
     ret = {}
-    with open(f"/etc/openvpn/{openvpninstance}/pki/index.txt", "r") as fp:
-        lines = fp.readlines()
-        for line in lines:
-            (status, expiration, revocation, serial, filename, name) = line.split("\t")
-            # remove /CN= from name
-            dt = datetime.strptime(expiration, "%y%m%d%H%M%SZ")
-            name = name.strip()[4:]
-            ret[name] = dt.timestamp()
+    try:
+        with open(f"/etc/openvpn/{openvpninstance}/pki/index.txt", "r") as fp:
+            lines = fp.readlines()
+            for line in lines:
+                (status, expiration, revocation, serial, filename, name) = line.split("\t")
+                # remove /CN= from name
+                dt = datetime.strptime(expiration, "%y%m%d%H%M%SZ")
+                name = name.strip()[4:]
+                ret[name] = dt.timestamp()
+    except:
+        return ret
     return ret
 
 def generate_2fa_secret():
@@ -232,8 +235,10 @@ def remove_instance(instance):
         for user in db_users:
             delete_user(instance, user["name"])
     u.delete("openvpn", instance)
-    u.save("openvpn")
+    u.commit("openvpn")
     firewall.delete_linked_sections(u, f"openvpn/{instance}")
+    u.commit('firewall')
+    u.commit('network')
     shutil.rmtree(f"/etc/openvpn/{instance}")
     
     return {"result": "success"}
@@ -571,8 +576,7 @@ def delete_user(ovpninstance, username):
         env["EASYRSA_PKI"] = f'/etc/openvpn/{ovpninstance}/pki'
         subprocess.run(["/usr/bin/easyrsa", "revoke", username], env=env, check=True, capture_output=True)
         subprocess.run(["/usr/bin/easyrsa", "gen-crl"], env=env, check=True, capture_output=True)
-    except Exception as e:
-        print(e, file=sys.stderr)
+    except:
         return utils.validation_error("username", "user_delete_failed", username)
     return {"result": "success"}
     


### PR DESCRIPTION
Changes:

- when a server instance is removed, remove also the OpenVPN configuration for the associated users https://trello.com/c/QcHSZwhd/256-openvpn-rw-accounts-previously-removed-reappear-during-new-server-creation
- Avoid to keep half-configured things if the server instance is not created from the drawer. https://trello.com/c/GQjEHIVQ/258-openvpn-rw-reverting-after-deleting-rw-server-breaks-openvpn-rw-page
- commit instance deletion https://trello.com/c/GQjEHIVQ/258-openvpn-rw-reverting-after-deleting-rw-server-breaks-openvpn-rw-page