### PR TITLE
Fix validation error in ns-api code

### DIFF
--- a/packages/ns-api/files/ns.backup
+++ b/packages/ns-api/files/ns.backup
@@ -129,7 +129,7 @@ elif cmd == 'call':
             # reboot takes a few seconds to complete, enough to send the response
             print(json.dumps({'message': 'success'}))
         except RuntimeError as error:
-            print(json.dumps(utils.generic_error(error.args[0])))
+            print(json.dumps(utils.validation_error('passphrase',error.args[0])))
 
     elif action == 'set-passphrase':
         try:


### PR DESCRIPTION
This pull request fixes the validation message to  `passphrase`. This PR updates the code to correctly handle the validation and provides a more informative error message inside the UI

REFs:
- https://github.com/NethServer/nethsecurity-ui/pull/295
- #587 