### PR TITLE
DNS: do not set local option

### DIFF
--- a/packages/ns-api/files/ns.dns
+++ b/packages/ns-api/files/ns.dns
@@ -145,9 +145,6 @@ def set_config(args):
            if type(val) == type(True):
                val = bool2str(val)
            u.set("dhcp", section, opt, val)
-        # calculate local option to avoid errors
-        if 'domain' in args and not 'local' in args:
-           u.set("dhcp", section, 'local', f'/{args["domain"]}/')
         u.save("dhcp")
     except:
         return utils.generic_error("config_write_error")

--- a/packages/ns-migration/files/scripts/dns
+++ b/packages/ns-migration/files/scripts/dns
@@ -29,8 +29,6 @@ for section in u.get("dhcp"):
 
         nsmigration.vprint(f"Setting DNS forwardings")
         u.set("dhcp", section, "server", data["forwardings"])
-        # Forward all non-local records, allow split DNS
-        u.set("dhcp", section, "local", '')
 
 # Create hosts entries
 for host in data["hosts"]:


### PR DESCRIPTION
Setting the "local server" to this new value can lead to an unwanted behaviour especially when there are internal resolvers for specific domains

Card: https://trello.com/c/79bj4dW5/275-dns-change-behaviour-of-dns-domain-option