### PR TITLE
packages: add supervisor

### DIFF
--- a/config/supervisor.conf
+++ b/config/supervisor.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_supervisor=y

--- a/packages/supervisor/Makefile
+++ b/packages/supervisor/Makefile
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=supervisor
+PKG_VERSION:=4.2.5
+PKG_RELEASE:=1
+ 
+PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>
+PKG_LICENSE:=GPL-3.0-only
+
+PKG_SOURCE:=supervisor-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/Supervisor/supervisor/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=skip
+
+PYTHON3_PKG_WHEEL_NAME=supervisor
+
+include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+ 
+define Package/supervisor
+	SECTION:=base
+	CATEGORY:=NethSecurity
+	TITLE:=Supervisor
+	URL:=https://github.com/Supervisor/supervisor
+	DEPENDS:=+python3-setuptools
+	PKGARCH:=all
+endef
+ 
+define Package/supervisor/description
+    Supervisor is a client/server system that allows its users to control a number of processes on UNIX-like operating systems.
+endef
+
+$(eval $(call Py3Package,supervisor))
+$(eval $(call BuildPackage,supervisor))
+$(eval $(call BuildPackage,supervisor-src))

--- a/packages/supervisor/README.md
+++ b/packages/supervisor/README.md
@@ -1,0 +1,5 @@
+# supervisor
+
+OpenWrt package of [supervisor](https://github.com/Supervisor/supervisor).
+
+See also [http://supervisord.org/](http://supervisord.org/).


### PR DESCRIPTION
Add supervisor package to be used as supervisor for important services like nethsecurity-api and dpi-report.

To make it work correctly we need to change many things:
- disable ns-api-server and dpi-report init.d
- add a new init.d for supervisor

/etc/init.d/supervisord (the stop action does still not work):
```bash
#!/bin/sh /etc/rc.common
START=95
USE_PROCD=0
PROG=/usr/bin/supervisord
DAEMON=${PROG}
# Location of the pid file
PIDFILE=/var/run/supervisord.pid
# Config of supervisor
CONFIG=/etc/supervisord/supervisord.conf

start_service()
{
    exec /usr/bin/supervisord -c $CONFIG -j $PIDFILE
}

stop_service()
{
    kill $(cat $PIDFILE)
}
```

/usr/sbin/ns-api-server
```bash
#!/bin/sh
WORK_DIR=/var/run/ns-api-server
TOKENS_DIR=${WORK_DIR}/tokens
SECRETS_DIR=/etc/ns-api-server
UPLOAD_FILE_PATH=${WORK_DIR}/uploads
UPLOAD_FILE_MAX_SIZE=64 # 64MB
mkdir -m 0700 -p ${TOKENS_DIR}
mkdir -m 0700 -p ${SECRETS_DIR}
export GIN_MODE=release
export LISTEN_ADDRESS=127.0.0.1:8090
export SECRET_JWT="$(uuidgen | sha256sum | awk '{print $1}')"
export ISSUER_2FA="$(uci -q get system.@system[0].hostname)"
export SECRETS_DIR=${SECRETS_DIR}
export TOKENS_DIR=${TOKENS_DIR}
export STATIC_DIR=${STATIC_DIR}
export UPLOAD_FILE_PATH=${UPLOAD_FILE_PATH}
export UPLOAD_FILE_MAX_SIZE=${UPLOAD_FILE_MAX_SIZE}
exec /usr/bin/nethsecurity-api
```

Config file with includes `/etc/supervisord/supervisord.conf `:
```
[supervisord]
logfile=/var/log/supervisord.log
pidfile=/var/run/supervisord.pid
user=root

[include]
files=/etc/supervisord/conf.d/*.conf
```

dpi-report: `/etc/supervisord/conf.d/dpi-report.conf`
```
[program:dpi-report]
command=/usr/bin/dpireport
redirect_stderr=true
```

api-server: `/etc/supervisord/conf.d/ns-api-server.conf ` (audit is not logged to messages) 
```
[program:ns-api-server]
command=/usr/sbin/ns-api-server
stderr_syslog=true
stdout_syslog=true
```

