### PR TITLE
ns-threat_shield: IP, use new enterprise download URL

### DIFF
--- a/packages/ns-threat_shield/files/banip.nethesis.feeds
+++ b/packages/ns-threat_shield/files/banip.nethesis.feeds
@@ -1,26 +1,26 @@
 {
         "yoroimallvl1": {
-                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_malware_level1.ipset",
+                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_malware_level1.ipset",
                 "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Yoroi malware - Level 1"
         },
         "yoroimallvl2": {
-                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_malware_level2.ipset",
+                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_malware_level2.ipset",
                 "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Yoroi malware - Level 2"
         },
         "yoroisusplvl1": {
-                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_souspicious_level1.ipset",
+                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_souspicious_level1.ipset",
                 "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Yoroi suspicious - Level 1"
         },
         "yoroisusplvl2": {
-                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/yoroi_souspicious_level2.ipset",
+                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/yoroi_souspicious_level2.ipset",
                 "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Yoroi suspicious - Level 2"
         },
         "nethesislvl3": {
-                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/nethesis-blacklists/nethesis_level3.netset",
+                "url_4": "https://__USER__:__PASSWORD__@bl.nethesis.it/plain/__TYPE__/nethesis-blacklists/nethesis_level3.netset",
                 "rule_4": "/^(([0-9]{1,3}\\.){3}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
                 "descr": "Nethesis suspicious - Level 3"
         }

--- a/packages/ns-threat_shield/files/ts-ip
+++ b/packages/ns-threat_shield/files/ts-ip
@@ -28,12 +28,13 @@ function exit_error {
 
 SYSTEM_SECRET=$(uci -q get ns-plug.config.secret)
 SYSTEM_ID=$(uci -q get ns-plug.config.system_id)
+TYPE=$(uci -q get ns-plug.config.type)
 
 if [ ! -z "$SYSTEM_SECRET" ] && [ ! -z "$SYSTEM_ID" ]; then
     jq -s '.[0] * .[1]' /etc/banip/banip.nethesis.feeds /etc/banip/banip.feeds \
-	    | sed -e "s/__USER__/$SYSTEM_ID/" -e "s/__PASSWORD__/$SYSTEM_SECRET/" > /etc/banip/banip.custom.feeds
+	    | sed -e "s/__USER__/$SYSTEM_ID/" -e "s/__PASSWORD__/$SYSTEM_SECRET/" -e "s/__TYPE__/$TYPE/" > /etc/banip/banip.custom.feeds
     if ! uci -q get banip.global.ban_allowurl | grep -q bl.nethesis.it; then
-        uci add_list banip.global.ban_allowurl="https://$SYSTEM_ID:$SYSTEM_SECRET@bl.nethesis.it/plain/nethesis-blacklists/whitelist.global"
+        uci add_list banip.global.ban_allowurl="https://$SYSTEM_ID:$SYSTEM_SECRET@bl.nethesis.it/plain/$TYPE/nethesis-blacklists/whitelist.global"
         uci commit banip
     fi
 else


### PR DESCRIPTION
A community subscription can now access enterprise blocklists if it has a valid entitlement for the service.

Remote validation now differs based on subscription type.