### PR TITLE
ns-api: fix auto-updates cron

### DIFF
--- a/packages/ns-api/files/schedule-automatic-updates
+++ b/packages/ns-api/files/schedule-automatic-updates
@@ -11,10 +11,10 @@
 
 action=${1:-"check"}
 timestamp=$2
-cmd="sleep echo \$(( RANDOM % 18000 )); /bin/opkg list-upgradable | /usr/bin/cut -f 1 -d ' ' | /usr/bin/xargs -r opkg upgrade"
+cmd="sleep \$(( RANDOM % 18000 )); /bin/opkg list-upgradable | /usr/bin/cut -f 1 -d ' ' | /usr/bin/xargs -r opkg upgrade"
 
 if [ "$action" == "add" ]; then
-    crontab -l | grep -q '$cmd' || echo "5 2 * * $cmd" >> /etc/crontabs/root
+    crontab -l | grep -q "$cmd" || echo "5 2 * * $cmd" >> /etc/crontabs/root
 elif [ "$action" == "remove" ]; then
     crontab -l | grep -v "$cmd" | sort | uniq | crontab -
 else


### PR DESCRIPTION
Fixes:
* Mar  9 16:48:00 NethSec crond[3694]: user root: parse error at sleep
* Every add action adds a crontab line
