### PR TITLE
ns-threat_shield: add community lists

### DIFF
--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -5501,7 +5501,7 @@ Response example:
 
 ## ns.threatshield
 
-Manage banip configuration.
+Manage banip and adguard configuration.
 
 ### list-blocklist
 
@@ -5637,6 +5637,161 @@ Response example:
 
 It can raise the following validation errors:
 - `address_not_found` if the address is not inside the allow list
+
+### dns-list-blocklist
+
+List current dns blocklist:
+```
+api-cli ns.threatshield dns-list-blocklist
+```
+
+Response example:
+```json
+{
+  "data": [
+    {
+      "name": "malware_lvl2",
+      "type": "community",
+      "enabled": true,
+      "confidence": 8,
+      "description": "Threat Intelligence Feed"
+    },
+    {
+      "name": "yoroi_malware_level1",
+      "type": "enterprise",
+      "enabled": false,
+      "confidence": -1,
+      "description": "malware"
+    }
+  ]
+}
+```
+
+### dns-edit-blocklist
+
+Enable or disable a dns blocklist:
+```
+api-cli ns.threatshield dns-edit-blocklist --data '{ "blocklist": "blocklist_name", "enabled": True }'
+```
+
+Response example:
+```json
+{"message": "success"}
+``` 
+
+### dns-list-settings
+
+Show current dns adblock settings:
+```
+api-cli ns.threatshield dns-list-settings
+```
+
+Response example:
+```json
+{"data": {"enabled": true, "zones": ["lan"]}}
+```
+
+### dns-edit-settings
+
+Edit dns adblock settings:
+```
+api-cli ns.threatshield dns-edit-settings --data '{"enabled": true, "zones": ["lan"]}'
+```
+
+Response example:
+```json
+{"message": "success"}
+```
+
+## dns-list-allowed
+
+List domains always allowed:
+```
+api-cli ns.threatshield dns-list-allowed
+```
+
+Response example:
+```json
+{
+  "data": [
+    {
+      "address": "nethesis.it"
+    }
+  ]
+}
+```
+
+### dns-add-allowed
+
+Add a domain which is always allowed:
+```
+api-cli ns.threatshield dns-add-allowed --data '{"address": "nethesis.it", "description": "my allow1"}'
+```
+
+Response example:
+```json
+{"message": "success"}
+```
+
+### dns-edit-allowed
+
+Change the description of an address already insie the allow list:
+```
+api-cli ns.threatshield dns-edit-allowed --data '{"address": "nethesis.it", "description": "my new desc"}'
+```
+
+Response example:
+```json
+{"message": "success"}
+```
+
+### dns-delete-allowed
+
+Delete an address from the allow list:
+```
+api-cli ns.threatshield dns-delete-allowed --data '{"address": "nethesis.it"}'
+```
+
+Response example:
+```json
+{"message": "success"}
+```
+
+### dns-list-bypass
+
+List hosts that can bypass the adblock DNS redirect:
+```
+api-cli ns.threatshield dns-list-bypass
+```
+
+Response example:
+```json
+{"data": ["192.168.1.22"]}
+```
+
+### dns-add-bypass
+
+Add a host that can bypass the adblock DNS redirect:
+```
+api-cli ns.threatshield dns-add-bypass --data '{"address": "192.168.1.22"}'
+```
+
+Response example:
+```json
+{"message": "success"}
+```
+
+### dns-delete-bypass
+
+Delete a host that can bypass the adblock DNS redirect:
+```
+api-cli ns.threatshield dns-delete-bypass --data '{"address": "192.168.1.22"}'
+```
+
+Response example:
+```json
+{"message": "success"}
+```
 
 ## ns.qos
 

--- a/packages/ns-api/files/ns.threatshield
+++ b/packages/ns-api/files/ns.threatshield
@@ -72,10 +72,10 @@ def list_feeds():
         with open('/etc/banip/banip.feeds') as f:
             return json.loads(f.read())
 
-def get_allow_list():
+def get_allow_list(file='/etc/banip/banip.allowlist'):
     ret = []
     try:
