### PR TITLE
refactor: bond creation process

### DIFF
--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -1047,7 +1047,7 @@ def delete_alias_interface(input_data):
 def create_vlan_device(input_data):
     uci = EUci()
     vlan_type = input_data.get('vlan_type')
-    base_device_name = input_data.get('base_device_name')
+    base_device_name: str = input_data.get('base_device_name')
     vlan_id = input_data.get('vlan_id')
 
     # validate input data
@@ -1064,7 +1064,7 @@ def create_vlan_device(input_data):
     # create device
 
     device_id = utils.get_random_id()
-    device_name = f'{base_device_name}.{vlan_id}'
+    device_name = f'{base_device_name.removeprefix("bond-")}.{vlan_id}'
     uci.set('network', device_id, 'device')
     uci.set('network', device_id, 'name', device_name)
     uci.set('network', device_id, 'type', vlan_type)

--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -1100,6 +1100,20 @@ def list_zones_for_device_config():
     return {'zones': zones}
 
 
+def delete_bond():
+    data = json.loads(sys.stdin.read())
+    e_uci = EUci()
+    if 'name' not in data:
+        raise utils.ValidationError('name', 'required')
+    bond = e_uci.get('network', data['name'], 'proto', default='')
+    if bond != 'bonding':
+        raise utils.ValidationError('name', 'invalid', data['name'])
+
+    # all good, delete the interface
+    e_uci.delete('network', data['name'])
+    e_uci.save('network')
+
+
 cmd = sys.argv[1]
 
 if cmd == 'list':
@@ -1157,7 +1171,10 @@ if cmd == 'list':
         'delete-device': {
             'device_name': 'string'
         },
-        'list-zones-for-device-config': {}
+        'list-zones-for-device-config': {},
+        'delete-bond': {
+            'name': 'string'
+        }
     }))
 elif cmd == 'call':
     action = sys.argv[2]
@@ -1196,6 +1213,9 @@ elif cmd == 'call':
         elif action == 'list-zones-for-device-config':
             zones = list_zones_for_device_config()
             print(json.dumps(zones))
+        elif action == 'delete-bond':
+            delete_bond()
+            print(json.dumps({'message': 'success'}))
         else:
             print(json.dumps(utils.generic_error(f'invalid method {action}')))
     except KeyError as e:

--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -42,7 +42,7 @@ def list_devices():
                not (is_bridge(physical_dev) and not get_interface(
                    physical_dev.get('name'), ifaces_from_config)) and
                # discard unconfigured bond devices (let's hide them on deletion, before commit)
-               not is_bond(physical_dev),
+               not (is_bond(physical_dev) and get_interface(physical_dev.get('name'), ifaces_from_config) is None),
                physical_devices))
 
     # add data from config

--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -41,7 +41,7 @@ def list_devices():
                # discard unconfigured bridges (they would appear after bridge removal, before committing changes)
                not (is_bridge(physical_dev) and not get_interface(
                    physical_dev.get('name'), ifaces_from_config)) and
-               # discard unconfigured bond devices (they would appear after committing bond creation)
+               # discard unconfigured bond devices (let's hide them on deletion, before commit)
                not is_bond(physical_dev),
                physical_devices))
 
@@ -49,7 +49,7 @@ def list_devices():
 
     merged_devices = []
 
-    for physical_dev in physical_devices:
+    for physical_dev in filtered_physical_devices:
         device_from_config_found = None
 
         for device_from_config in devices_from_config:
@@ -128,7 +128,8 @@ def list_devices():
                     ipaddr, netmask)
         else:
             # it's a device, associate its interface
-            iface = get_interface(deviceOrIface.get('name'), ifaces_from_config)
+            iface = get_interface(
+                deviceOrIface.get('name'), ifaces_from_config)
 
             if iface:
                 # convert ip4 addresses to CIDR notation
@@ -160,7 +161,8 @@ def list_devices():
 
                         # ip6
                         if pppoe_device_found.get('ip6addrs') and len(pppoe_device_found.get('ip6addrs')) > 0:
-                            iface['ip6addr'] = pppoe_device_found.get('ip6addrs')[0].get('address')
+                            iface['ip6addr'] = pppoe_device_found.get('ip6addrs')[
+                                0].get('address')
 
     devices_used_by_logical_ifaces = []
 
@@ -179,7 +181,6 @@ def list_devices():
                     dev['slaves'] = device.get('slaves')
                     dev['bonding_policy'] = device.get('bonding_policy')
                     dev['bond_interface'] = device.get('.name')
-                    all_devices.pop(key)
 
     # filter devices
 
@@ -1121,7 +1122,6 @@ def delete_bond():
 
     # all good, delete the interface
     e_uci.delete('network', data['name'])
-    # TODO: add device removal
     e_uci.save('network')
 
 

--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -49,7 +49,7 @@ def list_devices():
 
     merged_devices = []
 
-    for physical_dev in filtered_physical_devices:
+    for physical_dev in physical_devices:
         device_from_config_found = None
 
         for device_from_config in devices_from_config:
@@ -128,8 +128,7 @@ def list_devices():
                     ipaddr, netmask)
         else:
             # it's a device, associate its interface
-            iface = get_interface(
-                deviceOrIface.get('name'), ifaces_from_config)
+            iface = get_interface(deviceOrIface.get('name'), ifaces_from_config)
 
             if iface:
                 # convert ip4 addresses to CIDR notation
@@ -166,10 +165,21 @@ def list_devices():
     devices_used_by_logical_ifaces = []
 
     for device in all_devices:
-        if is_bond(device):
+        if is_bond(device) and 'slaves' in device:
             devices_used_by_logical_ifaces += device.get('slaves')
         elif is_bridge(device):
             devices_used_by_logical_ifaces += device.get('ports')
+
+    for key, device in enumerate(all_devices):
+        if device.get('proto') == 'bonding' and device.get('.type') == 'interface':
+            for dev in all_devices:
+                if dev.get('name') == 'bond-' + device.get('.name'):
+                    dev['ipaddr'] = device.get('ipaddr')
+                    dev['netmask'] = device.get('netmask')
+                    dev['slaves'] = device.get('slaves')
+                    dev['bonding_policy'] = device.get('bonding_policy')
+                    dev['bond_interface'] = device.get('.name')
+                    all_devices.pop(key)
 
     # filter devices
 
@@ -910,7 +920,7 @@ def unconfigure_device(iface_name):
                 device_found = dev
                 break
 
-        if device_found and not is_vlan(device_found) and not is_bond(device_found):
+        if device_found and not is_vlan(device_found):
             uci.delete('network', device_found['.name'])
 
     uci.save("firewall")
@@ -1111,6 +1121,7 @@ def delete_bond():
 
     # all good, delete the interface
     e_uci.delete('network', data['name'])
+    # TODO: add device removal
     e_uci.save('network')
 
 


### PR DESCRIPTION
- Added specific call to allow deletion of bonds (separating a little the app concerns)
- The bonding is... very complicated, especially on how we manage the behaviour of several things. Here's a list of what changed:
  - Removed the check to retrieve the stats only for the visible devices
  - Fixed an issue when listing slaves due to the way bonds are recognized
  - If there's a device created from a bond interface, you'll find the bond details inside the device, removing entirely the interface from the request. (bond reference can still be found in `bond_interface`)
  - When removing interface configuration, I'll remove the device even if it's a bond