### PR TITLE
ns-api-server: remove /usr/sbin directory

### DIFF
--- a/packages/ns-api-server/Makefile
+++ b/packages/ns-api-server/Makefile
@@ -43,8 +43,6 @@ define Package/ns-api-server/install
 	$(call GoPackage/Package/Install/Bin,$(1))
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/ns-api-server.initd $(1)/etc/init.d/ns-api-server
-	$(INSTALL_DIR) $(1)/usr/sbin/
-	$(INSTALL_BIN) $(GO_PKG_BUILD_DIR)/bin/nethsecurity-api $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_CONF) files/ns-api-server.keep $(1)/lib/upgrade/keep.d/ns-api-server
 endef

--- a/packages/ns-api-server/files/ns-api-server.initd
+++ b/packages/ns-api-server/files/ns-api-server.initd
@@ -7,7 +7,7 @@
 
 START=90
 USE_PROCD=1
-PROG=/usr/sbin/nethsecurity-api
+PROG=/usr/bin/nethsecurity-api
 
 WORK_DIR=/var/run/ns-api-server
 TOKENS_DIR=${WORK_DIR}/tokens


### PR DESCRIPTION
The build was failing form ARM targets because the binary is created in a different directory.

Also, with current implementation the nethsecurity-api binary was duplicated inside the package.