### PR TITLE
ns-phonehome: removing version from facts

### DIFF
--- a/packages/ns-phonehome/Makefile
+++ b/packages/ns-phonehome/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-phonehome
-PKG_VERSION:=0.0.5
+PKG_VERSION:=0.0.6
 PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-phonehome-$(PKG_VERSION)

--- a/packages/ns-phonehome/files/phonehome
+++ b/packages/ns-phonehome/files/phonehome
@@ -75,12 +75,10 @@ if not product:
     except:
         product = ""
 
-nethsec_version = ""
 version = ""
 with open('/etc/os-release', 'r') as file:
     for line in file:
         if line.startswith("VERSION_ID="):
-            nethsec_version = line.split('=')[1].split('-')[2][3:]
             version = line.split('=')[1].replace('"','').rstrip()
             break
 
@@ -114,7 +112,6 @@ data = {
             "system": { "used_bytes": _run("free | grep 'Mem': | awk '{print $3}'"), "available_bytes": _run("free | grep 'Mem:' | awk '{print $7}'") }
         },
         "pci": list(pci.values()),
-        "version": nethsec_version,
         "features": features
     }
 }


### PR DESCRIPTION
~~Opened now the latest version, it appears that the version is uncorrectly stripped out of endline and quotes (from /etc/os-release)~~

~~This fix works with both latest versions and testing ones~~

Removed version definition in facts, for Nethsecurity expecting to use version inside distro object. 