### PR TITLE
ns-api: dhcp, hide static leases from active ones

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-api
-PKG_VERSION:=0.0.44
+PKG_VERSION:=0.0.45
 PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-api-$(PKG_VERSION)

--- a/packages/ns-api/files/ns.dhcp
+++ b/packages/ns-api/files/ns.dhcp
@@ -165,6 +165,13 @@ def get_interface_device(uci, ip):
 def list_active_leases():
     ret = {"leases": []}
     u = EUci()
+
+    static_leases = []
+    for l in utils.get_all_by_type(u, 'dhcp', 'host'):
+        ldata = u.get_all('dhcp', l)
+        if 'mac' in ldata and 'ip' in ldata:
+            static_leases.append(ldata['mac'].lower())
+
     with open("/tmp/dhcp.leases", "r") as fp:
         for line in fp.readlines():
             tmp = line.split(" ")
@@ -172,6 +179,9 @@ def list_active_leases():
             if tmp[3] == "*":
                 hostname = ""
             (interface, device) = get_interface_device(u, tmp[2])
+            # skip static leases
+            if tmp[1].lower() in static_leases:
+                continue
             ret['leases'].append({"timestamp": tmp[0], "macaddr": tmp[1], "ipaddr": tmp[2], "hostname": hostname, 'interface': interface, "device": device})
     return ret
 


### PR DESCRIPTION
The UI uses the list-active-lease API to show only dynamic leases and not all active ones.

Card: https://trello.com/c/OL753h0v/360-dhcp-static-dymanic-lease