### PR TITLE
ns-flashstart: fix firewall rules

### DIFF
--- a/packages/ns-api/files/ns.flashstart
+++ b/packages/ns-api/files/ns.flashstart
@@ -86,6 +86,7 @@ elif cmd == 'call':
             e_uci.commit('dhcp')
             e_uci.commit('flashstart')
             subprocess.run(['flashstart-apply'], check=True)
+            subprocess.run(['/etc/init.d/dnsmasq', 'restart'], check=True, capture_output=True)
 
             print(json.dumps({"message": "success"}))
 

--- a/packages/ns-api/files/ns.flashstart
+++ b/packages/ns-api/files/ns.flashstart
@@ -8,6 +8,7 @@
 import json
 import subprocess
 import sys
+import ipaddress
 
 import nethsec.firewall
 from euci import EUci
@@ -58,13 +59,20 @@ elif cmd == 'call':
                     for dnsmasq in get_all_by_type(e_uci, 'dhcp', 'dnsmasq'):
                         # supporting at the moment only one dhcp
                         e_uci.set('flashstart', 'ns_old_conf', 'dnsmasq')
+                        preserved_forwarders = []
                         try:
                             cur_server = e_uci.get_all('dhcp', dnsmasq, 'server')
                         except:
                             cur_server = []
+                        for server in cur_server:
+                            # preserve all forwarders thar are not simple IP address, like /domain/1.2.3.4
+                            try:
+                                ipaddress.ip_address(server)
+                            except:
+                                preserved_forwarders.append(server)
                         e_uci.set('flashstart', 'ns_old_conf', 'server', cur_server)
                         # add flashstart as only DNS
-                        e_uci.set('dhcp', dnsmasq, 'server', ['127.0.0.1#5300'])
+                        e_uci.set('dhcp', dnsmasq, 'server', preserved_forwarders + ['127.0.0.1#5300'])
 
                 # flashstart will be disabled
                 else:

--- a/packages/ns-flashstart/files/flashstart-setup-firewall
+++ b/packages/ns-flashstart/files/flashstart-setup-firewall
@@ -39,7 +39,7 @@ for z in zones:
     u.set('firewall', zname, 'name', f'Flashstart-intercept-DNS-from-{z}')
     u.set('firewall', zname, 'src', z)
     u.set('firewall', zname, 'src_dport', 53)
-    u.set('firewall', zname, 'dest_port', 5300)
+    u.set('firewall', zname, 'dest_port', 53)
     u.set('firewall', zname, 'proto', "tcp udp")
     u.set('firewall', zname, 'target', 'DNAT')
     u.set('firewall', zname, 'ipset', f'!{bname}')

--- a/packages/ns-flashstart/files/flashstart-setup-firewall
+++ b/packages/ns-flashstart/files/flashstart-setup-firewall
@@ -38,10 +38,10 @@ for z in zones:
     u.set('firewall', zname, 'redirect')
     u.set('firewall', zname, 'name', f'Flashstart-intercept-DNS-from-{z}')
     u.set('firewall', zname, 'src', z)
-    u.set('firewall', zname, 'src_port', 53)
+    u.set('firewall', zname, 'src_dport', 53)
     u.set('firewall', zname, 'dest_port', 5300)
     u.set('firewall', zname, 'proto', "tcp udp")
     u.set('firewall', zname, 'target', 'DNAT')
-    u.set('firewall', zname, 'ipset', bname)
+    u.set('firewall', zname, 'ipset', f'!{bname}')
 
 firewall.apply(u)


### PR DESCRIPTION
Changes:
- fix redirect rules
- force dnsmasq restart

See:
- #420 
- #422 
