### PR TITLE
ns-plug: avoid sending backup of non-config files

### DIFF
--- a/packages/ns-plug/files/send-backup
+++ b/packages/ns-plug/files/send-backup
@@ -37,20 +37,26 @@ if [ -z "$SYSTEM_ID" ] || [ -z "$SYSTEM_SECRET" ]; then
     exit 0
 fi
 
-# hack: avoid to backup non-config file
-if [ -f /etc/acme/http.header ]; then
-    mv /etc/acme/http.header /tmp
-fi
+# hack: avoid to backup non-config files (space separated list)
+# files must exist
+files="/etc/banip/banip.blocklist"
+tmpdir=$(mktemp -d)
+for file in $files
+do
+    mv "$file" "$tmpdir"
+done
 
 # Create the backup
 mkdir -p $WORK_DIR
 sysupgrade -b $BACKUP 2>/dev/null
 md5sum $BACKUP | awk '{print $1}' > $MD5
 
-# hack: restore acme working file
-if [ -f /tmp/http.header ]; then
-    mv /tmp/http.header /etc/acme
-fi
+# hack: restore files
+for file in $files
+do
+    mv "${tmpdir}/$(basename "$file")" "$(dirname "$file")"
+done
+rm -rf "$tmpdir"
 
 # Send backup if there is no md5 saved
 if [ ! -f "$MD5_LAST" ]; then


### PR DESCRIPTION
Hack to "remove" modified non-config files from the backup.
Support a list of space separated files to skip.