### PR TITLE
ns-api: factoryreset, remove storage partition

### DIFF
--- a/packages/ns-api/files/ns.factoryreset
+++ b/packages/ns-api/files/ns.factoryreset
@@ -19,6 +19,7 @@ elif cmd == 'call':
     action = sys.argv[2]
     if action == "reset":
         try:
+            p = subprocess.run(["/usr/sbin/remove-storage"], check=False, capture_output=True)
             p = subprocess.run(["/sbin/firstboot", "-y"], check=True)
             p = subprocess.run(["/sbin/reboot"], check=True)
             ret = {"result": "success"}


### PR DESCRIPTION
After a factory reset the storage partition can't be accessed from the UI.
To workaround the problem, the user must access the command line and manually remove the partition or add it back with the `add-storage` command.

This commits forces the removal of the partition.

Caveats:
- if the remove-storage command fails (this is unlikely to happen), the partition could be still in a dangling state
- the partition removal works only if the factory reset is performed using the APIs