### PR TITLE
ns-api: force ipset reload

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -153,6 +153,7 @@ define Package/ns-api/install
 	$(INSTALL_BIN) ./files/post-commit/restart-netdata.py $(1)/usr/libexec/ns-api/post-commit/
 	$(INSTALL_BIN) ./files/pre-commit/fix-redirect-reflections.py $(1)/usr/libexec/ns-api/pre-commit
 	$(INSTALL_BIN) ./files/post-commit/configure-netifyd.py $(1)/usr/libexec/ns-api/post-commit
+	$(INSTALL_BIN) ./files/post-commit/reload-ipsets.py $(1)/usr/libexec/ns-api/post-commit
 endef
  
 $(eval $(call BuildPackage,ns-api))

--- a/packages/ns-api/files/post-commit/reload-ipsets.py
+++ b/packages/ns-api/files/post-commit/reload-ipsets.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# This script forces ipset reload: they are not correctly reloaded by fw4 reload
+
+import subprocess
+
+force_reload = False
+
+if 'firewall' in changes:
+    for change in changes['firewall']:
+        if 'ipset' in change:
+            force_reload = True
+            break
+
+if force_reload:
+    subprocess.run(["/sbin/fw4", "reload-sets"])


### PR DESCRIPTION
The 'fw4 reload' command does not update ipsets if an element has been removed.

The new post-commit hook forces the reload of all ipsets if an ipset has been changed during last uci commit.

Please note that the reload may take a while before been effective, usually 3-4 seconds on a fast machine.

#423 