### PR TITLE
ns-storage: discard warnings

### DIFF
--- a/packages/ns-storage/files/ns-storage-setup-partition
+++ b/packages/ns-storage/files/ns-storage-setup-partition
@@ -30,6 +30,6 @@ start_new=${start_current::-3}
 # preserve some space for future use
 start_new=$((start_new + preserve))
 
-parted -s --fix -a optimal ${dev} unit MiB mkpart ext4 ${start_new}MiB 100%
-mkfs.ext4 -q -O ^has_journal -F "${dev}"3 >/dev/null
+parted -s --fix -a optimal ${dev} unit MiB mkpart ext4 ${start_new}MiB 100% &>/dev/null
+mkfs.ext4 -q -O ^has_journal -F "${dev}"3 &>/dev/null
 echo '{"device": "'${dev}3'"}'


### PR DESCRIPTION
ns-storage-setup-partition fails if the disk has a "corrupt" GPT table.

```
Warning: Not all of the space available to /dev/sda appears to be used, you can fix the GPT to use all of the space (an extra 61885583 blocks) or continue with the current setting? 
Fixing, due to --fix
```
