### PR TITLE
config: enable UI on port 9090 by default

### DIFF
--- a/files/etc/config/firewall
+++ b/files/etc/config/firewall
@@ -24,11 +24,18 @@ config forwarding 'ns_lan2wan'
 	option src		lan
 	option dest		wan
 
-config rule 'ns_allow_webui'
-	option name 'Allow-UI-from-WAN'
+config rule 'ns_allow_https'
+	option name 'Allow-HTTPS-from-WAN'
 	option proto 'tcp'
 	option src 'wan'
 	option dest_port '443'
+	option target 'ACCEPT'
+
+config rule 'ns_allow_ui'
+	option name 'Allow-UI-from-WAN'
+	option proto 'tcp'
+	option src 'wan'
+	option dest_port '9090'
 	option target 'ACCEPT'
 
 # We need to accept udp packets on port 68,

--- a/packages/ns-ui/files/config
+++ b/packages/ns-ui/files/config
@@ -1,6 +1,6 @@
 
 config main 'config'
-	option luci_enable '1'
+	option luci_enable '0'
 	option nsui_enable '1'
 	option nsui_extra_port '9090'
-	option nsui_extra_enable '0'
+	option nsui_extra_enable '1'


### PR DESCRIPTION
Changes:
- expose the UI on port 9090 to ease migration from NS7
- open port 9090 from WAN
- rename UI rule to a more generic HTTP: the rule is used also for proxypass

Card: https://trello.com/c/AotUwjir/317-new-ui-port