### PR TITLE
ns-dpi: restore signatures

### DIFF
--- a/packages/ns-dpi/files/dpi.init
+++ b/packages/ns-dpi/files/dpi.init
@@ -16,6 +16,8 @@ start_service() {
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance
+    # wait for startup and update signatures on upgrade and after a restore
+    /usr/sbin/screen -dmS dpi-update /bin/bash -c "sleep 30; /usr/sbin/dpi-update"
 }
 
 stop_service() {


### PR DESCRIPTION
Signature files are not part of backup and get
lost on upgrade and restore.

Involved files:
- /etc/netify.d/netify-categories.json
- /etc/netify.d/netify-apps.conf

These files are updated every day.
If such files are added to the backup, the backup will be recreated and sent to the remote server
every night.

To avoid such scenario, files are not saved
but downloaded again at every boot that occurs
on upgrade and restore.

Card: https://trello.com/c/tWClJOWa/356-dpi-filter-loses-enterprise-apps-after-update

Replaces #358 