### PR TITLE
ns-api: flashstart, fix config on clean machine

### DIFF
--- a/packages/ns-api/files/ns.flashstart
+++ b/packages/ns-api/files/ns.flashstart
@@ -58,8 +58,11 @@ elif cmd == 'call':
                     for dnsmasq in get_all_by_type(e_uci, 'dhcp', 'dnsmasq'):
                         # supporting at the moment only one dhcp
                         e_uci.set('flashstart', 'ns_old_conf', 'dnsmasq')
-                        e_uci.set('flashstart', 'ns_old_conf', 'server',
-                                  e_uci.get('dhcp', dnsmasq, 'server', list=True))
+                        try:
+                            cur_server = e_uci.get_all('dhcp', dnsmasq, 'server')
+                        except:
+                            cur_server = []
+                        e_uci.set('flashstart', 'ns_old_conf', 'server', cur_server)
                         # add flashstart as only DNS
                         e_uci.set('dhcp', dnsmasq, 'server', ['127.0.0.1#5300'])
 


### PR DESCRIPTION
On a clean machine the 'server' could be empty.
Avoid error:

```
Traceback (most recent call last):
  File "/usr/libexec/rpcd/ns.flashstart", line 62, in <module>
    e_uci.get('dhcp', dnsmasq, 'server', list=True))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/euci/__init__.py", line 85, in get
```

Issue #411 