### PR TITLE
ts-ip: fix gawk regexp

### DIFF
--- a/packages/ns-threat_shield/files/banip.nethesis.feeds
+++ b/packages/ns-threat_shield/files/banip.nethesis.feeds
@@ -1,27 +1,27 @@
 {
         "yoroimallvl1": {
                 "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_malware_level1.ipset",
-                "rule_4": "/^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/{printf \"%s,\\n\",$1}",
+                "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Yoroi malware - Level 1"
         },
         "yoroimallvl2": {
                 "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_malware_level2.ipset",
-                "rule_4": "/^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/{printf \"%s,\\n\",$1}",
+                "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Yoroi malware - Level 2"
         },
         "yoroisusplvl1": {
                 "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_souspicious_level1.ipset",
-                "rule_4": "/^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/{printf \"%s,\\n\",$1}",
+                "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Yoroi suspicious - Level 1"
         },
         "yoroisusplvl2": {
                 "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_souspicious_level2.ipset",
-                "rule_4": "/^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/{printf \"%s,\\n\",$1}",
+                "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Yoroi suspicious - Level 2"
         },
         "nethesislvl3": {
                 "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/nethesis_level3.netset",
-                "rule_4": "/^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/{printf \"%s,\\n\",$1}",
+                "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Nethesis suspicious - Level 3"
         }
 }


### PR DESCRIPTION
The previous regexp gives the following error:
gawk: cmd. line:1: warning: regexp escape sequence `\d' is not a known regexp operator
and the feed is ignored:
May  3 17:09:47 fw banIP-0.9.4-3[16535]: skip empty feed 'yoroisusplvl2v4'
