### PR TITLE
Fix flashstart-authentication : bad "user"

### DIFF
--- a/packages/ns-flashstart/files/flashstart-auth
+++ b/packages/ns-flashstart/files/flashstart-auth
@@ -18,7 +18,7 @@ u = EUci()
 if not u.get("flashstart", "global", "enabled", default=False):
     sys.exit('0')
 
-user = u.get("flashstart", "global", "user", default="")
+user = u.get("flashstart", "global", "username", default="")
 password = u.get("flashstart", "global", "password", default="")
 counter = 0
 for wan in utils.get_all_wan_devices(u):


### PR DESCRIPTION
Fix wrong field : needs to look in the db for "username", not "user" 