-        with open('/etc/banip/banip.allowlist') as f:
+        with open(file) as f:
             for line in f:
                 line = line.strip()
                 if not line:
@@ -89,14 +89,23 @@ def get_allow_list():
         return []
     return ret
 
-def write_allow_list(allow_list):
-    with open('/etc/banip/banip.allowlist', 'w') as f:
+def write_allow_list(allow_list, file='/etc/banip/banip.allowlist'):
+    with open(file, 'w') as f:
         for x in allow_list:
             f.write(x['address'])
             if x['description']:
                 f.write(' #' + x['description'])
             f.write('\n')
     subprocess.run(["/etc/init.d/banip", "reload"], capture_output=True)
+
+def list_dns_feeds():
+    # Decompress and read the JSON file /etc/adblock/combined.sources.gz
+    sources = '/etc/adblock/combined.sources.gz'
+    if os.path.exists(sources) and os.path.getsize(sources) > 0:
+        data = subprocess.run(["gunzip", "-c", sources], capture_output=True).stdout
+        return json.loads(data)
+    else:
+        return {}
 
 ## APIs
 
@@ -116,11 +125,13 @@ def list_blocklist(e_uci):
             confidence = 8
         elif f.endswith('lvl3'):
             confidence = 6
+        elif f.endswith('lvl4'):
+            confidence = 5
         else:
             confidence = -1
         enabled = f in enabled_feeds
 
-        if 'bl.nethesis.it' in feed['url_4']:
+        if 'nethesis-blacklists' in feed.get('url_4'):
             type = 'enterprise'
         else:
             type = 'community'
@@ -204,18 +215,168 @@ def edit_allowed(payload):
     write_allow_list(cur)
     return {'message': 'success'}
 
