### PR TITLE
ns-api: ovpnrw, add compress option to client config

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -806,7 +806,7 @@ def download_user_configuration(ovpninstance, username):
     config = config + f'<ca>\n{slurp(os.path.join(cert_dir, "ca.crt"))}\n</ca>\n'
     config = config + f'<cert>\n{slurp(crt_file)}\n</cert>\n'
     config = config + f'<key>\n{slurp(os.path.join(cert_dir, f"private/{username}.key"))}\n</key>\n'
-    for option in ["auth", "digest"]:
+    for option in ["auth", "digest", "compress"]:
         try:
             config = config + f'{option} {u.get("openvpn", ovpninstance, option)}\n'
         except:


### PR DESCRIPTION
UCI does not support empty options, so 'compress' can't be set as an empty string inside the server to support this scenario from OpenVPN manual:

  If the algorithm parameter is empty, compression will be turned off,
  but the packet framing for compression will still be enabled, allowing a different setting to be pushed later.

As workaround, the compression must be explicitly
both on server and client configuration

#741 