### PR TITLE
OpenVPN: fix bridged road warrior server

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -325,7 +325,7 @@ def set_configuration(args):
     db_is_local = users.get_database_type(u, args["ns_user_db"]) == "local"
 
     if args["dev_type"] == "tap":
-        u.set("openvpn", ovpninstance, "dev", "taprw")
+        u.set("openvpn", ovpninstance, "dev", f"taprw{instance_num}")
         u.set("openvpn", ovpninstance, "ns_bridge", args["ns_bridge"])
         (ip, mask) = get_ip_and_mask(args["ns_bridge"])
         if not ip or not mask:

--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -39,6 +39,50 @@ def get_bridge_by_ip(ip):
                 return section
     return None
 
+def add_tap_to_bridge(u, bridge, interface):
+    if bridge is None or interface is None:
+        return
+    bridge_device = u.get("network", bridge, "device", default=None)
+    if not bridge_device:
+        return
+    devices = utils.get_all_by_type(u, "network", "device")
+    for d in devices:
+        device = devices[d]
+        if device.get("name") == bridge_device and device.get("type") == "bridge":
+            try:
+                ports = u.get_all("network", d, "ports")
+                if interface not in ports:
+                    ports = list(ports)
+                    ports.append(interface)
+                    u.set("network", d, "ports", ports)
+                    u.save("network")
+            except:
+                pass
+            finally:
+                return
+
+def remove_tap_from_bridge(u, bridge, interface):
+    if bridge is None or interface is None:
+        return
+    bridge_device = u.get("network", bridge, "device", default=None)
+    if not bridge_device:
+        return
+    devices = utils.get_all_by_type(u, "network", "device")
+    for d in devices:
+        device = devices[d]
+        if device.get("name") == bridge_device and device.get("type") == "bridge":
+            try:
+                ports = u.get_all("network", d, "ports")
+                if interface in ports:
+                    ports = list(ports)
+                    ports.remove(interface)
+                    u.set("network", d, "ports", ports)
+                    u.save("network")
+            except:
+                pass
+            finally:
+                return
+
 def get_ip_and_mask(bridge):
     u = EUci()
     interfaces = utils.get_all_by_type(u, "network", "interface")
@@ -330,6 +374,7 @@ def set_configuration(args):
         (ip, mask) = get_ip_and_mask(args["ns_bridge"])
         if not ip or not mask:
             return utils.validation_error("ns_bridge", "bridge_not_found", args["ns_bridge"])
+        add_tap_to_bridge(u, args["ns_bridge"], f"taprw{instance_num}")
         ipnet = ipaddress.IPv4Network(f"{ip}/{mask}", strict=False).network_address
         if ipaddress.ip_address(args['ns_pool_start']) not in ipaddress.ip_network(f'{ipnet}/{mask}'):
             return utils.validation_error("ns_pool_start", "start_not_in_network", args['ns_pool_start'])
@@ -353,9 +398,14 @@ def set_configuration(args):
         u.set("openvpn", ovpninstance, "server", f"{server_net} {ovpn.to_netmask(server_mask)}")
         u.set("openvpn", ovpninstance, "client_connect", f"\"/usr/libexec/ns-openvpn/openvpn-connect {ovpninstance}\"")
         u.set("openvpn", ovpninstance, "client_disconnect", f"\"/usr/libexec/ns-openvpn/openvpn-disconnect {ovpninstance}\"")
+        old_dev = u.get("openvpn", ovpninstance, "dev", default=None)
+        old_bridge = u.get("openvpn", ovpninstance, "ns_bridge", default=None)
         u.set("openvpn", ovpninstance, "dev", f"tunrw{instance_num}")
         try:
-            u.delete("openvpn", ovpninstance, "server_bridge")
+            if old_bridge:
+                remove_tap_from_bridge(u, old_bridge, old_dev)
+                u.delete("openvpn", ovpninstance, "server_bridge")
+                u.delete("openvpn", ovpninstance, "ns_bridge")
         except:
             pass
 

