### PR TITLE
mwan: remove unsupported objects

### DIFF
--- a/packages/ns-api/files/ns.mwan
+++ b/packages/ns-api/files/ns.mwan
@@ -12,6 +12,9 @@ from euci import EUci
 from nethsec import mwan, utils, objects
 
 def __filter_objects(e_uci: EUci, obj):
+    family = objects.get_info(e_uci, obj['id']).get('family', None)
+    if family and family == 'ipv6':
+        return False
     if obj['type'] == 'host_set':
         return objects.is_singleton_host_set(e_uci, obj['id'], allow_cidr=True)
     return True
@@ -157,7 +160,7 @@ elif cmd == 'call':
             print(json.dumps({'values': mwan.get_default_config(e_uci)}))
         elif action == "list_object_suggestions":
             ns_src = list(filter(lambda x: __filter_objects(e_uci, x), objects.list_objects(e_uci, include_domain_sets=False)))
-            ns_dst = list(filter(lambda x: __filter_objects(e_uci, x), objects.list_objects(e_uci, include_domain_sets=True)))
+            ns_dst = list(filter(lambda x: __filter_objects(e_uci, x), objects.list_objects(e_uci, include_domain_sets=False)))
             print(json.dumps({"objects": {'ns_src': ns_src, 'ns_dst': ns_dst}}))
 
     except KeyError as e:

--- a/packages/ns-objects/README.md
+++ b/packages/ns-objects/README.md
@@ -415,15 +415,14 @@ Supported object types depends on the field:
   - a static lease, a record of type `host` from `dhcp` db
   - a dns record, a record of type `domain` from `dhcp` db
   - a vpn user, a record of type `user` from `users` db with `openvpn_ipaddr`
-  - a singleton host set, a record of type `host` from `objects` db with only one IP address
+  - a singleton host set, a record of type `host` from `objects` db with only one IP address or CIDR
 
 - `ns_dst` can be:
 
-  - a domain set object, a record of type `domain` from `objects` db
   - a dns record, a record of type `domain` from `dhcp` db
   - a host set object, a record of type `host` from `objects` db
   - a vpn user, a record of type `user` from `users` db with `openvpn_ipaddr`
-  - a singleton host set, a record of type `host` from `objects` db with only one IP address
+  - a singleton host set, a record of type `host` from `objects` db with only one IP address or CIDR
 
 
 Example of multiwan rule with domain set object inside `/etc/config/mwan3`:

--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=python3-nethsec
-PKG_VERSION:=0.0.73
+PKG_VERSION:=0.0.74
 PKG_RELEASE:=1
  
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>


### PR DESCRIPTION
Changes:
- remove domain sets, mwan ipset support is broken on 23.05
- remove IPv6 objects, mwan does not directly support IPv6

Fixes failed tests: 3, 4 and 5

References:
- Issue #671
- Requires: https://github.com/NethServer/python3-nethsec/pull/64