### PR TITLE
ns-threat_shield: force banip restart

### DIFF
--- a/packages/ns-threat_shield/files/adjust-banip.py
+++ b/packages/ns-threat_shield/files/adjust-banip.py
@@ -11,7 +11,7 @@ import subprocess
 from euci import EUci
 
 # The changes variable is already within the scope from the caller
-if 'banip' in changes:
+if 'banip' in changes or 'network' in changes:
     uci = EUci()
     enabled = uci.get('banip', 'global', 'ban_enabled', default='0')
     try:
@@ -22,5 +22,11 @@ if 'banip' in changes:
 
     if running and not enabled:
         subprocess.run(["/etc/init.d/banip", "stop"])
-    if not running and enabled:
+    elif not running and enabled:
+        subprocess.run(["/etc/init.d/banip", "start"])
+    else:
+        # force nft rules reload for wan changes
+        # a restart is not good because sometimes banip
+        # service executes a reload and not a real restart
+        subprocess.run(["/etc/init.d/banip", "stop"])
         subprocess.run(["/etc/init.d/banip", "start"])


### PR DESCRIPTION
When changing ban_ifv4, ban_ifv6, ban_dev and ban_trigger options, after the banip database commit, the nft rules are not updated.

This change is an hack to force the restart of banip. A simple "/etc/init.d/banip restart" is not enough, because sometimes the service does only a reload which does not recreate nft rules

#505 