### PR TITLE
core: fix ns-download due to current subscription changes

### DIFF
--- a/files/usr/bin/ns-download
+++ b/files/usr/bin/ns-download
@@ -10,7 +10,6 @@
 
 . /etc/os-release
 DL_DIR=/tmp/download
-BASE_URL="https://updates.nethsecurity.nethserver.org"
 ARCH=$(echo "$OPENWRT_BOARD" | tr '/' '-')
 
 # Cleanup on kill
@@ -43,26 +42,47 @@ if [ "$force" -eq 1 ]; then
     rm -rf "$DL_DIR" &> /dev/null   
 fi
 
-# Extract channel from nethsecurity_core repository url
-url=$(cat /etc/opkg/distfeeds.conf | grep nethsecurity_core | awk '{print $3}')
-path=${url#"$BASE_URL"}
-channel=$(echo $path | cut -d"/" -f2)
+base_url="$(uci -q get ns-plug.config.repository_url)"
 
-# Set version to download
-if [ "$latest" -eq 1 ]; then
-    version=$(curl -L -s -m 10 $BASE_URL/$channel/latest_release)
-    if [ -z "$version" ]; then
-        exit 1
+# If subscription is active
+if [ "$(uci -q get ns-plug.config.system_id)" ]; then
+    if [ "$latest" -eq 1 ]; then
+        version=$(curl -L -s -m 10 $base_url/latest_release)
+        if [ -z "$version" ]; then
+            exit 1
+        fi
+    else
+        version=$VERSION
     fi
-else
-    version=$VERSION
-fi
+    openwrt_version=$(echo $version | cut -d'-' -f2)
 
-hash="$DL_DIR/sha256"
-img_name="nethsecurity-$version-$ARCH-generic-squashfs-combined-efi.img.gz"
-img="$DL_DIR/$img_name"
-img_url="$BASE_URL/$channel/$version/targets/$OPENWRT_BOARD/$img_name"
-hash_url="$BASE_URL/$channel/$version/targets/$OPENWRT_BOARD/sha256sums"
+    hash="$DL_DIR/sha256"
+    img_name="nethsecurity-$version-$ARCH-generic-squashfs-combined-efi.img.gz"
+    img="$DL_DIR/$img_name"
+    img_url="$base_url/$openwrt_version/targets/$OPENWRT_BOARD/$img_name"
+    hash_url="$base_url/$openwrt_version/targets/$OPENWRT_BOARD/sha256sums"
+else
+    # Extract channel from nethsecurity_core repository url
+    url=$(cat /etc/opkg/distfeeds.conf | grep nethsecurity_core | awk '{print $3}')
+    path=${url#"$base_url"}
+    channel=$(echo $path | cut -d"/" -f2)
+
+    # Set version to download
+    if [ "$latest" -eq 1 ]; then
+        version=$(curl -L -s -m 10 $base_url/$channel/latest_release)
+        if [ -z "$version" ]; then
+            exit 1
+        fi
+    else
+        version=$VERSION
+    fi
+
+    hash="$DL_DIR/sha256"
+    img_name="nethsecurity-$version-$ARCH-generic-squashfs-combined-efi.img.gz"
+    img="$DL_DIR/$img_name"
+    img_url="$base_url/$channel/$version/targets/$OPENWRT_BOARD/$img_name"
+    hash_url="$base_url/$channel/$version/targets/$OPENWRT_BOARD/sha256sums"
+fi
 
 # Download if image does not exists
 if [ ! -d "$DL_DIR" ] || [ ! -f "$img" ] || [ ! -f "$hash" ]; then


### PR DESCRIPTION
Fixing issue where with subscription enabled wasn't possible to download the correct image (and hence updating the firewall completely)

Ref: #412 