### PR TITLE
ns-api: threatshield, set ban_nftexpiry and ban_logcount

### DIFF
--- a/packages/ns-api/files/ns.threatshield
+++ b/packages/ns-api/files/ns.threatshield
@@ -150,12 +150,21 @@ def edit_blocklist(e_uci, payload):
     e_uci.save('banip')
     return {'message': 'success'}
 
+def set_default(e_uci, option, value):
+    try:
+        e_uci.get('banip', 'global', option)
+    pass:
+        e_uci.set('banip', 'global', option, value)
+
+
 def edit_settings(e_uci, payload):
     if payload['enabled']:
         e_uci.set('banip', 'global', 'ban_enabled', '1')
-        e_uci.set('banip', 'global', 'ban_fetchcmd', 'curl')
-        e_uci.set('banip', 'global', 'ban_protov4', '1')
-        e_uci.set('banip', 'global', 'ban_protov6', '1')
+        set_default('ban_fetchcmd', 'curl')
+        set_default('ban_protov4', '1')
+        set_default('ban_protov6', '1')
+        set_default('ban_nftexpiry', '30m')
+        set_default('ban_logcount', '3')
     else:
         e_uci.set('banip', 'global', 'ban_enabled', '0')
     e_uci.save('banip')


### PR DESCRIPTION
Make sure to set ban_nftexpiry and ban_logcount to avoid banning indefinitely hosts with bad login attempts.