### PR TITLE
ns-migration: network, set dest_ip for SNAT

### DIFF
--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -253,6 +253,7 @@ for s in data['snats']:
     u.set("firewall", sname, "proto", [s["proto"]])
     u.set("firewall", sname, "snat_ip", s["snat_ip"])
     u.set("firewall", sname, "src_ip", s["src_ip"])
+    u.set("firewall", sname, "dest_ip", s.get("dest_ip", "0.0.0.0/0"))
     u.set("firewall", sname, "src", "wan")
 
 # Save configuration


### PR DESCRIPTION
The UI requires a non-empty dest_ip field

Card: https://trello.com/c/tavYHA5b/283-nat-rules-source-and-destination-netmap