### PR TITLE
multiple packages: fix conffiles syntax

### DIFF
--- a/packages/ns-dpi/Makefile
+++ b/packages/ns-dpi/Makefile
@@ -49,7 +49,7 @@ exit 0
 endef
 
 define Package/ns-plug/conffiles
-	/etc/config/dpi
+/etc/config/dpi
 endef
 
 # this is required, otherwise compile will fail

--- a/packages/ns-flashstart/Makefile
+++ b/packages/ns-flashstart/Makefile
@@ -30,7 +30,7 @@ define Package/ns-flashstart/description
 endef
 
 define Package/ns-flashstart/conffiles
-	/etc/config/flashstart
+/etc/config/flashstart
 endef
 
 # this is required, otherwise compile will fail

--- a/packages/ns-objects/Makefile
+++ b/packages/ns-objects/Makefile
@@ -30,7 +30,7 @@ define Package/ns-objects/description
 endef
 
 define Package/ns-objects/conffiles
-	/etc/config/objects
+/etc/config/objects
 endef
 
 # this is required, otherwise compile will fail

--- a/packages/ns-phonehome/Makefile
+++ b/packages/ns-phonehome/Makefile
@@ -30,7 +30,7 @@ define Package/ns-phonehome/description
 endef
 
 define Package/ns-phonehome/conffiles
-	/etc/config/phonehome
+/etc/config/phonehome
 endef
 
 # this is required, otherwise compile will fail

--- a/packages/ns-plug/Makefile
+++ b/packages/ns-plug/Makefile
@@ -30,7 +30,7 @@ define Package/ns-plug/description
 endef
 
 define Package/ns-plug/conffiles
-	/etc/config/ns-plug
+/etc/config/ns-plug
 endef
 
 # this is required, otherwise compile will fail

--- a/packages/ns-ui/Makefile
+++ b/packages/ns-ui/Makefile
@@ -33,9 +33,6 @@ define Package/ns-ui/description
 NethSecurity web user interface
 endef
 
-define Package/ns-ui/conffiles
-endef
-
 define Build/Configure
 endef
 


### PR DESCRIPTION
From the official documentation:

```
Package/conffiles (optional)

A list of config files installed by this package, one file per line. The file list section should not be indented: no leading tabs or spaces in the section.
```