### PR TITLE
ns-api: migration, expose bridges and bonds

### DIFF
--- a/packages/ns-api/files/ns.migration
+++ b/packages/ns-api/files/ns.migration
@@ -56,6 +56,8 @@ elif cmd == 'call':
 
     elif action == 'upload':
         ret = []
+        bridges = {}
+        devices = {}
         try:
             # read input and prepare the paths
             data = json.load(sys.stdin)
@@ -67,9 +69,24 @@ elif cmd == 'call':
             subprocess.run(['/bin/tar', 'xzf', MIGRATE_PATH, '-C', MIGRATE_DIR], check=True)
             with open(f'{MIGRATE_DIR}/export/network.json', 'r') as fp:
                 data = json.load(fp)
+            devices = data.get('devices')
             # return the list of interfaces from the archive
             for i in data['interfaces']:
+                if i.get('name').startswith('br'):
+                    bridges[i.get('name')] = {"role": i.get("role"), "ipaddr": i.get('ipaddr')}
+                if not i.get("hwaddr"):
+                    continue
                 ret.append({"name": i.get('name'), "hwaddr": i.get('hwaddr'), "ipaddr": i.get('ipaddr'), "role": i.get("role")})
+            for b in data["bridges"]:
+                for p in b["ports"]:
+                    if p.get('hwaddr'):
+                        br = bridges.get(b.get('name'))
+                        iname = devices.get(p.get('hwaddr'))
+                        ret.append({"name": f"{iname} ({b.get('name')})", "hwaddr": p.get('hwaddr'), "ipaddr": br.get('ipaddr'), "role": br.get('role')})
+            for b in data["bonds"]:
+                for s in b["slaves"]:
+                    iname =  devices.get(s)
+                    ret.append({"name": f"{iname} ({b.get('name')})", "hwaddr": s, "ipaddr": b.get('ipaddr'), "role": b.get('zone')})
             print(json.dumps({'devices': ret}))
         except RuntimeError as error:
             print(json.dumps(utils.generic_error(error.args[0])))


### PR DESCRIPTION
Show inside the UI the bond slaves and the bridge ports. Without this change, it was not possible to correctly migrate these logical interfaces from the UI.

The export archive now must contain the 'devices' node inside network.json file

Card: https://trello.com/c/DREXWyEM/377-migration-remapping-should-display-only-physical-devices

Export with: nethserver-firewall-migration-0.0.12-1.ns7.noarch.rpm