### PR TITLE
ns-api: ssh, fix JSON output

### DIFF
--- a/packages/ns-api/files/ns.ssh
+++ b/packages/ns-api/files/ns.ssh
@@ -21,7 +21,7 @@ else:
         keys = '/etc/dropbear/authorized_keys'
         if os.path.exists(keys):
             with open(keys, 'r') as fp:
-                print({"keys": fp.read()})
+                print(json.dumps({"keys": fp.read()}))
         else:
-            print({"keys": ""})
+            print(json.dumps({"keys": ""}))
 


### PR DESCRIPTION
The API does not generate a valid JSON output, still it works correctly with rpcd.

The fix is usefull when invoking the script without rpcd as wrapper