### PR TITLE
ns-api: devices, set pppoe keepalive

### DIFF
--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -629,6 +629,7 @@ def set_network_configuration(device_type, interface_name, logical_type, interfa
         elif protocol == 'pppoe':
             values['username'] = pppoe_username
             values['password'] = pppoe_password
+            values['keepalive'] = '0 1'
         elif protocol in ['dhcp', 'dhcpv6']:
             # dhcp client id
             values['clientid'] = dhcp_client_id


### PR DESCRIPTION
Avoid errors like:
```
pppd[16354]: No response to 5 echo-requests
pppd[16354]: Serial link appears to be disconnected.
```