### PR TITLE
ns-api & ns-plug: add package list to backup

### DIFF
--- a/packages/ns-api/files/ns.backup
+++ b/packages/ns-api/files/ns.backup
@@ -34,7 +34,7 @@ def create_backup():
         # run sysupgrade to create backup file
         file_name = generate_random_file_name()
         backup_path = f'{DOWNLOAD_PATH}{file_name}'
-        subprocess.run(['/sbin/sysupgrade', '-b', backup_path], check=True, capture_output=True)
+        subprocess.run(['/sbin/sysupgrade', '-k', '-b', backup_path], check=True, capture_output=True)
         # if passphrase is present, encrypt backup file
         passphrase = fetch_passphrase()
         if passphrase is not None:

--- a/packages/ns-plug/files/send-backup
+++ b/packages/ns-plug/files/send-backup
@@ -39,7 +39,7 @@ fi
 
 # Create the backup
 mkdir -p $WORK_DIR
-sysupgrade -b $BACKUP 2>/dev/null
+sysupgrade -k -b $BACKUP 2>/dev/null
 md5sum $BACKUP | awk '{print $1}' > $MD5
 
 # Send backup if there is no md5 saved


### PR DESCRIPTION
This will ease the restore of packages installed
from repositories after an image upgrade

Please note that the package list is already saved during the upgrade process, if executed from the UI.

Example of restore:
```
 grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | xargs opkg install
```

References:
- #711 
- #710 