### PR TITLE
ipsec: fix wan interface retrieval

### DIFF
--- a/packages/ns-api/files/ns.ipsectunnel
+++ b/packages/ns-api/files/ns.ipsectunnel
@@ -20,14 +20,21 @@ from nethsec import utils, firewall, ipsec, ovpn
 def get_wan_by_ip(u, ipaddr):
     device = None
     ip_map = utils.get_all_device_ips()
+    try:
+        fallback = get_all_wan_devices(u, True)[0] # fallback to first wan
+    except:
+        fallback = 'wan'
     for d in ip_map:
         if ipaddr in ip_map[d]:
             device = d
     if device:
-        return utils.get_interface_from_device(u, device)
+        ret = utils.get_interface_from_device(u, device)
+        if ret:
+            return ret
+        else:
+            return fallback
     else:
-        # Fallback to general wan
-        return 'wan'
+        return fallback
 
 def next_id():
     max_id = 0

--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=python3-nethsec
-PKG_VERSION:=0.0.56
+PKG_VERSION:=0.0.57
 PKG_RELEASE:=1
  
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>


### PR DESCRIPTION
Make sure at least a wan is returned.
Before this commit, the function could also return a None value. In that case, the IPsec tunnel can connects but the traffic does not flow because there is no ipsecX interface.

#571 