### PR TITLE
ns-flashstart: use lazy health check mode

### DIFF
--- a/packages/ns-flashstart/files/flashstart-apply
+++ b/packages/ns-flashstart/files/flashstart-apply
@@ -16,8 +16,8 @@ enabled=$(/sbin/uci get flashstart.global.enabled)
 
 if [ "$enabled" = "1" ]; then
     echo "addLocal('0.0.0.0:5300', { reusePort=true })" > "$conf"
-    echo "newServer({address='185.236.104.104', name='flashstart1'})" >> "$conf"
-    echo "newServer({address='185.236.105.105', name='flashstart2'})" >> "$conf"
+    echo "newServer({address='185.236.104.104', healthCheckMode='lazy', checkInterval=1, lazyHealthCheckFailedInterval=30, rise=2, maxCheckFailures=3, lazyHealthCheckThreshold=30, lazyHealthCheckSampleSize=100, lazyHealthCheckMinSampleCount=10, lazyHealthCheckMode='TimeoutOnly', name='flashstart1'})" >> "$conf"
+    echo "newServer({address='185.236.105.105', healthCheckMode='lazy', checkInterval=1, lazyHealthCheckFailedInterval=30, rise=2, maxCheckFailures=3, lazyHealthCheckThreshold=30, lazyHealthCheckSampleSize=100, lazyHealthCheckMinSampleCount=10, lazyHealthCheckMode='TimeoutOnly', name='flashstart2'})" >> "$conf"
 
     if [ "$dnsdist" = 0 ]; then
         /sbin/uci set dnsdist.general.enabled=1


### PR DESCRIPTION
Reduce number of queries for the root DNS server:
these queries are billed by FlashStart

#657 