### PR TITLE
ns-api: devices, fix vlan list

### DIFF
--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -337,7 +337,8 @@ def get_interface(device_name, ifaces_from_config):
 
 
 def is_bridge(device):
-    if device.get('type') == 'bridge' or re.match(r"br[0-9]+", device.get('name', '')):
+    # regexp: match bridged but not vlan over bridges
+    if device.get('type') == 'bridge' or re.match(r"^br[0-9]+(?!\.)", device.get('name', '')):
         return True
     else:
         return False


### PR DESCRIPTION
Before this change, a vlan device named brX.Y was recognized as a bridge
As consequence the API was failing while trying to access non existing 'ports' field

Card: https://trello.com/c/VaDMVacB/381-interfaces-and-devices-error-when-creating-vlan-over-a-bridge