### PR TITLE
ns-api: netdata, fix restart

### DIFF
--- a/packages/ns-api/files/ns.netdata
+++ b/packages/ns-api/files/ns.netdata
@@ -48,7 +48,7 @@ def set_config(config):
         with open(fping_conf_file, 'w') as fp:
             hosts = " ".join(config['hosts'])
             fp.write(f'hosts="{hosts}"\n')
-            subprocess.run(["/etc/init.d/netdata", "restart"], check=True)
+        subprocess.run(["/etc/init.d/netdata", "restart"], check=True)
         return {"success": True}
     except:
         return {"success": False}


### PR DESCRIPTION
Netdata was restarted before the file descriptor of fping.conf was closed.
On stop, netdata was not able to find the fping process to be killed.

#824 