### PR TITLE
ns-api: ns.redirects, remove 'all' protocol

### DIFF
--- a/packages/ns-api/files/ns.redirects
+++ b/packages/ns-api/files/ns.redirects
@@ -174,7 +174,7 @@ def edit_redirect(args):
         return utils.generic_error("redirect_not_modified")
 
 def list_protocols():
-    return {"protocols": ["tcp", "udp", "udplite", "icmp", "esp", "ah", "sctp", "all"]}
+    return {"protocols": ["tcp", "udp", "udplite", "icmp", "esp", "ah", "sctp"]}
 
 def get_device_ips():
     ret = {}


### PR DESCRIPTION
Remove "all" from the list of protocols supported by port forward.

On the UI multiple protocols can be selected; e.g. "all" + "udp" doesn't make sense