### PR TITLE
ns-threat_shield: force banip start on post-commit

### DIFF
--- a/packages/ns-threat_shield/Makefile
+++ b/packages/ns-threat_shield/Makefile
@@ -40,6 +40,7 @@ define Package/ns-threat_shield/install
 	$(INSTALL_DIR) $(1)/etc/banip
 	$(INSTALL_DIR) $(1)/usr/share/ns-plug/hooks/register
 	$(INSTALL_DIR) $(1)/usr/share/ns-plug/hooks/unregister
+	$(INSTALL_DIR) $(1)/usr/libexec/ns-api/post-commit
 	$(INSTALL_BIN) ./files/ts-dns $(1)/usr/sbin/ts-dns
 	$(INSTALL_BIN) ./files/ts-ip $(1)/usr/sbin/ts-ip
 	$(INSTALL_BIN) ./files/20_threat_shield $(1)/etc/uci-defaults
@@ -50,6 +51,7 @@ define Package/ns-threat_shield/install
 	$(INSTALL_DIR) $(1)/usr/share/threat_shield
 	$(INSTALL_DATA) ./files/nethesis-dns.sources $(1)/usr/share/threat_shield
 	$(INSTALL_DATA) ./files/banip.nethesis.feeds $(1)/etc/banip
+	$(INSTALL_BIN) ./files/adjust-banip.py $(1)/usr/libexec/ns-api/post-commit/
 	gzip -9n $(1)/usr/share/threat_shield/nethesis-dns.sources
 endef
 

--- a/packages/ns-threat_shield/files/adjust-banip.py
+++ b/packages/ns-threat_shield/files/adjust-banip.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# This script makes sure the status of banip service corresponds to the configured one
+
+import subprocess
+from euci import EUci
+
+# The changes variable is already within the scope from the caller
+if 'banip' in changes:
+    uci = EUci()
+    enabled = uci.get('banip', 'global', 'ban_enabled', default='0')
+    try:
+        subprocess.run(["/etc/init.d/banip", "running"], check=True)
+        running = True
+    except:
+        running = False
+
+    if running and not enabled:
+        subprocess.run(["/etc/init.d/banip", "stop"])
+    if not running and enabled:
+        subprocess.run(["/etc/init.d/banip", "start"])


### PR DESCRIPTION
Create a post-commit hook that adjusts the status of banip service. Previously, if banip was not running, the UI was not able to enable it.

#507 