### PR TITLE
Improve usage statistics

### DIFF
--- a/packages/ns-phonehome/files/phonehome
+++ b/packages/ns-phonehome/files/phonehome
@@ -11,6 +11,7 @@ import json
 import uuid
 import subprocess
 from euci import EUci
+from nethsec import inventory
 
 def _run(cmd):
     try:
@@ -80,6 +81,12 @@ with open('/etc/os-release', 'r') as file:
             nethsec_version = line.split('=')[1].split('-')[2][3:]
             break
 
+features = {}
+for func in dir(inventory):
+    if func.startswith("fact_"):
+        method = getattr(inventory, func)
+        features[func.removeprefix('fact_')] = method(EUci())
+
 data = {
     "$schema": "https://schema.nethserver.org/facts/2022-12.json",
     "uuid": sid,
@@ -100,7 +107,8 @@ data = {
             "system": { "used_bytes": _run("free | grep 'Mem': | awk '{print $3}'"), "available_bytes": _run("free | grep 'Mem:' | awk '{print $7}'") }
         },
         "pci": list(pci.values()),
-        "version": nethsec_version
+        "version": nethsec_version,
+        "features": features
     }
 }
 print(json.dumps(data))

--- a/packages/ns-plug/files/inventory
+++ b/packages/ns-plug/files/inventory
@@ -9,7 +9,7 @@ import json
 import subprocess
 from euci import EUci
 from struct import pack
-from nethsec import utils
+from nethsec import utils, inventory
 from socket import inet_ntoa
 
 def _run(cmd):
@@ -106,6 +106,12 @@ for section in utils.get_all_by_type(u, 'network', 'interface'):
                 network['props']["bridge"] = u.get('network', d, 'ports')
     networks[device] = network
 
+features = {}
+for func in dir(inventory):
+    if func.startswith("fact_"):
+        method = getattr(inventory, func)
+        features[func.removeprefix('fact_')] = method(EUci())
+
 data = {
     "arp_macs": _run('cat /proc/net/arp | grep -v IP | wc -l'),
     "dmi": { "product": { "name": product, "uuid": _run("cat /sys/class/dmi/id/product_uuid") }, "bios": { "version": _run("cat /sys/devices/virtual/dmi/id/bios_version"), "vendor": _run("cat /sys/devices/virtual/dmi/id/bios_vendor")}, "board": { "product": board, "manufacturer": _run("cat /sys/devices/virtual/dmi/id/sys_vendor") }},
@@ -142,7 +148,8 @@ data = {
         }
     },
     "rpms": { "nethserver-firewall-base-ui": _run("opkg status ns-ui | grep Version | awk '{print $2}'") },
-    "public_ip": _run("curl https://ifconfig.co")
+    "public_ip": _run("curl https://ifconfig.co"),
+    "features": features
 }
 
 print(json.dumps(data))


### PR DESCRIPTION
Changes:
- add usage stats to phonehome
- add usage stats to inventory

Inventory example:
```json
{"arp_macs": "3", "dmi": {"product": {"name": "Standard PC (Q35 + ICH9, 2009)", "uuid": "3a278260-9b70-4dcc-836c-032e2d31ca57"}, "bios": {"version": "1.16.2-1.fc38", "vendor": "SeaBIOS"}, "board": {"product": "qemu-standard-pc-q35-ich9-2009", "manufacturer": "QEMU"}}, "virtual": "KVM", "kernel": "Linux", "kernelrelease": "5.15.150", "networking": {"fqdn": "NethSec"}, "os": {"type": "nethsecurity", "name": "NethSec", "release": {"full": "8-23.05.3-ns.0.0.5-rc2-62-ge22c143", "major": 7}, "family": "OpenWRT"}, "processors": {"count": "2", "models": ["Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz"], "isa": "x86_64"}, "timezone": "UTC", "system_uptime": {"seconds": "24768"}, "esmithdb": {"networks": [{"type": "bridge", "name": "br-lan", "props": {"role": "green", "ipaddr": "192.168.100.238", "netmask": "255.255.255.0", "gateway": null, "bridge": "eth0"}}, {"type": "ethernet", "name": "eth1", "props": {"role": "red", "ipaddr": "10.10.0.221", "netmask": "255.255.255.0", "gateway": "10.10.0.1"}}], "configuration": [{"name": "sysconfig", "type": "configuration", "props": {"Version": "8-23.05.3-ns.0.0.5-rc2-62-ge22c143"}}, {"name": "dns", "type": "configuration", "props": {"NameServers": "10.10.0.1,"}}, {"name": "SystemName", "type": "NethSec"}, {"name": "DomainName", "type": "NethSec"}]}, "memory": {"swap": {"used_bytes": 0, "available_bytes": 0, "total_bytes": 0}, "system": {"used_bytes": 135815168, "available_bytes": 814886912, "total_bytes": 814628864}}, "mountpoints": {"/": {"used_bytes": 53915648, "available_bytes": 210456576, "size_bytes": 264372224}}, "rpms": {"nethserver-firewall-base-ui": "0.77.0-1"}, "public_ip": "80.17.99.73", "features": {"controller": {"enabled": false}, "dhcp_server": {"count": 0}, "dpi": {"enabled": true, "rules": 1}, "flashstart": {"enabled": false, "bypass": 1}, "hotspot": {"enabled": false, "server": "https://my.nethspot.com/api"}, "ipsec": {"count": 0}, "multiwan": {"wans": 0}, "network": {"ipv6": 0, "ipv4": 3}, "openvpn_rw": {"enabled": 0, "server": 0}, "openvpn_tun": {"client": 0, "server": 0}, "proxy_pass": {"count": 0}, "qos": {"count": 0}, "storage": {"enabled": false}, "subscription_status": {"status": "no"}, "threat_shield": {"enabled": true, "community": 4, "enterprise": 1}, "ui": {"luci": false, "port443": true, "port9090": true}}}
```

