### PR TITLE
ns-threat_shield: increase default icmp limit

### DIFF
--- a/packages/ns-threat_shield/files/banip-defaults
+++ b/packages/ns-threat_shield/files/banip-defaults
@@ -14,7 +14,7 @@ delete banip.global.ban_logterm
 add_list banip.global.ban_logterm="Exit before auth from"
 add_list banip.global.ban_logterm="authentication failed for user"
 
-set banip.global.ban_icmplimit="10"
+set banip.global.ban_icmplimit="100"
 set banip.global.ban_synlimit="10"
 set banip.global.ban_udplimit="100"
 


### PR DESCRIPTION
The icmp limit could be hit if the network, or the firewall itself, is pinging many hosts for WAN status checking or link quality monitor.