### PR TITLE
Extend OpenVPN CRL expiration

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -740,6 +740,7 @@ def delete_user(ovpninstance, username):
         env = os.environ.copy()
         env["EASYRSA_BATCH"] = "1"
         env["EASYRSA_PKI"] = f'/etc/openvpn/{ovpninstance}/pki'
+        env["EASYRSA_CRL_DAYS"] = "3650"
         subprocess.run(["/usr/bin/easyrsa", "revoke", username], env=env, check=True, capture_output=True)
         subprocess.run(["/usr/bin/easyrsa", "gen-crl"], env=env, check=True, capture_output=True)
     except:

--- a/packages/ns-openvpn/Makefile
+++ b/packages/ns-openvpn/Makefile
@@ -41,6 +41,7 @@ define Package/ns-openvpn/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/ns-openvpnrw-add $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/ns-openvpnrw-init-pki $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/ns-openvpnrw-extend-crl $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/ns-openvpntunnel-add-client $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/openvpn-connect $(1)/usr/libexec/ns-openvpn/
 	$(INSTALL_BIN) ./files/openvpn-disconnect $(1)/usr/libexec/ns-openvpn/
@@ -54,6 +55,7 @@ define Package/ns-openvpn/install
 	$(INSTALL_BIN) ./files/80-save-connection $(1)/usr/libexec/ns-openvpn/connect-scripts
 	$(INSTALL_BIN) ./files/80-save-disconnection $(1)/usr/libexec/ns-openvpn/disconnect-scripts
 	$(INSTALL_BIN) ./files/99_ns-openvpn $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/99_ns-openvpn-renew-crl $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/openvpn-status $(1)/usr/bin
 	$(INSTALL_BIN) ./files/openvpn-kill $(1)/usr/bin
 endef
@@ -63,6 +65,12 @@ define Package/ns-openvpn/prerm
 if [ -z "$${IPKG_INSTROOT}" ]; then
     sed -i '/\/usr\/libexec\/ns-openvpn\/init-connections-db/d' /etc/openvpn.user
 fi
+exit 0
+endef
+
+define Package/ns-openvpn/postinst
+#!/bin/sh
+/usr/sbin/ns-openvpnrw-extend-crl
 exit 0
 endef
 

--- a/packages/ns-openvpn/files/99_ns-openvpn-renew-crl
+++ b/packages/ns-openvpn/files/99_ns-openvpn-renew-crl
@@ -1,0 +1,1 @@
+/usr/sbin/ns-openvpnrw-extend-crl

--- a/packages/ns-openvpn/files/ns-openvpnrw-extend-crl
+++ b/packages/ns-openvpn/files/ns-openvpnrw-extend-crl
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Regenerate the CRL for each roadwarrior instance present
+
+import os
+import subprocess
+
+from euci import EUci
+
+u = EUci()
+for key in [key for key in u.get('openvpn') if key.startswith('ns_roadwarrior')]:
+    env = os.environ.copy()
+    env["EASYRSA_BATCH"] = "1"
+    env["EASYRSA_PKI"] = f'/etc/openvpn/{key}/pki'
+    env["EASYRSA_CRL_DAYS"] = "3650"
+    subprocess.run(["/usr/bin/easyrsa", "gen-crl"], env=env, check=True, capture_output=True)

--- a/packages/ns-openvpn/files/ns-openvpnrw-init-pki
+++ b/packages/ns-openvpn/files/ns-openvpnrw-init-pki
@@ -24,6 +24,6 @@ if [ ! -f /etc/openvpn/$instance/pki/ca.crt ]; then
         EASYRSA_BATCH=1 EASYRSA_REQ_CN=$cn /usr/bin/easyrsa build-ca nopass
         openssl dhparam -dsaparam -out pki/dh.pem 2048
         EASYRSA_BATCH=1 EASYRSA_REQ_CN=$cn /usr/bin/easyrsa build-server-full server nopass
-        EASYRSA_BATCH=1 EASYRSA_REQ_CN=$cn /usr/bin/easyrsa gen-crl
+        EASYRSA_BATCH=1 EASYRSA_CRL_DAYS=3650 EASYRSA_REQ_CN=$cn /usr/bin/easyrsa gen-crl
     ) &> /dev/null
 fi


### PR DESCRIPTION
Extending CRL expiration when generating the CRL file, also extending the time when updating the package or the whole image

Ref:
 - https://github.com/NethServer/nethsecurity/issues/739
