### PR TITLE
ns-phonehome: fix json format

### DIFF
--- a/packages/ns-phonehome/files/phonehome
+++ b/packages/ns-phonehome/files/phonehome
@@ -74,10 +74,13 @@ if not product:
     except:
         product = ""
 
+nethsec_version = ""
+version = ""
 with open('/etc/os-release', 'r') as file:
     for line in file:
-        if line.startswith("VERSION_ID"):
+        if line.startswith("VERSION_ID="):
             nethsec_version = line.split('=')[1].split('-')[2][3:]
+            version = line.split('=')[1].replace('"','').rstrip()
             break
 
 data = {
@@ -85,6 +88,10 @@ data = {
     "uuid": sid,
     "installation": "nethsecurity",
     "facts": {
+        "distro": {
+            "name": "NethSecurity",
+            "version": version
+        },
         "processors": { 
             "count": _run("grep processor /proc/cpuinfo  | wc -l"), 
             "model":  _get_cpu_field("Model name", cpu_info),


### PR DESCRIPTION
The `distro` node is required, otherwise the server will not accept the payload.

Regression introduced in commit 2b9e1d1251924562d90ec8a8514b70d816519f05

Server error:
```
n1 app[1492815]: [2024-05-16 12:49:38] production.DEBUG: JsonSchema validation failed {"/facts":["The required properties (distro) are missing"]}
```