### PR TITLE
ns-api: assigning a dev_type so that UI does not rely on defaults

### DIFF
--- a/packages/ns-api/files/ns.ovpntunnel
+++ b/packages/ns-api/files/ns.ovpntunnel
@@ -74,6 +74,7 @@ def import_client(tunnel):
     u.set("openvpn", iname, "enabled", 1)
     u.set("openvpn", iname, "nobind", "1")
     u.set("openvpn", iname, "dev", tun)
+    u.set("openvpn", iname, "dev_type", "tun")
     u.set("openvpn", iname, "ns_client", "1")
     
     if tunnel['Topology'] == 'p2p':


### PR DESCRIPTION
Ref:
 - #751