--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -287,6 +287,12 @@ def remove_instance(instance):
     device = u.get("openvpn", instance, "dev", default='')
     if device:
         firewall.remove_device_from_zone(u, device, 'rwopenvpn')
+
+    old_bridge = u.get("openvpn", instance, "ns_bridge", default=None)
+    if old_bridge:
+        old_dev = u.get("openvpn", instance, "dev", default=None)
+        remove_tap_from_bridge(u, old_bridge, old_dev)
+
     u.delete("openvpn", instance)
     shutil.rmtree(f"/etc/openvpn/{instance}", ignore_errors=True)
     try:

--- a/packages/ns-migration/files/scripts/openvpn
+++ b/packages/ns-migration/files/scripts/openvpn
@@ -25,6 +25,44 @@ def save_cert(path, data):
     gid = grp.getgrnam("nogroup").gr_gid
     os.chown(path, uid, gid)
 
+def is_bridge(u, name):
+    devices = utils.get_all_by_type(u, "network", "device")
+    for d in devices:
+        device = devices[d]
+        if device.get("name") == name and device.get("type") == "bridge":
+            return True
+    return False
+
+def get_bridge_by_ip(u, ip):
+    for section in utils.get_all_by_type(u, "network", "interface"):
+        if u.get("network", section, "proto", default="") == "static":
+            device = u.get("network", section, "device", default="")
+            if is_bridge(u, device) and u.get("network", section, "ipaddr", default="") == ip:
+                return section
+    return None
+
+def add_tap_to_bridge(u, bridge, interface):
+    if bridge is None or interface is None:
+        return
+    bridge_device = u.get("network", bridge, "device", default=None)
+    if not bridge_device:
+        return
+    devices = utils.get_all_by_type(u, "network", "device")
+    for d in devices:
+        device = devices[d]
+        if device.get("name") == bridge_device and device.get("type") == "bridge":
+            try:
+                ports = u.get_all("network", d, "ports")
+                if interface not in ports:
+                    ports = list(ports)
+                    ports.append(interface)
+                    u.set("network", d, "ports", ports)
+                    u.commit("network")
+            except:
+                pass
+            finally:
+                return
+
 
 iname="ns_roadwarrior1"
 cert_dir=f"/etc/openvpn/{iname}/pki/"
@@ -51,14 +89,27 @@ u.set("openvpn", iname, "openvpn")
 # local-service option is enabled
 if data['rw']['options'].get('topology') == 'net30':
     data['rw']['options']['topology' ] = 'subnet'
-# Force device name
-data['rw']['options']['dev'] = 'tunrw1'
 for option in data['rw']['options']:
     nsmigration.vprint(f"Setting OpenVPN Road Warrior option {option}")
     u.set("openvpn", iname, option, data['rw']['options'][option])
 
-# Force device type
-u.set("openvpn", iname, 'dev_type', data['rw']['options'].get('dev_type', 'tun'))
+# Force device type and name
+if data['rw']['options'].get('dev', '').startswith("tun"):
+    dev_type ='tun'
+else:
+    dev_type ='tap'
+
+u.set("openvpn", iname, 'dev_type', dev_type)
+if dev_type == 'tap':
+    u.set("openvpn", iname, 'dev', 'taprw1')
+    ip = data['rw']['options'].pop("server_bridge").split(" ", 1)
+    ns_bridge = get_bridge_by_ip(u, ip[0])
+    if ns_bridge:
+        u.set("openvpn", iname, 'ns_bridge', ns_bridge)
+        add_tap_to_bridge(u, ns_bridge, 'taprw1')
+else:
+    u.set("openvpn", iname, 'dev', 'tunrw1')
+
 # Setup server certificates
 save_cert(os.path.join(cert_dir, 'ca.crt'), data['rw']['ca']['ca.crt'])
 save_cert(os.path.join(cert_dir, 'index'), data['rw']['ca']['certindex'])


### PR DESCRIPTION
Changes:
- Make sure the tap device is added to the bridge; also remove it on edit
- Avoid tap interface name collision, if multiple bridged servers has been configured.

Todo:
- [x] remove the interface on server deletion
- [x] configure the bridge during migration

#445 