### PR TITLE
uci-defaults: set rpcd timeout

### DIFF
--- a/files/etc/uci-defaults/99-nethsec-rpcd-timeout
+++ b/files/etc/uci-defaults/99-nethsec-rpcd-timeout
@@ -1,0 +1,6 @@
+[ "$(uci -q get rpcd.@rpcd[0].timeout)" != "30" ] && exit 0
+
+uci -q batch << EOI
+set rpcd.@rpcd[0].timeout="300"
+commit rpcd
+EOI


### PR DESCRIPTION
Make sure default rpcd timeout is at 300 seconds
to avoid errors on long tasks.

If the timeout has been already modified, preserve the value.