+def dns_list_blocklist(e_uci):
+    ret = []
+    feeds = list_dns_feeds()
+    has_bl = has_bl_entitlement(e_uci)
+    try:
+        enabled_feeds = list(e_uci.get_all('adblock', 'global', 'adb_sources'))
+    except:
+        enabled_feeds = []
+    for f in feeds:
+        feed = feeds[f]
+        if f.endswith('lvl1'):
+            confidence = 10
+        elif f.endswith('lvl2'):
+            confidence = 8
+        elif f.endswith('lvl3'):
+            confidence = 6
+        else:
+            confidence = -1
+        enabled = f in enabled_feeds
+
+        if 'nethesis-blacklists' in feed.get('url'):
+            type = 'enterprise'
+        else:
+            type = 'community'
+
+        # list enabled enterprise lists, even if there is no Internet connection
+        if not enabled:
+            if type == 'enterprise' and not has_bl:
+                continue
+
+        ret.append({ 'name': f, 'type': type, 'enabled': enabled, 'confidence': confidence, 'description': feed.get('focus')})
+    return { "data": ret }
+
+def dns_edit_blocklist(e_uci, payload):
+    feeds = list_dns_feeds()
+    try:
+        enabled = list(e_uci.get_all('adblock', 'global', 'adb_sources'))
+    except:
+        enabled = []
+    if payload['enabled'] and payload['blocklist'] not in enabled:
+        enabled.append(payload['blocklist'])
+    if not payload['enabled'] and payload['blocklist'] in enabled:
+        enabled.remove(payload['blocklist'])
+    e_uci.set('adblock', 'global', 'adb_sources', enabled)
+    e_uci.save('adblock')
+    return {'message': 'success'}
+
+def dns_list_settings(e_uci):
+    try:
+        zones = list(e_uci.get('adblock', 'global', 'adb_zonelist'))
+    except:
+        zones = []
+    return { 'data': {'enabled': e_uci.get('adblock', 'global', 'ts_enabled') == '1', "zones": zones} }
+
+def dns_edit_settings(e_uci, payload):
+    if payload['enabled']:
+        e_uci.set('adblock', 'global', 'ts_enabled', '1')
+        e_uci.set('adblock', 'global', 'adb_enabled', '1')
+        e_uci.set('adblock', 'global', 'adb_backup', '1')
+        e_uci.set('adblock', 'global', 'adb_forcedns', '1')
+        e_uci.set('adblock', 'global', 'adb_zonelist', payload.get('zones', ['lan']))
+        try:
+            e_uci.get('adblock', 'global', 'adb_portlist')
+        except:
+            e_uci.set('adblock', 'global', 'adb_portlist', ['53', '853'])
+    else:
+        e_uci.set('adblock', 'global', 'ts_enabled', '0')
+        e_uci.set('adblock', 'global', 'adb_enabled', '0')
+        e_uci.set('adblock', 'global', 'adb_forcedns', '0')
+    e_uci.save('adblock')
+    return {'message': 'success'}
+
+def dns_list_allowed():
+    return { "data": get_allow_list('/etc/adblock/adblock.whitelist') }
+
+def dns_add_allowed(payload):
+    cur = get_allow_list('/etc/adblock/adblock.whitelist')
+    # extract address from cur list
+    if payload['address'] in [x['address'] for x in cur]:
+        raise ValidationError('address', 'address_already_present', payload['address'])
+    cur.append({ "address": payload['address'], "description": payload['description'] })
+    write_allow_list(cur, '/etc/adblock/adblock.whitelist')
+    return {'message': 'success'}
+
+def dns_edit_allowed(payload):
+    cur = get_allow_list('/etc/adblock/adblock.whitelist')
+    if payload['address'] not in [x['address'] for x in cur]:
+        raise ValidationError('address', 'address_not_found', payload['address'])
+    for i in range(len(cur)):
+        if cur[i]['address'] == payload['address']:
+            cur[i]['description'] = payload['description']
+            break
+    write_allow_list(cur, '/etc/adblock/adblock.whitelist')
+    return {'message': 'success'}
+
+def dns_delete_allowed(payload):
+    cur = get_allow_list('/etc/adblock/adblock.whitelist')
+    if payload['address'] not in [x['address'] for x in cur]:
+        raise ValidationError('address', 'address_not_found', payload['address'])
+    # remove address from cur list
+    for i in range(len(cur)):
+        if cur[i]['address'] == payload['address']:
+            del cur[i]
+            break
+    write_allow_list(cur, '/etc/adblock/adblock.whitelist')
+    return {'message': 'success'}
+
+def dns_list_bypass(e_uci):
+    # adblock.global.adb_bypass
+    try:
+        bypass = e_uci.get_all('adblock', 'global', 'adb_bypass')
+    except:
+        bypass = []
+    return { "data": bypass }
+
+def dns_add_bypass(e_uci, payload):
+    try:
+        bypass = list(e_uci.get_all('adblock', 'global', 'adb_bypass'))
+    except:
+        bypass = []
+    if payload['address'] in bypass:
+        raise ValidationError('address', 'address_already_present', payload['address'])
+    bypass.append(payload['address'])
+    e_uci.set('adblock', 'global', 'adb_bypass', bypass)
+    e_uci.save('adblock')
+    return {'message': 'success'}
+
+def dns_delete_bypass(e_uci, payload):
+    try:
+        bypass = list(e_uci.get_all('adblock', 'global', 'adb_bypass'))
+    except:
+        bypass = []
+    if payload['address'] not in bypass:
+        raise ValidationError('address', 'address_not_found', payload['address'])
+    bypass.remove(payload['address'])
+    e_uci.set('adblock', 'global', 'adb_bypass', bypass)
+    e_uci.save('adblock')
+    return {'message': 'success'}
+
 cmd = sys.argv[1]
 
 if cmd == 'list':
     print(json.dumps({
         'list-blocklist': {},
         'edit-blocklist': { "blocklist": "blocklist_name", "enabled": True },
-        'list-settings': { 'data': { 'enabled': True } },
+        'list-settings': {},
         'edit-settings': { 'enabled': True },
         'list-allowed': {},
         'add-allowed': { 'address': '1.2.3.4', 'description': 'optional' },
         'edit-allowed': { 'address': '1.2.3.4', 'description': 'optional' },
-        'delete-allowed': { 'address': '1.2.3.4' }
+        'delete-allowed': { 'address': '1.2.3.4' },
+        'dns-list-blocklist': {},
+        'dns-edit-blocklist': { "blocklist": "blocklist_name", "enabled": True },
+        'dns-list-settings': {},
+        'dns-edit-settings': { 'enabled': True, 'zones': ["lan"] },
+        'dns-list-allowed': {},
+        'dns-add-allowed': { 'address': 'test.org' , 'description': 'optional'},
+        'dns-edit-allowed': { 'address': 'test.org', 'description': 'optional' },
+        'dns-delete-allowed' : { 'address': 'test.org' },
+        'dns-list-bypass': {},
+        'dns-add-bypass': { 'address': '1.2.3.4' },
+        'dns-delete-bypass': { 'address': '1.2.3.4' }
     }))
 elif cmd == 'call':
     action = sys.argv[2]
