### PR TITLE
New update-packages script

### DIFF
--- a/docs/design/distfeed.md
+++ b/docs/design/distfeed.md
@@ -79,11 +79,7 @@ Updates are pushed to the subscription channel after one week from the release d
 If you have a machine with a valid subscription and want to force an update, you can use the following commands:
 
 ```bash
-cp /etc/opkg/distfeeds.conf /etc/opkg/distfeeds.conf.ori
-cat /rom/etc/opkg/distfeeds.conf | sed 's/dev/stable/g' > /etc/opkg/distfeeds.conf
-opkg update
-/bin/opkg list-upgradable | /usr/bin/cut -f 1 -d ' ' | /usr/bin/xargs -r opkg upgrade && echo "Update successful!"
-mv /etc/opkg/distfeeds.conf.ori /etc/opkg/distfeeds.conf
+update-packages --force-stable
 ```
 
 At the end, the original `distfeeds.conf` file is restored.

--- a/packages/ns-api/files/ns.update
+++ b/packages/ns-api/files/ns.update
@@ -80,7 +80,7 @@ def get_package_updates_lat_check():
 
 def install_package_updates():
     try:
-        out = subprocess.check_output("/usr/sbin/screen -dmS install_package_updates /bin/bash -c \"/bin/opkg list-upgradable | /usr/bin/cut -f 1 -d ' ' | /usr/bin/xargs -r opkg upgrade\"", shell=True)
+        out = subprocess.check_output("/usr/sbin/screen -dmS install_package_updates /usr/sbin/update-packages", shell=True)
     except Exception as e:
         print(e, file=sys.stderr)
         return utils.generic_error("opkg_ugrade_failed")

--- a/packages/ns-api/files/schedule-automatic-updates
+++ b/packages/ns-api/files/schedule-automatic-updates
@@ -11,7 +11,7 @@
 
 action=${1:-"check"}
 timestamp=$2
-cmd="sleep \$(( RANDOM % 18000 )); /bin/opkg list-upgradable | /usr/bin/cut -f 1 -d ' ' | /usr/bin/xargs -r opkg upgrade"
+cmd="sleep \$(( RANDOM % 18000 )); /usr/sbin/update-packages"
 
 if [ "$action" == "add" ]; then
     crontab -l | grep -q "$cmd" || echo "5 2 * * * $cmd" >> /etc/crontabs/root

--- a/packages/ns-plug/Makefile
+++ b/packages/ns-plug/Makefile
@@ -42,6 +42,8 @@ define Package/ns-plug/postinst
 if [ -z "$${IPKG_INSTROOT}" ]; then
   (. /etc/uci-defaults/20_ns-plug)
   rm -f /etc/uci-defaults/20_ns-plug
+  (. /etc/uci-defaults/40_ns-plug_automatic_updates)
+  rm -f /etc/uci-defaults/40_ns-plug_automatic_updates
   /etc/init.d/cron restart
 fi
 exit 0
@@ -84,6 +86,7 @@ define Package/ns-plug/install
 	$(INSTALL_BIN) ./files/ns-download $(1)/usr/bin
 	$(INSTALL_BIN) ./files/20_ns-plug $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/30_ns-plug_alerts $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/40_ns-plug_automatic_updates $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/netadata_enable_alerts $(1)/usr/share/ns-plug/hooks/register/70netadata_enable_alerts
 	$(INSTALL_BIN) ./files/netadata_disable_alerts $(1)/usr/share/ns-plug/hooks/unregister/70netadata_disable_alerts
 	$(INSTALL_BIN) ./files/enable_automatic_updates $(1)/usr/share/ns-plug/hooks/register/60enable_automatic_updates

--- a/packages/ns-plug/Makefile
+++ b/packages/ns-plug/Makefile
@@ -79,6 +79,7 @@ define Package/ns-plug/install
 	$(INSTALL_BIN) ./files/register $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/unregister $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/subscription-info $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/update-packages $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/inventory $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/ns-download $(1)/usr/bin
 	$(INSTALL_BIN) ./files/20_ns-plug $(1)/etc/uci-defaults

--- a/packages/ns-plug/Makefile
+++ b/packages/ns-plug/Makefile
@@ -40,10 +40,7 @@ endef
 define Package/ns-plug/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-  (. /etc/uci-defaults/20_ns-plug)
-  rm -f /etc/uci-defaults/20_ns-plug
-  (. /etc/uci-defaults/40_ns-plug_automatic_updates)
-  rm -f /etc/uci-defaults/40_ns-plug_automatic_updates
+  /usr/libexec/ns-plug/40_ns-plug_automatic_updates
   /etc/init.d/cron restart
 fi
 exit 0
@@ -71,6 +68,7 @@ define Package/ns-plug/install
 	$(INSTALL_DIR) $(1)/etc/netdata
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_DIR) $(1)/usr/lib/netdata/python.d/
+	$(INSTALL_DIR) $(1)/usr/libexec/ns-plug
 	$(INSTALL_BIN) ./files/ns-plug.init $(1)/etc/init.d/ns-plug
 	$(INSTALL_BIN) ./files/ns-plug $(1)/usr/sbin/ns-plug
 	$(INSTALL_BIN) ./files/distfeed-setup $(1)/usr/sbin/distfeed-setup
