### PR TITLE
ns-storage: fix management of free partition

### DIFF
--- a/packages/ns-storage/files/ns-storage-has-free-space
+++ b/packages/ns-storage/files/ns-storage-has-free-space
@@ -21,7 +21,7 @@ if [ "${pnum}" -gt 3 ]; then
 fi
 
 # find free space
-free_part=$(parted -s -m "${dev}" unit B print free 2>/dev/null | grep free)
+free_part=$(parted -s -m "${dev}" unit B print free 2>/dev/null | grep free | tail -n -1)
 
 if [ -z "${free_part}" ]; then
     # no free space

--- a/packages/ns-storage/files/ns-storage-setup-partition
+++ b/packages/ns-storage/files/ns-storage-setup-partition
@@ -15,7 +15,7 @@ dev=${dev::-1}
 preserve=${1:-100}
 
 # find free space
-free_part=$(parted -s -m $dev unit MiB print free 2>/dev/null | grep free)
+free_part=$(parted -s -m $dev unit MiB print free 2>/dev/null | grep free | tail -n -1)
 
 if [ -z "${free_part}" ]; then
     # no free space


### PR DESCRIPTION
If there is a free space before the first partition, just ignore it. Use always the free space at the end of the disk.

Example of a disk with free space before the first partition:
```
Number  Start   End     Size    File system  Name  Flags
        17.4kB  262kB   245kB   Free Space
 1      262kB   17.0MB  16.8MB  fat16              legacy_boot
 2      17.0MB  332MB   315MB
        332MB   64.0GB  63.7GB  Free Space
```

Workaround for #492 