### PR TITLE
conf: add sftp-server package

### DIFF
--- a/config/sftp-server.conf
+++ b/config/sftp-server.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_openssh-sftp-server=y


### PR DESCRIPTION
Simplify SFTP file transfer with firewall

This commit adds the 'sftp-server' package, eliminating the need for the '-O' flag in scp commands when transferring files with recent SSH client