### PR TITLE
fix: ipv6 flag management for pppoe ifaces

### DIFF
--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -755,7 +755,13 @@ def create_and_set_network_device(device_name, device_type, protocol, logical_ty
         # add default ipv6 rules
         firewall.add_default_ipv6_rules(uci)
 
-    ip6_value = '1' if enable_ipv6 else '0'
+    ip6_value = '0'
+
+    if protocol == 'pppoe' and enable_ipv6:
+        ip6_value = 'auto'
+    elif enable_ipv6:
+        ip6_value = '1'
+
     ip4_mtu_value = ip4_mtu if ip4_mtu else ''
     ip6_mtu_value = ip6_mtu if ip6_mtu else ''
 


### PR DESCRIPTION
Set `ipv6 = auto` on PPPoE interfaces with IPv6 enabled

Card: https://trello.com/c/PYrd3n37/301-interfaces-pppoe-ipv6

See also:
- https://github.com/NethServer/nethsecurity-ui/pull/165