### PR TITLE
fix: ns.redirect list-object-suggestions

### DIFF
--- a/packages/ns-api/files/ns.redirects
+++ b/packages/ns-api/files/ns.redirects
@@ -215,7 +215,7 @@ def list_zones():
 
 def list_object_suggestions(u):
     return {
-        "ns_src": objects.list_objects(u, include_host_sets=False),
+        "ns_src": objects.list_domain_sets(u),
         "ns_dst": objects.list_objects(u, singleton_only=True, include_domain_sets=False)
     }
 


### PR DESCRIPTION
`ns.redirect list-object-suggestions` api should return domain sets only. Before this change also other objects, e.g. VPN users and DHCP reservations were returned.

Ref:
- https://github.com/NethServer/nethsecurity/issues/689