### PR TITLE
ns-threat_shield: configure banip wans

### DIFF
--- a/packages/ns-threat_shield/Makefile
+++ b/packages/ns-threat_shield/Makefile
@@ -41,6 +41,7 @@ define Package/ns-threat_shield/install
 	$(INSTALL_DIR) $(1)/usr/share/ns-plug/hooks/register
 	$(INSTALL_DIR) $(1)/usr/share/ns-plug/hooks/unregister
 	$(INSTALL_DIR) $(1)/usr/libexec/ns-api/post-commit
+	$(INSTALL_DIR) $(1)/usr/libexec/ns-api/pre-commit
 	$(INSTALL_BIN) ./files/ts-dns $(1)/usr/sbin/ts-dns
 	$(INSTALL_BIN) ./files/ts-ip $(1)/usr/sbin/ts-ip
 	$(INSTALL_BIN) ./files/20_threat_shield $(1)/etc/uci-defaults
@@ -52,6 +53,7 @@ define Package/ns-threat_shield/install
 	$(INSTALL_DATA) ./files/nethesis-dns.sources $(1)/usr/share/threat_shield
 	$(INSTALL_DATA) ./files/banip.nethesis.feeds $(1)/etc/banip
 	$(INSTALL_BIN) ./files/adjust-banip.py $(1)/usr/libexec/ns-api/post-commit/
+	$(INSTALL_BIN) ./files/configure-banip-wans.py $(1)/usr/libexec/ns-api/pre-commit/
 	gzip -9n $(1)/usr/share/threat_shield/nethesis-dns.sources
 endef
 

--- a/packages/ns-threat_shield/files/configure-banip-wans.py
+++ b/packages/ns-threat_shield/files/configure-banip-wans.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# This script configures banip wans:
+# it sets ban_ifv4, ban_ifv6, ban_dev and ban_trigger
+
+from euci import EUci
+from nethsec import utils
+
+save = False
+# The changes variable is already within the scope from the caller
+if 'network' in changes or 'banip' in changes:
+    uci = EUci()
+    devices = []
+    interfaces = []
+
+    if uci.get("banip", "global", "ban_autodetect", default="1") == "1":
+        uci.set("banip", "global", "ban_autodetect", "0")
+        save = True
+
+    devices = utils.get_all_wan_devices(uci, exclude_aliases=True)
+    for d in devices:
+        interfaces.append(utils.get_interface_from_device(uci, d))
+
+    for opt in ('ban_ifv4', 'ban_ifv6', 'ban_trigger'):
+        if tuple(interfaces) != uci.get("banip", "global", opt, default=()):
+            uci.set("banip", "global", opt, list(interfaces))
+            save = True
+
+    if tuple(devices) != uci.get("banip", "global", "ban_dev", default=()):
+        uci.set("banip", "global", "ban_dev", list(devices))
+        save = True
+
+if save:
+    if 'banip' in changes:
+        # the commit on banip database  will already done later by the system
+        uci.save("banip")
+    else:
+        # make sure to commit banip db when there were changes only to network db
+        uci.commit("banip")


### PR DESCRIPTION
New pre-commit hook that configures all banip wan options. The hook is executed every time network or banip databases have been changed.

#505 