### PR TITLE
Realtime monitoring: instant ranking

### DIFF
--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -43,24 +43,110 @@ api-cli ns.talkers list --data '{"limit": 1}'
 Response:
 ```json
 {
-  "talkers": [
-    {
-      "mac": "40:62:31:19:05:22",
-      "totals": {
-        "download": 21666,
-        "upload": 483727,
-        "packets": 643,
-        "bandwidth": 16846.433333333334,
-        "bandwiddh_h": "16.5 KB/s"
+  "talkers": {
+    "top_hosts": [
+      {
+        "mac": "40:62:31:19:05:22",
+        "totals": {
+          "download": 21666,
+          "upload": 483727,
+          "packets": 643,
+          "bandwidth": 16846.433333333334,
+          "bandwiddh_h": "16.5 KB/s"
+        },
+        "apps": {
+          "0.netify.unclassified": 0,
+          "10334.netify.nethserver": 505393
+        },
+        "ip": "192.168.5.211",
+        "host": "nethvoice.nethesis.it"
+      }
+    ],
+    "top_apps": [
+      {
+        "name": "10974.netify.meta-cdn",
+        "value": 149845562
       },
-      "apps": {
-        "0.netify.unclassified": 0,
-        "10334.netify.nethserver": 505393
+      {
+        "name": "201.netify.instagram",
+        "value": 63817984
       },
-      "ip": "192.168.5.211",
-      "host": "nethvoice.nethesis.it"
-    }
-  ]
+      {
+        "name": "10334.netify.nethserver",
+        "value": 31100837
+      },
+      {
+        "name": "0.netify.unclassified",
+        "value": 10138483
+      },
+      {
+        "name": "126.netify.google",
+        "value": 6314644
+      },
+      {
+        "name": "119.netify.facebook",
+        "value": 4381644
+      },
+      {
+        "name": "10034.netify.hubspot",
+        "value": 2430153
+      },
+      {
+        "name": "156.netify.spotify",
+        "value": 1139379
+      },
+      {
+        "name": "10002.netify.github",
+        "value": 1114048
+      },
+      {
+        "name": "10041.netify.google-ads",
+        "value": 791534
+      }
+    ],
+    "top_protocols": [
+      {
+        "name": "QUIC",
+        "value": 218488582
+      },
+      {
+        "name": "HTTP/S",
+        "value": 24080025
+      },
+      {
+        "name": "STUN",
+        "value": 21171007
+      },
+      {
+        "name": "SYSLOG/S",
+        "value": 5880696
+      },
+      {
+        "name": "HTTP",
+        "value": 2545062
+      },
+      {
+        "name": "Unknown",
+        "value": 851164
+      },
+      {
+        "name": "SSH",
+        "value": 684836
+      },
+      {
+        "name": "WireGuard",
+        "value": 600214
+      },
+      {
+        "name": "TLS",
+        "value": 507668
+      },
+      {
+        "name": "OpenVPN",
+        "value": 467074
+      }
+    ]
+  }
 }
 ```
 

--- a/packages/ns-api/files/ns.talkers
+++ b/packages/ns-api/files/ns.talkers
@@ -11,10 +11,14 @@ import sys
 import json
 import socket
 
+from nethsec import dpi
+
+
 def list_talkers(limit = 20, stat_file="/tmp/netify-plugin-stats.json"):
     data = None
     stats = dict()
-    time_diff = 1
+    applications = dict()
+    protocols = dict()
 
     with open(stat_file, 'r') as fp:
         data = json.load(fp)
@@ -39,19 +43,35 @@ def list_talkers(limit = 20, stat_file="/tmp/netify-plugin-stats.json"):
                 for app in data['stats'][mac][ip]:
                     if app not in stats[ip]['apps']:
                         stats[ip]['apps'][app] = 0
+                    if app not in applications:
+                        applications[app] = 0
                     for proto in data['stats'][mac][ip][app]:
+                        if proto not in protocols:
+                            protocols[proto] = 0
                         stats[ip]['totals']['download'] += data['stats'][mac][ip][app][proto]['download']
                         stats[ip]['totals']['upload'] += data['stats'][mac][ip][app][proto]['upload']
                         stats[ip]['totals']['bandwidth'] +=  data['stats'][mac][ip][app][proto]['download'] +  data['stats'][mac][ip][app][proto]['upload']
                         stats[ip]['totals']['packets'] += data['stats'][mac][ip][app][proto]['packets']
                         stats[ip]['apps'][app] += data['stats'][mac][ip][app][proto]['download'] + data['stats'][mac][ip][app][proto]['upload']
 
+                        applications[app] += data['stats'][mac][ip][app][proto]['download'] + data['stats'][mac][ip][app][proto]['upload']
+
+                        protocols[proto] += data['stats'][mac][ip][app][proto]['download'] + data['stats'][mac][ip][app][proto]['upload']
+
             # name resolution can highly slow down the API
             stats[ip]['host'] = socket.getnameinfo((ip, 0), 0)[0]
             stats[ip]['totals']['bandwidth'] = stats[ip]['totals']['bandwidth'] / time_diff
 
     ordered = sorted(stats.values(), key=lambda x: x['totals']['bandwidth'], reverse=True)
-    return ordered[:limit]
+    applications = [{"name": k, "value": v} for k, v in sorted(applications.items(), key=lambda x: x[1], reverse=True)]
+    protocols_naming = dpi.load_protocols()
+    protocols = {protocols_naming.get(int(k), k): v for k, v in protocols.items()}
+    protocols = [{"name": k, "value": v} for k, v in sorted(protocols.items(), key=lambda x: x[1], reverse=True)][:limit]
+    return {
+        'top_hosts': ordered[:limit],
+        'top_apps': applications[:limit],
+        'top_protocols': protocols
+    }
 
 
 cmd = sys.argv[1]

--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=python3-nethsec
-PKG_VERSION:=0.0.77
+PKG_VERSION:=0.0.78
 PKG_RELEASE:=1
  
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>


### PR DESCRIPTION
Add to the realtime monitoring api the applications and protocols most active:
- [X] App traffic
- [X] Protocol traffic

This is intended as a breaking change, and `ns-api` should be released as `2.0.0`

Ref:
- https://github.com/NethServer/nethsecurity/issues/756