### PR TITLE
ns-api: ovpntunnel, fix server status

### DIFF
--- a/packages/ns-api/files/ns.ovpntunnel
+++ b/packages/ns-api/files/ns.ovpntunnel
@@ -313,9 +313,9 @@ def list_tunnels():
             clients.append(client)
         else:
             connected = ovpn.list_connected_clients(section, topology)
-            if 'client' in connected:
+            if len(connected) > 0:
                 record["connected"] = True
-                record = record | connected['client']
+                record = record | list(connected.values())[0]
 
             local = []
             remote = []


### PR DESCRIPTION
Sometimes connected client has a specific name
and not a generic 'client' label

The change can now handle both cases.

Card: https://trello.com/c/gbHDm9C1/335-openvpn-tunnel-server-status-inconsistency