### PR TITLE
ns-api: improve threat_shield_ip count accuracy

### DIFF
--- a/packages/ns-api/files/ns.dashboard
+++ b/packages/ns-api/files/ns.dashboard
@@ -350,7 +350,7 @@ def counter(service):
     if service == "hosts":
         ret = count_hosts()
     elif service == "threat_shield_ip":
-        ret = _run("grep \"$(date -d '-1 hour' +'%b %e %H:%M')\" /var/log/messages | grep kernel | grep banIP/ | wc -l")
+        ret = _run("grep -e \"$(date -d '-1 hour' +'%b %e %H:%M')\" -e \"$(date  +'%b %e %H:')\" /var/log/messages | grep kernel | grep banIP/ | wc -l")
     elif service == "openvpn_rw":
         ret = count_openvpn_rw()
 


### PR DESCRIPTION
Modify the grep command to include events from the current hour until now. This ensures that recent threat
shield events are not missed in the dashboard counter.

#781 