### PR TITLE
Migration: fix failure and improve logging

### DIFF
--- a/files/etc/uci-defaults/95-nethsec-migrate
+++ b/files/etc/uci-defaults/95-nethsec-migrate
@@ -1,6 +1,6 @@
 archive="/usr/share/migration/export.tar.gz"
 if [ -f "${archive}" ]; then
-    /usr/sbin/ns-import $archive | tee /var/log/migration.log
+    /usr/sbin/ns-import $archive
 
     if [ $? -eq 0 ]; then
         mv "${archive}" "${archive}.done"

--- a/packages/ns-migration/README.md
+++ b/packages/ns-migration/README.md
@@ -39,7 +39,7 @@ tar xvzf export.tar.gz
 The `ns-import` script is verbose by default, use the `-q` option to suppress output to standard output.
 
 On first boot, if a file named `/usr/share/migration/export.tar.gz` is present, the system
-will automatically import the configuration. Migration output will be logged to `/var/log/migration.log`.
+will automatically import the configuration. Migration output will be logged to `/root/migration.log`.
 
 ### Remapping interfaces
 

--- a/packages/ns-migration/files/ns-import
+++ b/packages/ns-migration/files/ns-import
@@ -21,6 +21,7 @@ try_restart() {
 
 maps=''
 quiet=""
+log='/root/migration.log'
 
 while getopts "qm:" opt
 do
@@ -60,7 +61,8 @@ cd $work_dir
 for f in $(find /usr/share/ns-migration/ -type f)
 do
     if [ -x "$f" ]; then
-        "$f" $quiet $maps "$tmp_dir/export"
+        echo "$f" $quiet $maps "$tmp_dir/export" | tee -a "$log"
+        "$f" $quiet $maps "$tmp_dir/export" 2>&1 | tee -a "$log"
     fi
 done
 

--- a/packages/ns-migration/files/scripts/network
+++ b/packages/ns-migration/files/scripts/network
@@ -227,7 +227,7 @@ for a in data['aliases']:
         u.set("network", aname, "device", device)
         u.set("network", aname, "ipaddr", [ipaddr.with_prefixlen])
         u.set("network", aname, "proto", a["proto"])
-        if a["gateway"]:
+        if a.get("gateway"):
             u.set("network", aname, "gateway", a["gateway"])
         acount = acount - 1
         if not a['zone'] in alias_zones:


### PR DESCRIPTION
- Fix issue #716 
- Always log migration to /root/migration.log

See each commit message for more details