Phonehome example:
```json
{"$schema": "https://schema.nethserver.org/facts/2022-12.json", "uuid": "3a278260-9b70-4dcc-836c-032e2d31ca57", "installation": "nethsecurity", "facts": {"distro": {"name": "NethSecurity", "version": "8-23.05.3-ns.0.0.5-rc2-62-ge22c143"}, "processors": {"count": "2", "model": "Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz", "architecture": "x86_64"}, "product": {"name": "Standard PC (Q35 + ICH9, 2009)", "manufacturer": "QEMU"}, "virtual": "KVM", "memory": {"swap": {"used_bytes": "0", "available_bytes": "0"}, "system": {"used_bytes": "128756", "available_bytes": "799916"}}, "pci": [{"class_id": "0600", "vendor_id": "8086", "device_id": "29c0", "revision": "", "class_name": "Host bridge", "vendor_name": "Intel Corporation", "device_name": "82G33/G31/P35/P31 Express DRAM Controller", "driver": ""}, {"class_id": "0300", "vendor_id": "1af4", "device_id": "1050", "revision": "01", "class_name": "VGA compatible controller", "vendor_name": "Red Hat, Inc.", "device_name": "Virtio GPU", "driver": "virtio-pci"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0604", "vendor_id": "1b36", "device_id": "000c", "revision": "", "class_name": "PCI bridge", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU PCIe Root port", "driver": "pcieport"}, {"class_id": "0403", "vendor_id": "8086", "device_id": "293e", "revision": "03", "class_name": "Audio device", "vendor_name": "Intel Corporation", "device_name": "82801I (ICH9 Family) HD Audio Controller", "driver": ""}, {"class_id": "0601", "vendor_id": "8086", "device_id": "2918", "revision": "02", "class_name": "ISA bridge", "vendor_name": "Intel Corporation", "device_name": "82801IB (ICH9) LPC Interface Controller", "driver": "lpc_ich"}, {"class_id": "0106", "vendor_id": "8086", "device_id": "2922", "revision": "02", "class_name": "SATA controller", "vendor_name": "Intel Corporation", "device_name": "82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]", "driver": "ahci"}, {"class_id": "0c05", "vendor_id": "8086", "device_id": "2930", "revision": "02", "class_name": "SMBus", "vendor_name": "Intel Corporation", "device_name": "82801I (ICH9 Family) SMBus Controller", "driver": ""}, {"class_id": "0200", "vendor_id": "1af4", "device_id": "1041", "revision": "01", "class_name": "Ethernet controller", "vendor_name": "Red Hat, Inc.", "device_name": "Virtio network device", "driver": "virtio-pci"}, {"class_id": "0200", "vendor_id": "1af4", "device_id": "1041", "revision": "01", "class_name": "Ethernet controller", "vendor_name": "Red Hat, Inc.", "device_name": "Virtio network device", "driver": "virtio-pci"}, {"class_id": "0c03", "vendor_id": "1b36", "device_id": "000d", "revision": "01", "class_name": "USB controller", "vendor_name": "Red Hat, Inc.", "device_name": "QEMU XHCI Host Controller", "driver": "xhci_hcd"}, {"class_id": "0780", "vendor_id": "1af4", "device_id": "1043", "revision": "01", "class_name": "Communication controller", "vendor_name": "Red Hat, Inc.", "device_name": "Virtio console", "driver": "virtio-pci"}, {"class_id": "0100", "vendor_id": "1af4", "device_id": "1042", "revision": "01", "class_name": "SCSI storage controller", "vendor_name": "Red Hat, Inc.", "device_name": "Virtio block device", "driver": "virtio-pci"}, {"class_id": "00ff", "vendor_id": "1af4", "device_id": "1045", "revision": "01", "class_name": "Unclassified device [00ff]", "vendor_name": "Red Hat, Inc.", "device_name": "Virtio memory balloon", "driver": "virtio-pci"}, {"class_id": "00ff", "vendor_id": "1af4", "device_id": "1044", "revision": "01", "class_name": "Unclassified device [00ff]", "vendor_name": "Red Hat, Inc.", "device_name": "Virtio RNG", "driver": "virtio-pci"}, {"class_id": "0100", "vendor_id": "1af4", "device_id": "1048", "revision": "01", "class_name": "SCSI storage controller", "vendor_name": "Red Hat, Inc.", "device_name": "Virtio SCSI", "driver": "virtio-pci"}, {"class_id": "0200", "vendor_id": "1af4", "device_id": "1041", "revision": "01", "class_name": "Ethernet controller", "vendor_name": "Red Hat, Inc.", "device_name": "Virtio network device", "driver": "virtio-pci"}], "version": "0.0.5", "features": {"controller": {"enabled": false}, "dhcp_server": {"count": 0}, "dpi": {"enabled": true, "rules": 1}, "flashstart": {"enabled": false, "bypass": 1}, "hotspot": {"enabled": false, "server": "https://my.nethspot.com/api"}, "ipsec": {"count": 0}, "multiwan": {"wans": 0}, "network": {"ipv6": 0, "ipv4": 3}, "openvpn_rw": {"enabled": 0, "server": 0}, "openvpn_tun": {"client": 0, "server": 0}, "proxy_pass": {"count": 0}, "qos": {"count": 0}, "storage": {"enabled": false}, "subscription_status": {"status": "no"}, "threat_shield": {"enabled": true, "community": 4, "enterprise": 1}, "ui": {"luci": false, "port443": true, "port9090": true}}}}

```

Requires: https://github.com/NethServer/python3-nethsec/pull/43


Issue: #537 