### PR TITLE
python3-nethsec: bump to 0.0.70

### DIFF
--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=python3-nethsec
-PKG_VERSION:=0.0.69
+PKG_VERSION:=0.0.70
 PKG_RELEASE:=1
  
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>


### PR DESCRIPTION
Pulling in the changes coming from `python3-nethsec`

Ref:
- #646