@@ -242,6 +403,36 @@ elif cmd == 'call':
         elif action == 'delete-allowed':
             payload = json.loads(sys.stdin.read())
             ret = delete_allowed(payload)
+
+        if action == 'dns-list-blocklist':
+            ret = dns_list_blocklist(e_uci)
+        elif action == 'dns-edit-blocklist':
+            payload = json.loads(sys.stdin.read())
+            ret = dns_edit_blocklist(e_uci, payload)
+        elif action == 'dns-list-settings':
+            ret = dns_list_settings(e_uci)
+        elif action == 'dns-edit-settings':
+            payload = json.loads(sys.stdin.read())
+            ret = dns_edit_settings(e_uci, payload)
+        elif action == 'dns-add-allowed':
+            payload = json.loads(sys.stdin.read())
+            ret = dns_add_allowed(payload)
+        elif action == 'dns-edit-allowed':
+            payload = json.loads(sys.stdin.read())
+            ret = dns_edit_allowed(payload)
+        elif action == 'dns-list-allowed':
+            ret = dns_list_allowed()
+        elif action == 'dns-delete-allowed':
+            payload = json.loads(sys.stdin.read())
+            ret = dns_delete_allowed(payload)
+        elif action == 'dns-list-bypass':
+            ret = dns_list_bypass(e_uci)
+        elif action == 'dns-add-bypass':
+            payload = json.loads(sys.stdin.read())
+            ret = dns_add_bypass(e_uci, payload)
+        elif action == 'dns-delete-bypass':
+            payload = json.loads(sys.stdin.read())
+            ret = dns_delete_bypass(e_uci, payload)
 
         print(json.dumps(ret))
     except ValidationError as ex:

--- a/packages/ns-threat_shield/Makefile
+++ b/packages/ns-threat_shield/Makefile
@@ -51,10 +51,12 @@ define Package/ns-threat_shield/install
 	$(LN) /usr/sbin/ts-ip $(1)/usr/share/ns-plug/hooks/unregister/80ts-ip
 	$(INSTALL_DIR) $(1)/usr/share/threat_shield
 	$(INSTALL_DATA) ./files/nethesis-dns.sources $(1)/usr/share/threat_shield
+	$(INSTALL_DATA) ./files/community-dns.sources $(1)/usr/share/threat_shield
 	$(INSTALL_DATA) ./files/banip.nethesis.feeds $(1)/etc/banip
 	$(INSTALL_BIN) ./files/adjust-banip.py $(1)/usr/libexec/ns-api/post-commit/
 	$(INSTALL_BIN) ./files/configure-banip-wans.py $(1)/usr/libexec/ns-api/pre-commit/
 	gzip -9n $(1)/usr/share/threat_shield/nethesis-dns.sources
+	gzip -9n $(1)/usr/share/threat_shield/community-dns.sources
 endef
 
 define Package/ns-threat_shield/postinst

--- a/packages/ns-threat_shield/README.md
+++ b/packages/ns-threat_shield/README.md
@@ -24,7 +24,7 @@ The following categories require a valid entitlement:
 
 After machine registration, above categories will be automatically added to existing banip categories (`/etc/banip/banip.custom.feeds`).
 
-A special global allowist will also be added to banip (`ban_allowurl` option).
+A special global allowlist will also be added to banip (`ban_allowurl` option).
 
 ### Examples
 
