### PR TITLE
ns-api: dhcp, exclude bond device

### DIFF
--- a/packages/ns-api/files/ns.dhcp
+++ b/packages/ns-api/files/ns.dhcp
@@ -68,8 +68,8 @@ def list_interfaces():
         dhcps = []
     for i in interfaces:
         record = {"device": "", "start": "", "end": "", "active": False, "options": {} }
-        # skip loopback, wans and interfaces with no IP address (e.g. DHCP interfaces)
-        if i == "loopback" or i in wans or not ('ipaddr' in interfaces[i]):
+        # skip loopback, bond devices, wans and interfaces with no IP address (e.g. DHCP interfaces)
+        if i == "loopback" or i in wans or not ('ipaddr' in interfaces[i]) or interfaces[i].get('proto') == 'bonding':
             continue
 
         record['device'] = interfaces[i].get('device', '')


### PR DESCRIPTION
Exclue bond device, but expose bond associated interface

Card: https://trello.com/c/ni6YH2kq/240-interfaces-and-devices-bond