@@ -87,6 +85,7 @@ define Package/ns-plug/install
 	$(INSTALL_BIN) ./files/20_ns-plug $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/30_ns-plug_alerts $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/40_ns-plug_automatic_updates $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/40_ns-plug_automatic_updates $(1)/usr/libexec/ns-plug
 	$(INSTALL_BIN) ./files/netadata_enable_alerts $(1)/usr/share/ns-plug/hooks/register/70netadata_enable_alerts
 	$(INSTALL_BIN) ./files/netadata_disable_alerts $(1)/usr/share/ns-plug/hooks/unregister/70netadata_disable_alerts
 	$(INSTALL_BIN) ./files/enable_automatic_updates $(1)/usr/share/ns-plug/hooks/register/60enable_automatic_updates

--- a/packages/ns-plug/files/40_ns-plug_automatic_updates
+++ b/packages/ns-plug/files/40_ns-plug_automatic_updates
@@ -1,0 +1,7 @@
+old_cmd="sleep \$(( RANDOM % 18000 )); /bin/opkg list-upgradable | /usr/bin/cut -f 1 -d ' ' | /usr/bin/xargs -r opkg upgrade"
+
+# Remove old command from crontab and add new one
+if crontab -l | grep -q "$old_cmd"; then
+    crontab -l | grep -v "$old_cmd" | sort | uniq | crontab -
+    /usr/libexec/ns-api/schedule-automatic-updates add
+fi

--- a/packages/ns-plug/files/40_ns-plug_automatic_updates
+++ b/packages/ns-plug/files/40_ns-plug_automatic_updates
@@ -1,7 +1,9 @@
 old_cmd="sleep \$(( RANDOM % 18000 )); /bin/opkg list-upgradable | /usr/bin/cut -f 1 -d ' ' | /usr/bin/xargs -r opkg upgrade"
+cmd="sleep \$(( RANDOM % 18000 )); /usr/sbin/update-packages"
 
 # Remove old command from crontab and add new one
 if crontab -l | grep -q "$old_cmd"; then
     crontab -l | grep -v "$old_cmd" | sort | uniq | crontab -
-    /usr/libexec/ns-api/schedule-automatic-updates add
+    # can't use /usr/libexec/ns-api/schedule-automatic-updates because new version could not be installed yet
+    crontab -l | grep -q "$cmd" || echo "5 2 * * * $cmd" >> /etc/crontabs/root
 fi

--- a/packages/ns-plug/files/update-packages
+++ b/packages/ns-plug/files/update-packages
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+#
+# Update packages and log everything to syslog
+# Usage: update-packages [--force-stable]
+# --force-stable: force update from stable channel even if the system has a subscription
+#
+
+error_exit() {
+    echo "$1" | logger -s -t update-packages
+    exit 1
+}
+
+cleanup() {
+    if [ -f /etc/opkg/distfeeds.conf.orig ]; then
+        echo "Restoring original distfeeds.conf" | logger -s -t update-packages
+        mv /etc/opkg/distfeeds.conf.orig /etc/opkg/distfeeds.conf || error_exit "Failed to restore distfeeds.conf"
+    fi
+}
+
+# Check if the force flag is set, default to false
+force=0
+if [ "$1" = "--force-stable" ]; then
+    force=1
+    echo "Flag force-stable is set" | logger -s -t update-packages
+fi
+
+channel='dev'
+# channel is subscription if "$(uci -q get ns-plug.config.system_id)" is not empty
+if [ -n "$(uci -q get ns-plug.config.system_id)" ]; then
+    channel='subscription'
+fi
+
+# Set up trap to call cleanup function on script exit
+trap cleanup EXIT
+
+# Create temporary opkg configuration
+if [ "$force" -eq 1 ]; then
+    channel='stable'
+    # Preserve original distfeed.conf
+    cp /etc/opkg/distfeeds.conf /etc/opkg/distfeeds.conf.orig || error_exit "Failed to backup distfeeds.conf"
+
+    echo "Creating temporary distfeed configuration" | logger -s -t update-packages
+    # make sure to replace dev with stable in case we are using a dev image
+    sed 's/dev/stable/g' /rom/etc/opkg/distfeeds.conf > /etc/opkg/distfeeds.conf || error_exit "Failed to create temporary opkg configuration"
+fi
+
+echo "Updating packages from $channel channel" | logger -s -t update-packages
+
+# Update metadata, make sure to output even if in case of error
+output=$(opkg update 2>&1)
+status=$?
+echo "$output" | logger -s -t update-packages
+[ $status -ne 0 ] && error_exit "Failed to update metadata"
+
+error_count=0
+# Upgrade each package individually and capture output
+opkg list-upgradable | cut -f 1 -d ' ' | while read -r package; do
+    output=$(opkg upgrade "$package" 2>&1)
+    status=$?
+    [ $status -ne 0 ] && error_count=$((error_count + 1))
+    echo "$output" | logger -s -t update-packages
+done
+
+# Check if there were any errors
+[ $error_count -ne 0 ] && error_exit "Failed to upgrade $error_count packages"
+
+echo "Update successful" | logger -s -t update-packages


### PR DESCRIPTION
Add a new `update-packages` script, features:

- all operations are written to syslog and stderr: this change is very useful for troubleshooting and tracking the automatic updates
- accept the 'force-stable' flag to gather updates from stable channel regardless of subscription status: this can be used to quickly distribute fixes

#668 