### PR TITLE
ns-api: reverseproxy, force uci_manage_ssl option

### DIFF
--- a/packages/ns-api/files/ns.reverseproxy
+++ b/packages/ns-api/files/ns.reverseproxy
@@ -245,6 +245,7 @@ elif cmd == 'call':
             # set default certificate for _lan
             e_uci.set('nginx', '_lan', 'ssl_certificate', valid_certificates[data['name']]['cert_path'])
             e_uci.set('nginx', '_lan', 'ssl_certificate_key', valid_certificates[data['name']]['key_path'])
+            e_uci.set('nginx', '_lan', 'uci_manage_ssl', 'custom')
 
             # submit changes
             e_uci.save('nginx')


### PR DESCRIPTION
When the option is set to 'self-signed', the nginx init script will try to create a new certificate if the expiration date is less then 13 months

See https://github.com/openwrt/packages/issues/12022

Card: https://trello.com/c/Gps2BetF/336-custom-certificate-overwritten-with-self-generated-certificate-in-openwrt