### PR TITLE
ns-api: add ns.commit API

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -73,6 +73,19 @@ Several distinctive options have been incorporated into UCI configuration sectio
 - `ns_tag`: this option allows the assignment of a list of tags to any section.
    Users can define custom tags. Meanwhile, the system already employs the special `automated` tag to label automatically generated sections.
 
+### Commit hooks
+
+To overcome UCI limitations, the UI should always use the `ns.commit` API to commit changes.
+The API will:
+- execute all scripts in `/usr/libexec/ns-api/pre-commit` before committing changes
+- commit UCI changes
+- execute all scripts in `/usr/libexec/ns-api/post-commit` after committing changes
+- notify ubus about the changes to apply them
+
+Execution of hooks script will continue even if a script fails. A failure of the
+hook script will not be reflected inside the API exit code.
+Every script within the hook directory will be provided with a JSON-formatted list of changes via standard input.
+
 ### Packages
 
 See [Packages](../packages/).

--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -61,6 +61,8 @@ define Package/ns-api/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/usr/libexec/ns-api/
+	$(INSTALL_DIR) $(1)/usr/libexec/ns-api/pre-commit
+	$(INSTALL_DIR) $(1)/usr/libexec/ns-api/post-commit
 	$(INSTALL_BIN) ./files/api-cli $(1)/usr/bin/
 	$(INSTALL_BIN) ./files/ns.talkers $(1)/usr/libexec/rpcd/
 	$(INSTALL_DATA) ./files/ns.talkers.json $(1)/usr/share/rpcd/acl.d/
@@ -128,6 +130,8 @@ define Package/ns-api/install
 	$(INSTALL_DATA) ./files/ns.devices.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_BIN) ./files/ns.users $(1)/usr/libexec/rpcd/
 	$(INSTALL_DATA) ./files/ns.users.json $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_BIN) ./files/ns.commit $(1)/usr/libexec/rpcd/
+	$(INSTALL_DATA) ./files/ns.commit.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_CONF) files/msmtp.keep $(1)/lib/upgrade/keep.d/msmtp
 	$(LN) /usr/bin/msmtp $(1)/usr/sbin/sendmail

--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -5,6 +5,32 @@ NethSecurity APIs for `rpcd`.
 * TOC
 {:toc}
 
+## ns.commit
+
+This API will take care to commit all UCI changes. This is the workflow:
+
+- pre-commit hook: run all executable scripts inside the /usr/libexec/ns-api/pre-commit directory
+- commit UCI changes
+- post-commit hook: run all executable scripts inside the /usr/libexec/ns-api/post-commit directory
+- inform ubus about changes to apply them
+
+Usage example:
+```
+api-cli ns.commit commit --data '{"changes":{"system":[["set","cfg01e48a","hostname","NethSec2"]]}}'
+```
+
+Successful response example:
+```json
+{"pre_errors": [], "post_errors": []}
+```
+
+The API will fail only if commit of UCI changes raises and error.
+Even if one of the hooks script fail, the API will exit successfully (with exit status code 0) but 
+the failed scripts will be added to the array below:
+```json
+{"pre_errors": ["/usr/libexec/ns-api/pre-commit/test.py", "/usr/libexec/ns-api/pre-commit/test_bash"], "post_errors": []}
+```
+
 ## ns.talkers
 
 ### list

--- a/packages/ns-api/files/ns.commit
+++ b/packages/ns-api/files/ns.commit
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import os
+import sys
+import glob
+import json
+import syslog
+import subprocess
+from euci import EUci
+
+
+def execute_hook(directory, changes):
+    script_files = glob.glob(os.path.join(directory, '*'))
+    errors = []
+    for script in script_files:
+        if os.access(script, os.X_OK):
+            try:
+                # directly execute python scripts to speedup the run
+                if script.endswith('.py'):
+                    exec(open(script).read())
+                else:
+                    subprocess.run([script], input=json.dumps(changes), check=True, capture_output=True, text=True)
+            except Exception as e:
+                syslog.syslog(syslog.LOG_ERR, f"{e}")
+                errors.append(script)
+                continue
+    return errors
+
+
+cmd = sys.argv[1]
+
+if cmd == 'list':
+    print(json.dumps({ 'commit': {} }))
+elif cmd == 'call':
+    action = sys.argv[2]
+    u = EUci()
+    args = json.loads(sys.stdin.read())
+    if action == 'commit':
+        pre_errors = execute_hook("/usr/libexec/ns-api/pre-commit", args['changes'])
+        for config in args["changes"]:
+            u.commit(config)
+        post_errors = execute_hook("/usr/libexec/ns-api/post-commit", args['changes'])
+        subprocess.run(["/bin/ubus", "call", "uci", "reload_config"], check=True)
+        print(json.dumps({"pre_errors": pre_errors, "post_errors": post_errors}))

--- a/packages/ns-api/files/ns.commit.json
+++ b/packages/ns-api/files/ns.commit.json
@@ -1,0 +1,13 @@
+{
+  "commit-manager": {
+    "description": "Execute commit",
+    "write": {},
+    "read": {
+      "ubus": {
+        "ns.commit": [
+          "*"
+        ]
+      }
+    }
+  }
+}

--- a/run
+++ b/run
@@ -51,16 +51,20 @@ fi
 # Download latest image
 podman pull $image
 
-# Renove existing container
+# Remove existing container
 if [ "$(podman ps -a --format '{{.Names}}')" == "nethsec-builder" ]; then
     podman rm nethsec-builder
 fi
 
 # Use VERSION from the environment, need for CI
 # VERSION has the following format: 8-<owrt_release>-ns.<nethsecurity_release>[-<commit_since_last_tag>-g<commit_hash>]
-if [ -z "{$VERSION}" ]; then
+if [ -z "${VERSION}" ]; then
     # Setup version from git if the env var is not set
-    VERSION=$(git describe --tags)
+    if [[ -n "${CI}" ]]; then
+        # Fetch all history when running con Github CI
+        git fetch --prune --unshallow
+    fi
+    VERSION=$(git describe)
 fi
 # OWRT_VERSION is like 23.05.2
 OWRT_VERSION=$(echo $VERSION | cut -d'-' -f1)


### PR DESCRIPTION
This api will take care to commit all changes.

API workflow:
- pre-commit hook: run all executable scripts inside the /usr/libexec/ns-api/pre-commit directory
- commit UCI changes
- post-commit hook: run all executable scripts inside the /usr/libexec/ns-api/post-commit directory
- inform ubus about changes to apply them

Each script inside the hook directory will receive the list of changes inside a JSON in the standard input.

Example of pre-commit script, `/usr/libexec/ns-api/post-commit/log`:
```
#!/bin/bash

read -r data
logger -t DEBUG $data
```

Related UI PR: https://github.com/NethServer/nethsecurity-ui/pull/156

TODO:
- [x] validate the behavior
- [x] add developer documentation: api and hooks customization
- [x] evaluate if support only python scripts: this can be done by removing `subprocess` calls and use `exec`; python-only implementation should be much quicker