### PR TITLE
ns-api: ovpnrw, better handle cert expirtation

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -145,9 +145,12 @@ def list_user_expirations(openvpninstance):
 
 def get_cert_expiration(instance, user):
     # used for migrated certificates not present inside the index
-    p = subprocess.run(f"openssl x509 -enddate -noout -in /etc/openvpn/{instance}/pki/issued/{user}.crt | sed 's/notAfter=//'", shell=True, capture_output=True, text=True)
-    dt = datetime.strptime(p.stdout.strip(), "%b %d %H:%M:%S %Y %Z")
-    return dt.timestamp()
+    p = subprocess.run(f"openssl x509 -enddate -noout -in '/etc/openvpn/{instance}/pki/issued/{user}.crt' | sed 's/notAfter=//'", shell=True, capture_output=True, text=True)
+    try:
+       dt = datetime.strptime(p.stdout.strip(), "%b %d %H:%M:%S %Y %Z")
+       return dt.timestamp()
+    except:
+        return 0
 
 def generate_2fa_secret():
     return pyotp.random_base32()


### PR DESCRIPTION
Avoid error if the date is invalid or the certificate file name contains spaces

#553 