### PR TITLE
ns-api: ovpntunnel, fix remote_cert_tls option

### DIFF
--- a/packages/ns-api/files/ns.ovpntunnel
+++ b/packages/ns-api/files/ns.ovpntunnel
@@ -88,6 +88,10 @@ def import_client(tunnel):
         u.set("openvpn", iname, "cert", cert)
         u.set("openvpn", iname, "key", cert)
         u.set("openvpn", iname, "ca", cert)
+        # Enable cert verification only for NethSecurity 8 tunnels
+        ext = subprocess.run(["openssl", "x509", "-noout", "-ext", "keyUsage", "-in", cert], capture_output=True, text=True, check=True)
+        if ext and "Key Agreement" in ext.stdout:
+            u.set("openvpn", iname, "remote_cert_tls", "server")
     
     u.set("openvpn", iname, "proto", tunnel['Protocol'])
     u.set("openvpn", iname, "port", tunnel['RemotePort'])
@@ -110,8 +114,6 @@ def import_client(tunnel):
 
     if tunnel.get('TlsVersionMin', ''):
         u.set("openvpn", iname, "tls_version_min", tunnel['TlsVersionMin'])
-
-    u.set("openvpn", iname, "remote_cert_tls", "server")
 
     # Add management socket
     u.set("openvpn", iname, 'management', f'/var/run/openvpn_{iname}.socket unix')


### PR DESCRIPTION
During import, tunnels created from NS7 can't use
remote_cert_tls validation because the certificate lacks the Key Agreement extension.
In this case, disable remote_cert_tls to avoid errors like:

 Certificate does not have key usage extension

The option will be added only if the certificate has the extension. Please note that certificates created from NethSecurity 8 have the above extensions.

#735 