### PR TITLE
Fix validation for enterprise in ns.backup

### DIFF
--- a/packages/ns-api/files/ns.backup
+++ b/packages/ns-api/files/ns.backup
@@ -177,7 +177,7 @@ elif cmd == 'call':
             subprocess.run(['/usr/sbin/remote-backup', 'download', data['file'], backup_path],
                            check=True, capture_output=True)
             # fetch completed successfully, restore system
-            restore_backup(backup_path, None)
+            restore_backup(backup_path, data.get('passphrase', None))
             # restore successful, restart the system
             subprocess.run(['/sbin/reboot'], check=True, capture_output=True)
             # reboot takes a few seconds to complete, enough to send the response

--- a/packages/ns-api/files/ns.backup
+++ b/packages/ns-api/files/ns.backup
@@ -50,9 +50,21 @@ def create_backup():
             raise RuntimeError('backup failed')
     return file_name
 
+def is_encrypted(file_path):
+    try:
+        # Run the 'file' command on the specified file
+        result = subprocess.run(['file', file_path], capture_output=True, text=True, check=True)
+        # Check if the output contains indications of PGP encryption
+        if "GPG" in result.stdout:
+            return True
+        else:
+            return False
+    except subprocess.CalledProcessError as e:
+        return False
+
 def restore_backup(archive, passphrase=None):
     try:
-        if passphrase is not None:
+        if is_encrypted(archive) and passphrase is not None:
             subprocess.run([
                 '/usr/bin/gpg',
                 '--decrypt',
@@ -63,7 +75,8 @@ def restore_backup(archive, passphrase=None):
                 archive
             ], check=True, capture_output=True)
             shutil.move(f'{archive}.decrypted', archive)
-
+        elif is_encrypted(archive) and passphrase is None:
+            raise RuntimeError('passphrase required')
         # run sysupgrade to restore backup file
         subprocess.run(['/sbin/sysupgrade', '-r', archive], check=True, capture_output=True)
 

--- a/packages/ns-api/files/ns.backup
+++ b/packages/ns-api/files/ns.backup
@@ -187,7 +187,7 @@ elif cmd == 'call':
         except KeyError as error:
             print(json.dumps(utils.validation_error('file', 'required')))
         except RuntimeError as error:
-            print(json.dumps(utils.generic_error(error.args[0])))
+            print(json.dumps(utils.validation_error('passphrase',error.args[0])))
 
     elif action == 'registered-download-backup':
         os.makedirs(DOWNLOAD_PATH, exist_ok=True)


### PR DESCRIPTION
This pull request fixes a validation issue in the `ns.backup` file for the enterprise feature. 

This pull request fixes also the usage of passphrase with the stored backup, previously it was `None` 

now in case of restore we handle three errors

- wrong backup type
- encrypted archive but missing passphrase : `error.backup_passphrase_passphrase_required`
- encrypted archive but wrong passphrase

translation must be added

https://github.com/NethServer/nethsecurity/issues/587