### PR TITLE
ns-api(openvpntunnel): fix wrong cipher default

### DIFF
--- a/packages/ns-api/files/ns.ovpntunnel
+++ b/packages/ns-api/files/ns.ovpntunnel
@@ -561,7 +561,7 @@ def setup_client(u, iname, args):
     if args.get('ifconfig_local', None) and  args.get('ifconfig_remote', None):
         u.set('openvpn', iname, 'ifconfig', f"{args.get('ifconfig_local')} {args.get('ifconfig_remote')}")
         # disable default BF-CBC cipher not supported by OpenSSL
-        if args.get('cipher', None):
+        if args.get('cipher', None) is None:
             u.set('openvpn', iname, 'cipher', 'AES-128-CBC')
     else:
         # subnet topology


### PR DESCRIPTION
OpenVPN Tunnel Client is being reset into using `AES-128-CBC` as a cipher all the time.

Ref:
 - #758
