### PR TITLE
ns-api: pre-commit, fix pf with reflections

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -139,6 +139,7 @@ define Package/ns-api/install
 	$(INSTALL_CONF) ./files/config $(1)/etc/config/ns-api
 	$(INSTALL_CONF) ./files/templates $(1)/etc/config/
 	$(INSTALL_BIN) ./files/post-commit/restart-netdata.py $(1)/usr/libexec/ns-api/post-commit/
+	$(INSTALL_BIN) ./files/pre-commit/fix-redirect-reflections.py $(1)/usr/libexec/ns-api/pre-commit
 endef
  
 $(eval $(call BuildPackage,ns-api))

--- a/packages/ns-api/files/pre-commit/fix-redirect-reflections.py
+++ b/packages/ns-api/files/pre-commit/fix-redirect-reflections.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# This script is used to remove non-existing zones from port forwards (redirects)
+# that uses such zone as reflection zone
+
+import sys
+from euci import EUci
+from nethsec import firewall, utils
+
+
+save = False
+# The changes variable is already within the scope from the caller
+if 'firewall' in changes:
+    e_uci = EUci()
+    for pf in  utils.get_all_by_type(e_uci, 'firewall', 'redirect'):
+        try:
+            zones = e_uci.get_all('firewall', pf, 'reflection_zone')
+        except Exception as e:
+            continue
+        to_remove = []
+        for zone in zones:
+            zid, zname = firewall.get_zone_by_name(e_uci, zone)
+            if zid is None:
+                to_remove.append(zone)
+        if to_remove:
+            zones = list(zones)
+            save = True
+            for zone in to_remove:
+                zones.remove(zone)
+            e_uci.set('firewall', pf, 'reflection_zone', zones)
+
+if save:
+    e_uci.save('firewall')


### PR DESCRIPTION
If a port forward has a reflection on a non-existing zone, the rule is disabled.

This commit removes all non-existing zones from port forwards.

Card: https://trello.com/c/t7JkwqRz/302-hairpin-nat-issue-with-port-forwarding