### PR TITLE
packages: add irqbalance

### DIFF
--- a/config/irqbalance.conf
+++ b/config/irqbalance.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_irqbalance=y


### PR DESCRIPTION
irqbalance should improve network performance on multi-core systems.
Decision about default installation postponed after benchmarks.

```
opkg update
opkg install irqbalance
uci set irqbalance.irqbalance.enabled=1
uci commit
service irqbalance start
```