### PR TITLE
uci-defaults: nginx, delete _redirect2ssl

### DIFF
--- a/files/etc/uci-defaults/99-nethsec-nginx
+++ b/files/etc/uci-defaults/99-nethsec-nginx
@@ -3,3 +3,6 @@ set nginx._lan.error_log=syslog:server=unix:/dev/log
 set nginx._lan.access_log=syslog:server=unix:/dev/log
 commit nginx
 EOI
+
+# make sure nginx does not listen on port 80 to avoid conflicts with acme.sh
+uci -q delete nginx._redirect2ssl


### PR DESCRIPTION
Do not listen on port 80 to avoid conflict with acme.sh

Card: https://trello.com/c/94ZKwwjY/339-acmesh-lets-encrypt-certificate-request-failed