### PR TITLE
ns-threat_shield: use new enterprise download URL

### DIFF
--- a/packages/ns-threat_shield/files/nethesis-dns.sources
+++ b/packages/ns-threat_shield/files/nethesis-dns.sources
@@ -1,27 +1,27 @@
 {
         "yoroi_malware_level1": {
-                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_malware_level1.dns",
+                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_malware_level1.dns",
                 "rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
                 "size": "XL",
                 "focus": "malware",
                 "descurl": "https://www.nethesis.it"
         },
         "yoroi_malware_level2": {
-                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_malware_level2.dns",
+                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_malware_level2.dns",
                 "rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
                 "size": "XL",
                 "focus": "malware",
                 "descurl": "https://www.nethesis.it"
         },
         "yoroi_susp_level1": {
-                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_suspicious_level1.dns",
+                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_suspicious_level1.dns",
                 "rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
                 "size": "XL",
                 "focus": "malware",
                 "descurl": "https://www.nethesis.it"
         },
         "yoroi_susp_level2": {
-                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_suspicious_level2.dns",
+                "url": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_suspicious_level2.dns",
                 "rule": "/^([[:alnum:]_-]{1,63}\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
                 "size": "XL",
                 "focus": "malware",

--- a/packages/ns-threat_shield/files/ts-dns
+++ b/packages/ns-threat_shield/files/ts-dns
@@ -13,6 +13,7 @@ TMP_FILE=/tmp/combined.sources
 
 SYSTEM_ID=$(uci -q get ns-plug.config.system_id)
 SYSTEM_SECRET=$(uci -q get ns-plug.config.secret)
+TYPE=$(uci -q get ns-plug.config.type)
 TS_ENABLED=$(uci -q get adblock.global.ts_enabled)
 
 if [ "$TS_ENABLED" = 1 ]; then
@@ -38,7 +39,7 @@ if [ "$TS_ENABLED" = 1 ]; then
     # Setup Nethesis sources if the machine has a subscription
     if [ ! -z "$SYSTEM_SECRET" ] && [ ! -z "$SYSTEM_ID" ]; then
         # Replaces credentials and compress
-        gunzip -c $NETHESIS_SOURCES | sed -e "s/__USER__/$SYSTEM_ID/" -e "s/__PASSWORD__/$SYSTEM_SECRET/" >> $TMP_FILE
+        gunzip -c $NETHESIS_SOURCES | sed -e "s/__USER__/$SYSTEM_ID/" -e "s/__PASSWORD__/$SYSTEM_SECRET/" -e "s/__TYPE__/$TYPE/" >> $TMP_FILE
     fi
 
     # Merge the source list and compress it to the final file


### PR DESCRIPTION
A community subscription can now access enterprise blocklists if it has a valid entitlement for the service.

Remote validation now differs based on subscription type.