### PR TITLE
Controller: new API and improve ns-plug

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -142,6 +142,8 @@ define Package/ns-api/install
 	$(INSTALL_DATA) ./files/ns.plug.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_BIN) ./files/ns.netifyd $(1)/usr/libexec/rpcd/
 	$(INSTALL_DATA) ./files/ns.netifyd.json $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_BIN) ./files/ns.controller $(1)/usr/libexec/rpcd/
+	$(INSTALL_DATA) ./files/ns.controller.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_CONF) files/msmtp.keep $(1)/lib/upgrade/keep.d/msmtp
 	$(LN) /usr/bin/msmtp $(1)/usr/sbin/sendmail

--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -6175,3 +6175,7 @@ Response example:
 ```json
 {"result": "success"}
 ```
+
+## ns.controller
+
+### info

--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -6178,4 +6178,24 @@ Response example:
 
 ## ns.controller
 
+This API is designed to be called from the controller:
+it simplifies the communication between the controller and the managed devices.
+
 ### info
+
+Get the information of the device:
+```
+api-cli ns.controller info
+```
+
+Response example:
+```json
+{
+  "unit_name": "MyFirewall",
+  "version": "NethSecurity 8 23.05.2-ns.0.0.2-beta2-88-gd3a896a",
+  "subscription_type": "enterprise",
+  "system_id": "xxxxxxxxxxxxxxx",
+  "ssh_port": 22,
+  "fqdn": "fw.local"
+}
+```

--- a/packages/ns-api/files/ns.controller
+++ b/packages/ns-api/files/ns.controller
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# APIs used only by the controller
+
+import sys
+import json
+import subprocess
+from nethsec import utils
+from euci import EUci
+
+def get_hostname():
+    with open('/proc/sys/kernel/hostname', 'r') as fp:
+        return fp.read().strip()
+
+def get_version():
+    version = ""
+    with open('/etc/os-release', 'r') as f:
+        for line in f.readlines():
+            if line.startswith("PRETTY_NAME"):
+                version = line[line.index('=')+2:-2]
+                return version.replace("-", " ", 1)
+    return version
+
+def info():
+    ret = {"unit_name": "", "version": "", "subscription_type": "", "system_id": "", "ssh_port": -1, "fqdn": ""}
+    u = EUci()
+    for section in u.get_all("dropbear"):
+        if u.get("dropbear", section, "Port", default=None):
+            ret["ssh_port"] = int(u.get("dropbear", section, "Port"))
+            break
+    ret["version"] = get_version()
+    ret["unit_name"] = u.get("ns-plug", "config", "unit_name", default=get_hostname())
+    ret["fqdn"] = get_hostname()
+    ret["system_id"] = u.get("ns-plug", "config", "system_id", default="")
+    ret["subscription_type"] = u.get("ns-plug", "config", "type", default="")
+    return ret
+
+cmd = sys.argv[1]
+
+if cmd == 'list':
+    print(json.dumps({"info": {}}))
+elif cmd == 'call':
+    action = sys.argv[2]
+    if action == "info":
+        ret = info()
+
+    print(json.dumps(ret))

--- a/packages/ns-api/files/ns.controller.json
+++ b/packages/ns-api/files/ns.controller.json
@@ -1,0 +1,13 @@
+{
+  "controller-manager": {
+    "description": "APIs called from controller",
+    "write": {},
+    "read": {
+      "ubus": {
+        "ns.controller": [
+          "*"
+        ]
+      }
+    }
+  }
+}

--- a/packages/ns-api/files/ns.plug
+++ b/packages/ns-api/files/ns.plug
@@ -55,7 +55,8 @@ def register(join_code, tls_verify, unit_name):
     u.set("ns-plug", "config", "server", "https://"+config["fqdn"])
     u.set("ns-plug", "config", "token", config["token"])
     if not unit_name:
-        u.set("ns-plug", "config", "unit_name", get_hostname())
+        unit_name = get_hostname()
+    u.set("ns-plug", "config", "unit_name", unit_name)
     if tls_verify:
         u.set("ns-plug", "config", "tls_verify", "1")
     else:

--- a/packages/ns-api/files/ns.plug
+++ b/packages/ns-api/files/ns.plug
@@ -80,7 +80,6 @@ def unregister():
     u.set("ns-plug", "config", "server", "")
     u.set("ns-plug", "config", "unit_name", "")
     u.commit("ns-plug")
-    u.delete("rpcd", "controller")
     u.commit("rpcd")
     u.delete("rsyslog", "promtail")
     u.commit("rsyslog")


### PR DESCRIPTION
Changes:

- add a new ns.controller API that can be called from the controller to retrieve and cache unit info
- ns.plug API: fix unit_name set and do not delete rpcd user (more info inside commit messages)

See also https://github.com/NethServer/nethsecurity-controller/pull/16