### PR TITLE
ns-api: redirects, expand object support

### DIFF
--- a/packages/ns-api/files/ns.redirects
+++ b/packages/ns-api/files/ns.redirects
@@ -213,9 +213,17 @@ def list_zones():
             ret['zones'].append(name)
     return ret
 
+def filter_ranges(obj):
+    # remove host sets with IP ranges
+    if 'subtype' in obj and obj['subtype'] == 'host_set':
+        for ip in obj.get('ipaddr', []):
+            if '-' in ip:
+                return False
+    return True
+
 def list_object_suggestions(u):
     return {
-        "ns_src": objects.list_domain_sets(u),
+        "ns_src": list(filter(filter_ranges, objects.list_objects(u, include_domain_sets=True, include_host_sets=True, expand=True))),
         "ns_dst": objects.list_objects(u, singleton_only=True, include_domain_sets=False)
     }
 

--- a/packages/ns-objects/README.md
+++ b/packages/ns-objects/README.md
@@ -369,7 +369,7 @@ Objects can be used inside the following fields:
 
 Supported object types depends on the field:
 
-- `ns_src` can be any type of object
+- `ns_src` can be any type of object, except for host sets containing an IP range
 - `ns_dst` can be an object with only one IP address, like:
   - a static lease, a record of type `host` from `dhcp` db
   - a dns record, a record of type `domain` from `dhcp` db


### PR DESCRIPTION
The ns_src field can support all object types except for host sets including an IP range

#818 