### PR TITLE
ns-don: open netdata port (19999)

### DIFF
--- a/packages/ns-don/files/20-don.nft
+++ b/packages/ns-don/files/20-don.nft
@@ -1,1 +1,1 @@
-iifname "tunDON" tcp dport {981,9090,443} counter accept comment ns-allow-don
+iifname "tunDON" tcp dport {981,9090,443,19999} counter accept comment ns-allow-don


### PR DESCRIPTION
Add access to port 19999 from tunDON to allow viewing netdata UI from remote support sessions.