### PR TITLE
ns-api & ns-plug: enable/disable FQDN in logs

### DIFF
--- a/packages/ns-api/files/ns.plug
+++ b/packages/ns-api/files/ns.plug
@@ -91,6 +91,8 @@ def unregister():
         subprocess.run(['/etc/init.d/ns-plug', 'restart'], check=True, capture_output=True)
     except:
         return utils.generic_error("failed_to_restart_ns-plug")
+    # Disable sending of FQDN, no matter if it fails
+    subprocess.run("sed -i '/^\\$PreserveFQDN on$/d' /etc/rsyslog.conf", shell=True, capture_output=True)
     try:
         subprocess.run(['/etc/init.d/rsyslog', 'restart'], check=True, capture_output=True)
     except:

--- a/packages/ns-plug/files/ns-plug
+++ b/packages/ns-plug/files/ns-plug
@@ -132,6 +132,8 @@ if [ "$(uci -q get rsyslog.promtail)" == "" ]; then
     uci set rsyslog.promtail.rfc=5424
     uci set rsyslog.promtail.target=$(echo "$response" | jq -r .data.promtail_address)
     uci commit rsyslog
+    # Use FQDN when sending logs #733
+    grep -qF '$PreserveFQDN on' /etc/rsyslog.conf || echo '$PreserveFQDN on' >> /etc/rsyslog.conf
     /etc/init.d/rsyslog restart
     sleep 5 # wait for rsyslog
 fi


### PR DESCRIPTION
Make sure to send the logs using FQDN to controller: this will prevent conflicts with firewall with the same hostname

#733