### PR TITLE
Revert "ns-api(objects): use new library function to list domains"

### DIFF
--- a/packages/ns-api/files/ns.objects
+++ b/packages/ns-api/files/ns.objects
@@ -54,7 +54,7 @@ elif cmd == 'call':
     e_uci = EUci()
     try:
         if action == 'list-domain-sets':
-            print(json.dumps({'values': objects.list_objects(e_uci, include_host_sets=False, expand=True)}))
+            print(json.dumps({'values': objects.list_domain_sets(e_uci)}))
         elif action == 'list-hosts':
             print(json.dumps({'values': objects.list_objects(e_uci, include_domain_sets=False, expand=True)}))
         else:


### PR DESCRIPTION
This reverts commit 667747139094107f88d25a2bc856c59fbf4ba57b.

The new implementation returns also non-domains objects.

#697 

I think this change can cause a regression in #671 