### PR TITLE
ns-api: reverseproxy, fix chain upload

### DIFF
--- a/packages/ns-api/files/ns.reverseproxy
+++ b/packages/ns-api/files/ns.reverseproxy
@@ -166,6 +166,7 @@ elif cmd == 'call':
 
                 if 'chain_path' in data:
                     with open(f'/etc/nginx/custom_certs/{data["name"]}.crt', 'a') as cert:
+                        cert.write("\n")
                         with open(data['chain_path'], 'r') as chain_file:
                             cert.write(chain_file.read())
 


### PR DESCRIPTION
The main certificate and the chain file must be
separated by a new line, otherwise the generated
file is not in valid PEM format

Card: https://trello.com/c/a8hMaMCD/337-certificate-subject-display-error-on-certificates-page