### PR TITLE
Update log rotation size to a dynamic value

### DIFF
--- a/files/usr/sbin/ns-log-size
+++ b/files/usr/sbin/ns-log-size
@@ -22,11 +22,14 @@ get_log_rotation_size() {
 
 set_log_rotation_size() {
     local new_size=$1
+    #The value 9223372036854775807 bytes is the maximum value that can be set (8589.93 GB)
+
+    # Check if the new size is a positive integer
     if [[ ! $new_size =~ ^[0-9]+$ ]]; then
         echo "Error: Size must be a positive integer."
         exit 1
     fi
-    
+
     # Check if the new size is less than the minimum required size
     if (( new_size < MIN_SIZE )); then
         echo "Error: The input size is too low. The minimum value is $MIN_SIZE."

--- a/files/usr/sbin/ns-log-size
+++ b/files/usr/sbin/ns-log-size
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# Get the current log rotation size and update it in the rsyslog configuration file
+# Usage: ns-log-size {get|set <size>}
+# Example: ns-log-size get
+# Example: ns-log-size set 104857600
+# the service must be restarted after the size is changed
+
+
+CONFIG_FILE="/etc/rsyslog.conf"
+LOG_ROTATION_LINE=$(grep -E '^\$outchannel log_rotation' "$CONFIG_FILE")
+MIN_SIZE=52428800
+
+get_log_rotation_size() {
+    local size=$(echo "$LOG_ROTATION_LINE" | awk -F', ' '{print $2}')
+    echo "$size (in bytes)"
+}
+
+set_log_rotation_size() {
+    local new_size=$1
+    if [[ ! $new_size =~ ^[0-9]+$ ]]; then
+        echo "Error: Size must be a positive integer."
+        exit 1
+    fi
+    
+    # Check if the new size is less than the minimum required size
+    if (( new_size < MIN_SIZE )); then
+        echo "Error: The input size is too low. The minimum value is $MIN_SIZE."
+        exit 1
+    fi
+
+    # Full match from start to end
+    sed -i "s/\(\$outchannel log_rotation,\/var\/log\/messages,[ ]*\)[0-9]\+\([ ]*, \/usr\/sbin\/rotate-messages\)/\1$new_size\2/" "$CONFIG_FILE"
+    
+    # Verify if the value was correctly replaced
+    local updated_line
+    updated_line=$(grep -E '^\$outchannel log_rotation' "$CONFIG_FILE")
+    if echo "$updated_line" | grep -q "$new_size"; then
+        echo "Log rotation size updated successfully to $new_size (in bytes)."
+        /etc/init.d/rsyslog restart
+        if [[ $? -ne 0 ]]; then
+            echo "Failed to restart rsyslog service."
+            exit 1
+        fi
+        echo "The rsyslog service has been restarted."
+    else
+        echo "Failed to update log rotation size."
+        exit 1
+    fi
+}
+
+case $1 in
+    get)
+        get_log_rotation_size
+        ;;
+    set)
+        if [[ -z "$2" ]]; then
+            echo "Error: No size provided for set action."
+            exit 1
+        fi
+        set_log_rotation_size "$2"
+        ;;
+    *)
+        echo "Usage: $0 {get|set <size>}"
+        exit 1
+        ;;
+esac

--- a/packages/ns-storage/files/30_ns-storage
+++ b/packages/ns-storage/files/30_ns-storage
@@ -2,9 +2,6 @@
 
 [ "$(uci -q get rsyslog.ns_memory)" == "selector" ] && exit 0
 
-echo '# Rotate in-memory log if size is bigger than 50MB' >> /etc/rsyslog.conf
-echo '$outchannel log_rotation,/var/log/messages, 52428800, /usr/sbin/rotate-messages' >> /etc/rsyslog.conf
-
 uci -q import rsyslog << EOI
 config syslog 'syslog'
 	option tcp_input_port '514'
@@ -21,3 +18,21 @@ config selector ns_memory
 EOI
 
 crontab -l | grep -q '/usr/sbin/logrotate /etc/logrotate.conf' || echo '5 1 * * * /usr/sbin/logrotate /etc/logrotate.conf' >> /etc/crontabs/root
+
+# Default log_size in case of error
+log_size=52428800
+
+# Try to extract tmpfs size, fall back to default log_size if an error occurs
+tmpfs_size=$(df -k /tmp | awk 'NR==2 {print $2}')
+if [ -z "$tmpfs_size" ] || ! echo "$tmpfs_size" | grep -qE '^[0-9]+$'; then
+	echo "Error: Could not retrieve tmpfs size, defaulting log_size to 52428800" >&2
+else
+	# Calculate 10% of tmpfs size in bytes
+	ten_percent_bytes=$(( tmpfs_size * 1024 / 10 ))
+
+	# Use default log_size if the calculated value is less than 52428800
+	if [ "$ten_percent_bytes" -gt "$log_size" ]; then
+		log_size=$ten_percent_bytes
+	fi
+fi
+echo '$outchannel log_rotation,/var/log/messages, '$log_size', /usr/sbin/rotate-messages' >> /etc/rsyslog.conf


### PR DESCRIPTION
This pull request adds a script to adjust manually the size of the log, the service must be restarted after by the sysadmin

```
 ns-log-size get
 ns-log-size set 104857600
```

verify 

`cat /var/etc/rsyslog.conf`


References:
- https://github.com/orgs/NethServer/projects/10/views/2?pane=issue&itemId=81705733
- mattermost talk https://mattermost.nethesis.it/nethesis/pl/sy17gdxa8tr8tj4aptwff4qxfa
- Issue: #865

