### PR TITLE
ns-plug: remove hack for acme backup

### DIFF
--- a/packages/ns-plug/files/send-backup
+++ b/packages/ns-plug/files/send-backup
@@ -37,20 +37,10 @@ if [ -z "$SYSTEM_ID" ] || [ -z "$SYSTEM_SECRET" ]; then
     exit 0
 fi
 
-# hack: avoid to backup non-config file
-if [ -f /etc/acme/http.header ]; then
-    mv /etc/acme/http.header /tmp
-fi
-
 # Create the backup
 mkdir -p $WORK_DIR
 sysupgrade -b $BACKUP 2>/dev/null
 md5sum $BACKUP | awk '{print $1}' > $MD5
-
-# hack: restore acme working file
-if [ -f /tmp/http.header ]; then
-    mv /tmp/http.header /etc/acme
-fi
 
 # Send backup if there is no md5 saved
 if [ ! -f "$MD5_LAST" ]; then


### PR DESCRIPTION
Acme new version no longer updates http.header every day: the hack to avoid the daily backup is not necessary anymore.