@@ -50,45 +50,48 @@ ts-ip
 ## ts-dns
 
 Threat shield DNS (`ts-dns`) is a special configuration for [adblock](https://github.com/openwrt/packages/tree/master/net/adblock).
-If `adblock` is enabled and the machine has a valid subscription, the following extra block categories will be available:
-
-- `yoroi_malware_level1`
-- `yoroi_malware_level2`
-- `yoroi_susp_level1` (was `yoroi_suspicious_level1` on NS7)
-- `yoroi_susp_level2` (was `yoroi_suspicious_level2` on NS7)
+The `ts-dns` is invoked every time adblock is started or reloaded.
 
 The package adds a new option to `adblock`:
 
-- `ts_enabled`: if set to `1`, it enables the download of threat shield DNS categories
+- `ts_enabled`: if set to `1`, it enables the download of enterprise categories and community free categories.
 
-Extra categories are loaded from `/usr/share/threat_shield/nethesis-dns.sources.gz` and require a valid entitlement.
+If `ts_enabled` is set to 1:
+
+- a new category source file is generated according to the machine registration and the entitlement
+- all DNS queries are redirected to the local machine
+- adblock is configured to use the new category source file and will be started
+
+As default a machine has access to all community free categories, that are listed at `/usr/share/threat_shield/community-dns.sources.gz`.
+If the machine has a subscription and a valid entitlement for nethesis-blacklists, the machine will have access to the enterprise categories, 
+that are listed at `/usr/share/threat_shield/nethesis-dns.sources.gz`.
+
 DNS block categories will be automatically reloaded every 12 hours.
 
-Enable adblock with threat shield categories, example:
+Enable adblock with all available categories, example:
 ```
-uci set adblock.global.ts_enabled=1
-uci set adblock.global.adb_enabled=1
-uci add_list adblock.global.adb_sources=yoroi_malware_level1
-uci add_list adblock.global.adb_sources=yoroi_malware_level2
-uci add_list adblock.global.adb_sources=yoroi_susp_level1
-uci add_list adblock.global.adb_sources=yoroi_susp_level2
-uci commit adblock
-/etc/init.d/adblock start
+echo '{"enabled": true, "zones": ["lan"]}' | /usr/libexec/rpcd/ns.threatshield call dns-edit-settings
+uci commit adblock && service adblock restart
 ```
 
 Keep adblock enabled but disable threat shield categories:
 ```
+echo '{"enabled": false, "zones": ["lan"]}' | /usr/libexec/rpcd/ns.threatshield call dns-edit-settings
 uci set adblock.global.ts_enabled=0
 uci commit adblock
-/etc/init.d/adblock reload
+/etc/init.d/adblock restart
 ```
+
+### Custom categories
+
+To add custom categories, create a file `/etc/adblock/custom.sources.gz` with the list of categories to block.
+If such file is present, the `/usr/share/threat_shield/community-dns.sources.gz` will be ignored.
+
+### DNS redirect bypass
 
 Allow bypass of DNS redirect for a specific source IP:
 ```
-uci set adblock.global.adb_forcedns=1
 uci add_list adblock.global.adb_bypass=192.168.100.2
-uci add_list adblock.global.adb_zonelist=lan
-uci add_list adblock.global.adb_portlist=53
 uci commit adblock
 /etc/init.d/adblock restart
 ```

--- a/packages/ns-threat_shield/files/community-dns.sources
+++ b/packages/ns-threat_shield/files/community-dns.sources
@@ -1,0 +1,58 @@
+{
+	"malware_lvl2": {
+		"url": "https://bl.nethesis.it/plain/community/free/malware_lvl2.dns",
+		"rule": "/^[^#]/ { print }",
+		"size": "XXL",
+		"focus": "Threat Intelligence Feed",
+		"descurl": "www.nethesis.it"
+	},
+	"malware_privacy_lvl2": {
+		"url": "https://bl.nethesis.it/plain/community/free/malware_privacy_lvl2.dns",
+		"rule": "/^[^#]/ { print }",
+		"size": "XXL",
+		"focus": "Multi Light: malware & privacy",
+		"descurl": "www.nethesis.it"
+	},
+	"malware_privacy_lvl3": {
+		"url": "https://bl.nethesis.it/plain/community/free/malware_privacy_lvl3.dns",
+		"rule": "/^[^#]/ { print }",
+		"size": "XXL",
+		"focus": "Multi Normal: malware and privacy",
+		"descurl": "www.nethesis.it"
+	},
+	"malware_privacy_lvl4": {
+		"url": "https://bl.nethesis.it/plain/community/free/malware_privacy_lvl4.dns",
+		"rule": "/^[^#]/ { print }",
+		"size": "XXL",
+		"focus": "Multi Pro: malware and privacy",
+		"descurl": "www.nethesis.it"
+	},
+	"adult": {
+		"url": "https://bl.nethesis.it/plain/community/free/adult.dns",
+		"rule": "/^[^#]/ { print }",
+		"size": "XXL",
+		"focus": "Adult",
+		"descurl": "www.nethesis.it"
+	},
+	"doh_vpn_tor_proxy": {
+		"url": "https://bl.nethesis.it/plain/community/free/doh_vpn_tor_proxy.dns",
+		"rule": "/^[^#]/ { print }",
+		"size": "XXL",
+		"focus": "Prevent DNS bypass",
+		"descurl": "www.nethesis.it"
+	},
+	"gambling": {
+		"url": "https://bl.nethesis.it/plain/community/free/gambling.dns",
+		"rule": "/^[^#]/ { print }",
+		"size": "XXL",
+		"focus": "Gambling",
+		"descurl": "www.nethesis.it"
+	},
+	"piracy": {
+		"url": "https://bl.nethesis.it/plain/community/free/piracy.dns",
+		"rule": "/^[^#]/ { print }",
+		"size": "XXL",
+		"focus": "Piracy",
+		"descurl": "www.nethesis.it"
+	}
+}

--- a/packages/ns-threat_shield/files/nethesis-dns.sources
+++ b/packages/ns-threat_shield/files/nethesis-dns.sources
@@ -1,27 +1,27 @@
 {
         "yoroi_malware_level1": {
-                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_malware_level1.dns",
+                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_malware_level1.dns",
                 "rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
                 "size": "XL",
                 "focus": "malware",
                 "descurl": "https://www.nethesis.it"
         },
         "yoroi_malware_level2": {
-                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_malware_level2.dns",
+                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_malware_level2.dns",
                 "rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
                 "size": "XL",
                 "focus": "malware",
                 "descurl": "https://www.nethesis.it"
         },
         "yoroi_susp_level1": {
-                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_suspicious_level1.dns",
+                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_suspicious_level1.dns",
                 "rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
                 "size": "XL",
                 "focus": "malware",
                 "descurl": "https://www.nethesis.it"
         },
         "yoroi_susp_level2": {
-                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_suspicious_level2.dns",
+                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_suspicious_level2.dns",
                 "rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
                 "size": "XL",
                 "focus": "malware",

--- a/packages/ns-threat_shield/files/ts-dns
+++ b/packages/ns-threat_shield/files/ts-dns
@@ -7,18 +7,15 @@
 
 DEST_DIR=/etc/adblock
 NETHESIS_SOURCES=/usr/share/threat_shield/nethesis-dns.sources.gz
-ADBLOCK_SOURCES=/etc/adblock/adblock.sources.gz
+COMMUNITY_SOURCES=/usr/share/threat_shield/community-dns.sources.gz
+CUSTOM_SOURCES=/etc/adblock/custom.sources.gz
+TMP_FILE=/tmp/combined.sources
 
 SYSTEM_ID=$(uci -q get ns-plug.config.system_id)
 SYSTEM_SECRET=$(uci -q get ns-plug.config.secret)
 TS_ENABLED=$(uci -q get adblock.global.ts_enabled)
 
-if [ ! -z "$SYSTEM_SECRET" ] && [ ! -z "$SYSTEM_ID" ] && [ "$TS_ENABLED" = 1 ]; then
-    # Setup Nethesis sources if the machine has a subscription
-
-    # Explode sources, combine them in one object, replaces credentials and compress
-    gunzip -c $ADBLOCK_SOURCES $NETHESIS_SOURCES | jq -s '.[0]*.[1]' | sed -e "s/__USER__/$SYSTEM_ID/" -e "s/__PASSWORD__/$SYSTEM_SECRET/" | gzip > "$DEST_DIR"/combined.sources.gz
-
+if [ "$TS_ENABLED" = 1 ]; then
     # Setup new blacklist source
     uci set adblock.global.adb_srcarc="$DEST_DIR"/combined.sources.gz
 
@@ -30,8 +27,27 @@ if [ ! -z "$SYSTEM_SECRET" ] && [ ! -z "$SYSTEM_ID" ] && [ "$TS_ENABLED" = 1 ]; 
     uci set adblock.global.adb_fetchutil='wget'
     uci set adblock.global.adb_fetchparm="--compression=gzip --no-cache --no-cookies --max-redirect=0 --timeout=20 -O"
 
+    if [ -f $CUSTOM_SOURCES ]; then
+        # Add custom sources, if present
+        gunzip -c $CUSTOM_SOURCES > $TMP_FILE
+    else
+	# Use community sources
+        gunzip -c $COMMUNITY_SOURCES > $TMP_FILE
+    fi
+
+    # Setup Nethesis sources if the machine has a subscription
+    if [ ! -z "$SYSTEM_SECRET" ] && [ ! -z "$SYSTEM_ID" ]; then
+        # Replaces credentials and compress
+        gunzip -c $NETHESIS_SOURCES | sed -e "s/__USER__/$SYSTEM_ID/" -e "s/__PASSWORD__/$SYSTEM_SECRET/" >> $TMP_FILE
+    fi
+
+    # Merge the source list and compress it to the final file
+    jq -s 'reduce .[] as $item ({}; . * $item)' $TMP_FILE |  gzip -c > "$DEST_DIR"/combined.sources.gz
+
+    # Cleanup
+    rm -f $TMP_FILE
 else
-    # Reset sources to origin file if the machine has no subscription
+    # Reset sources to origin file if threat shield is not enabled
     uci -q delete adblock.global.adb_srcarc
     uci -q delete adblock.global.adb_fetchparam
     uci set adblock.global.adb_fetchutil='curl'

--- a/packages/ns-threat_shield/files/ts-dns
+++ b/packages/ns-threat_shield/files/ts-dns
@@ -13,6 +13,7 @@ TMP_FILE=/tmp/combined.sources
 
 SYSTEM_ID=$(uci -q get ns-plug.config.system_id)
 SYSTEM_SECRET=$(uci -q get ns-plug.config.secret)
+TYPE=$(uci -q get ns-plug.config.type)
 TS_ENABLED=$(uci -q get adblock.global.ts_enabled)
 
 if [ "$TS_ENABLED" = 1 ]; then
@@ -38,7 +39,7 @@ if [ "$TS_ENABLED" = 1 ]; then
     # Setup Nethesis sources if the machine has a subscription
     if [ ! -z "$SYSTEM_SECRET" ] && [ ! -z "$SYSTEM_ID" ]; then
         # Replaces credentials and compress
-        gunzip -c $NETHESIS_SOURCES | sed -e "s/__USER__/$SYSTEM_ID/" -e "s/__PASSWORD__/$SYSTEM_SECRET/" >> $TMP_FILE
+        gunzip -c $NETHESIS_SOURCES | sed -e "s/__USER__/$SYSTEM_ID/" -e "s/__PASSWORD__/$SYSTEM_SECRET/" -e "s/__TYPE__/$TYPE/" >> $TMP_FILE
     fi
 
     # Merge the source list and compress it to the final file


### PR DESCRIPTION
Improved threat shield implementation for community.

To better understand how threat shield DNS works, see [README](https://github.com/NethServer/nethsecurity/blob/021fa95ce170c804636d89608aa0f44b6df4c765/packages/ns-threat_shield/README.md#ts-dns)

APIs are suitable for a future implementation of the UI very similar to one already implemented for Threat Shield IP.

Issue #640 


See also: 
- https://github.com/NethServer/nethsecurity-docs/pull/100
- https://github.com/nethesis/blacklists/pull/23
