### PR TITLE
ns-api: ovpnrw, fix remote user creation

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -531,7 +531,11 @@ def add_user(args):
     ovpn_config={"openvpn_enabled":  args.get("enabled", "1"), "openvpn_ipaddr": args.get("ipaddr", ""), "openvpn_2fa": generate_2fa_secret()}
 
     if u.get("users", db) == "ldap":
-        users.add_remote_user(u, args["username"], db, extra_fields=ovpn_config)
+        # remote user
+        if users.get_user_by_name(u, args['username'], db):
+            users.edit_remote_user(u, args["username"], db, extra_fields=ovpn_config)
+        else:
+            users.add_remote_user(u, args["username"], db, extra_fields=ovpn_config)
     else:
         users.edit_local_user(u, args['username'], extra_fields=ovpn_config)
     u.commit("users")

--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -244,7 +244,7 @@ def remove_instance(instance):
     if device:
         firewall.remove_device_from_zone(u, device, 'rwopenvpn')
     u.delete("openvpn", instance)
-    shutil.rmtree(f"/etc/openvpn/{instance}")
+    shutil.rmtree(f"/etc/openvpn/{instance}", ignore_errors=True)
     try:
         # workaround: manually delete config since it's not removed from init script
         os.unlink(f"/var/etc/openvpn-{instance}.conf")


### PR DESCRIPTION
If the user already exists inside the db, do not recreate it to avoid errors.

#437 