### PR TITLE
ns-plug: fix update-packages stable updates

### DIFF
--- a/packages/ns-plug/files/update-packages
+++ b/packages/ns-plug/files/update-packages
@@ -48,6 +48,9 @@ if [ "$force" -eq 1 ]; then
     echo "Creating temporary distfeed configuration" | logger -s -t update-packages
     # make sure to replace dev with stable in case we are using a dev image
     sed 's/dev/stable/g' /rom/etc/opkg/distfeeds.conf > /etc/opkg/distfeeds.conf || error_exit "Failed to create temporary opkg configuration"
+
+    # force cache cleanup: it seems a duble opkg update is required
+    opkg update 2>&1
 fi
 
 echo "Updating packages from $channel channel" | logger -s -t update-packages


### PR DESCRIPTION
When the --force-stable flag, there might be an issue if metadata have been previously downloaded using the subscription repository: opkg will try to download some packages using the subscription URL instead of the sable one.

To avoid this issue, force the cleanup of all opkg caches.