### PR TITLE
fix: removing scheduled update once ran

### DIFF
--- a/files/etc/uci-defaults/99-nethsec-remove-scheduled-upgrade
+++ b/files/etc/uci-defaults/99-nethsec-remove-scheduled-upgrade
@@ -1,0 +1,1 @@
+/usr/libexec/ns-api/schedule-system-update remove


### PR DESCRIPTION
Removing the scheduled update once ran, removing the cron from the system.

Ref:
- https://github.com/NethServer/nethsecurity/issues/610 
