### PR TITLE
Fix validation error in registered-restore

### DIFF
--- a/packages/ns-api/files/ns.backup
+++ b/packages/ns-api/files/ns.backup
@@ -187,7 +187,7 @@ elif cmd == 'call':
         except KeyError as error:
             print(json.dumps(utils.validation_error('file', 'required')))
         except RuntimeError as error:
-            print(json.dumps(utils.generic_error(error.args[0])))
+            print(json.dumps(utils.validation_error('passphrase',error.args[0])))
 
     elif action == 'registered-download-backup':
         os.makedirs(DOWNLOAD_PATH, exist_ok=True)


### PR DESCRIPTION
This pull request fixes a validation error in the `registered-restore` function of the `ns.backup` file.

The error occurred when a passphrase was not provided. The fix updates the error message to specifically indicate that a passphrase is required.

#587 