### PR TITLE
Fix update packages

### DIFF
--- a/docs/design/distfeed.md
+++ b/docs/design/distfeed.md
@@ -79,14 +79,20 @@ Updates are pushed to the subscription channel after one week from the release d
 If you have a machine with a valid subscription and want to force an update, you can use the following commands:
 
 ```bash
-cp /etc/opkg/distfeeds.conf /etc/opkg/distfeeds.conf.ori
-cat /rom/etc/opkg/distfeeds.conf | sed 's/dev/stable/g' > /etc/opkg/distfeeds.conf
+cp /etc/opkg/customfeeds.conf /etc/opkg/customfeeds.conf.ori
+cat /rom/etc/opkg/distfeeds.conf | sed 's/dev/stable/g' > /etc/opkg/customfeeds.conf
 opkg update
 /bin/opkg list-upgradable | /usr/bin/cut -f 1 -d ' ' | /usr/bin/xargs -r opkg upgrade && echo "Update successful!"
-mv /etc/opkg/distfeeds.conf.ori /etc/opkg/distfeeds.conf
 ```
 
-At the end, the original `distfeeds.conf` file is restored.
+The customfeed.confg file takes precedence over distfeed.conf, so you can safely
+ignore errors like `opkg_conf_parse_file: Duplicate src declaration`.
+
+At the end, retstore the original `customfeeds.conf`:
+```
+mv /etc/opkg/customfeeds.conf /etc/opkg/customfeeds.conf
+opkg update
+```
 
 ## Upstream OpenWrt repositories
 

--- a/docs/design/distfeed.md
+++ b/docs/design/distfeed.md
@@ -79,7 +79,11 @@ Updates are pushed to the subscription channel after one week from the release d
 If you have a machine with a valid subscription and want to force an update, you can use the following commands:
 
 ```bash
-update-packages --force-stable
+cp /etc/opkg/distfeeds.conf /etc/opkg/distfeeds.conf.ori
+cat /rom/etc/opkg/distfeeds.conf | sed 's/dev/stable/g' > /etc/opkg/distfeeds.conf
+opkg update
+/bin/opkg list-upgradable | /usr/bin/cut -f 1 -d ' ' | /usr/bin/xargs -r opkg upgrade && echo "Update successful!"
+mv /etc/opkg/distfeeds.conf.ori /etc/opkg/distfeeds.conf
 ```
 
 At the end, the original `distfeeds.conf` file is restored.

--- a/packages/ns-plug/files/update-packages
+++ b/packages/ns-plug/files/update-packages
@@ -7,50 +7,12 @@
 
 #
 # Update packages and log everything to syslog
-# Usage: update-packages [--force-stable]
-# --force-stable: force update from stable channel even if the system has a subscription
 #
 
 error_exit() {
     echo "$1" | logger -s -t update-packages
     exit 1
 }
-
-cleanup() {
-    if [ -f /etc/opkg/distfeeds.conf.orig ]; then
-        echo "Restoring original distfeeds.conf" | logger -s -t update-packages
-        mv /etc/opkg/distfeeds.conf.orig /etc/opkg/distfeeds.conf || error_exit "Failed to restore distfeeds.conf"
-    fi
-}
-
-# Check if the force flag is set, default to false
-force=0
-if [ "$1" = "--force-stable" ]; then
-    force=1
-    echo "Flag force-stable is set" | logger -s -t update-packages
-fi
-
-channel='dev'
-# channel is subscription if "$(uci -q get ns-plug.config.system_id)" is not empty
-if [ -n "$(uci -q get ns-plug.config.system_id)" ]; then
-    channel='subscription'
-fi
-
-# Set up trap to call cleanup function on script exit
-trap cleanup EXIT
-
-# Create temporary opkg configuration
-if [ "$force" -eq 1 ]; then
-    channel='stable'
-    # Preserve original distfeed.conf
-    cp /etc/opkg/distfeeds.conf /etc/opkg/distfeeds.conf.orig || error_exit "Failed to backup distfeeds.conf"
-
-    echo "Creating temporary distfeed configuration" | logger -s -t update-packages
-    # make sure to replace dev with stable in case we are using a dev image
-    sed 's/dev/stable/g' /rom/etc/opkg/distfeeds.conf > /etc/opkg/distfeeds.conf || error_exit "Failed to create temporary opkg configuration"
-fi
-
-echo "Updating packages from $channel channel" | logger -s -t update-packages
 
 # Update metadata, make sure to output even if in case of error
 output=$(opkg update 2>&1)


### PR DESCRIPTION
When the --force-stable flag, there might be an issue if
metadata have been previously downloaded using the subscription
repository: opkg will try to download some packages using
the subscription URL instead of the sable one.

This PR removes the force flag and restore the old documentation.

#765 