### PR TITLE
build: support snapshosts

### DIFF
--- a/builder/build-builder
+++ b/builder/build-builder
@@ -7,12 +7,16 @@
 
 set -e
 
-OWRT_VERSION=$(git describe | cut -d'-' -f1)
+# check env variable OWRT_VERSION is set
+if [ -z "$OWRT_VERSION" ]; then
+    OWRT_VERSION=$(git describe | cut -d'-' -f1)
+fi
 
 if [ -z "$OWRT_VERSION" ]; then
     echo "Missing OWRT_VERSION"
     exit 1
 fi
+
 repobase="ghcr.io/nethserver"
 reponame="nethsecurity-builder"
 
@@ -35,7 +39,13 @@ echo "Creating 'build' user"
 buildah run ${container} -- useradd -s /bin/bash -m build
 
 echo "Downloading OpenWrt $OWRT_VERSION"
-buildah run --user build ${container} -- bash -c "ls /home; cd /home/build && wget https://github.com/openwrt/openwrt/archive/refs/tags/v${OWRT_VERSION}.tar.gz -O openwrt.tgz"
+if [ "$OWRT_VERSION" == "snapshot" ]; then
+    # special value for OWR_VERSION is 'snapshot'
+    echo "Building SNAPSHOT from main branch"
+    buildah run --user build ${container} -- bash -c "ls /home; cd /home/build && wget https://github.com/openwrt/openwrt/archive/refs/heads/main.tar.gz -O openwrt.tgz"
+else
+    buildah run --user build ${container} -- bash -c "ls /home; cd /home/build && wget https://github.com/openwrt/openwrt/archive/refs/tags/v${OWRT_VERSION}.tar.gz -O openwrt.tgz"
+fi
 
 echo "Extracting OpenWrt image"
 buildah run --user build ${container} -- bash -c "cd /home/build && mkdir openwrt && tar xvf openwrt.tgz --strip-components=1 -C openwrt && rm -f openwrt.tgz"
@@ -69,3 +79,4 @@ buildah add "${container}" ../packages /nspackages
 buildah add "${container}" ../patches /patches
 buildah config --user build --workingdir /home/build/openwrt --entrypoint='["/entrypoint.sh"]' --cmd='["/make.sh"]' ${container}
 buildah commit "${container}" "${repobase}/${reponame}"
+build tag "${repobase}/${reponame}" "${repobase}/${reponame}:${OWRT_VERSION}"

--- a/builder/build-builder
+++ b/builder/build-builder
@@ -79,4 +79,4 @@ buildah add "${container}" ../packages /nspackages
 buildah add "${container}" ../patches /patches
 buildah config --user build --workingdir /home/build/openwrt --entrypoint='["/entrypoint.sh"]' --cmd='["/make.sh"]' ${container}
 buildah commit "${container}" "${repobase}/${reponame}"
-build tag "${repobase}/${reponame}" "${repobase}/${reponame}:${OWRT_VERSION}"
+buildah tag "${repobase}/${reponame}" "${repobase}/${reponame}:${OWRT_VERSION}"

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -136,7 +136,7 @@ To build a snapshot locally, follow these steps:
     ```
     IMAGE_TAG=snapshot ./run
     ```
-    Since multiple versions of OpenWrt can't be build using the same directory, the snaphost build will use
+    Since multiple versions of OpenWrt can't be built using the same directory, the snaphost build will use
     different podman volume named with `_snapshot` suffix, like `nethsecurity-build_dir_snapshot`
 
 ## Versioning

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -130,7 +130,7 @@ To build a snapshot locally, follow these steps:
    OWRT_VERSION=snapshot ./build-builder
    popd
    ```
-   This will create an image named `ghcr.io/nethserver/nethsecurity-builder:snapshot` than will be used to build the output image
+   This will create an image named `ghcr.io/nethserver/nethsecurity-builder:snapshot` that will be used to build the output image
 
 2. Build the image using the builder:
     ```

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -77,24 +77,11 @@ During the start-up, the container will:
 - generate the diffconfig
 - generate a random public key to sign packages
 
-### Build locally for a release
-
-If you need to build some packages locally for a release, make sure the following environment variables are set:
-- `USIGN_PUB_KEY` and `USIGN_PRIV_KEY`: make sure to read the whole key file using `cat` and set the content as the environment variable
-- `NETIFYD_ACCESS`: required to download and compile netifyd closed source plugins
-
-Then execute the `run` script:
-```
-NETIFYD_ACCESS_TOKEN=xxxUSIGN_PUB_KEY=$(cat nethsecurity-pub.key) USIGN_PRIV_KEY=$(cat nethsecurity-priv.key) ./run 
-```
-
-See the [manual release process](../development_process/#manually-releasing-packages) for more info.
-
 ### Environment variables
 
 The `run` script behavior can be changed using the following environment variables:
 
-- `IMAGE_TAG`: specify the image tag of the builder; if not set default is `latest`
+- `IMAGE_TAG`: specify the image tag of the builder; if not set default is `latest`, the special value `snapshot` will build a snapshot from the OpenWrt main branch
 - `USIGN_PUB_KEY` and `USIGN_PRIV_KEY`: see [package signing section](#package-signing)
    with the given keys
 - `NETIFYD_ACCESS_TOKEN`: GitLab private access token; if set, download and compile netifyd closed
@@ -117,6 +104,40 @@ TAG=$(podman images --quiet ghcr.io/nethserver/nethsecurity-builder:latest)
 podman tag $TAG ghcr.io/nethserver/nethsecurity-builder:$IMAGE_TAG
 ./run
 ```
+
+### Build locally for a release
+
+If you need to build some packages locally for a release, make sure the following environment variables are set:
+- `USIGN_PUB_KEY` and `USIGN_PRIV_KEY`: make sure to read the whole key file using `cat` and set the content as the environment variable
+- `NETIFYD_ACCESS`: required to download and compile netifyd closed source plugins
+
+Then execute the `run` script:
+```
+NETIFYD_ACCESS_TOKEN=xxxUSIGN_PUB_KEY=$(cat nethsecurity-pub.key) USIGN_PRIV_KEY=$(cat nethsecurity-priv.key) ./run 
+```
+
+See the [manual release process](../development_process/#manually-releasing-packages) for more info.
+
+### Build locally a snapshot
+
+A snapshot is a build that is based on OpenWrt main branch.
+
+To build a snapshot locally, follow these steps:
+
+1. Build the image builder based on main branch:
+   ```
+   pushd builder
+   OWRT_VERSION=snapshot ./build-builder
+   popd
+   ```
+   This will create an image named `ghcr.io/nethserver/nethsecurity-builder:snapshot` than will be used to build the output image
+
+2. Build the image using the builder:
+    ```
+    IMAGE_TAG=snapshot ./run
+    ```
+    Since multiple versions of OpenWrt can't be build using the same directory, the snaphost build will use
+    different podman volume named with `_snapshot` suffix, like `nethsecurity-build_dir_snapshot`
 
 ## Versioning
 

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -113,7 +113,7 @@ If you need to build some packages locally for a release, make sure the followin
 
 Then execute the `run` script:
 ```
-NETIFYD_ACCESS_TOKEN=xxxUSIGN_PUB_KEY=$(cat nethsecurity-pub.key) USIGN_PRIV_KEY=$(cat nethsecurity-priv.key) ./run 
+NETIFYD_ACCESS_TOKEN=xxx USIGN_PUB_KEY=$(cat nethsecurity-pub.key) USIGN_PRIV_KEY=$(cat nethsecurity-priv.key) ./run 
 ```
 
 See the [manual release process](../development_process/#manually-releasing-packages) for more info.

--- a/run
+++ b/run
@@ -49,7 +49,11 @@ fi
 
 # Setup cache volumes
 if [ $cache -ge 1 ]; then
-    opts=" -v nethsecurity-build_dir:/home/build/openwrt/build_dir:z -v nethsecurity-staging_dir:/home/build/openwrt/staging_dir:z -v nethsecurity-ccache:/home/build/openwrt/.ccache -v nethsecurity-download:/home/build/openwrt/download"
+    vsuffix=""
+    if [ "$image_tag" == "snapshot" ]; then
+        vsuffix="_snapshot"
+    fi
+    opts=" -v nethsecurity-build_dir$vsuffix:/home/build/openwrt/build_dir:z -v nethsecurity-staging_dir$vsuffix:/home/build/openwrt/staging_dir:z -v nethsecurity-ccache$vsuffix:/home/build/openwrt/.ccache -v nethsecurity-download$vsuffix:/home/build/openwrt/download"
 fi
 
 # Download latest image
@@ -68,6 +72,11 @@ if [ -z "${VERSION}" ]; then
     git fetch --prune --unshallow &> /dev/null
     VERSION=$(git describe)
 fi
+# Force snapshot version for snapshot builds
+if [ "$image_tag" == "snapshot" ]; then
+    VERSION="snapshot"
+fi
+
 # OWRT_VERSION is like 23.05.2
 OWRT_VERSION=$(echo $VERSION | cut -d'-' -f1)
 # NS_VERSION is a semver release like '1.0.0' for stable and '1.0.0-alpha1' or '1.0.0-234-g1bc543c' for dev
@@ -84,6 +93,10 @@ if [ -z "$PRE_RELEASE" ]; then
      REPO_CHANNEL="stable"
  else
      REPO_CHANNEL="dev"
+fi
+# Force snapshot channel for snapshot builds
+if [ "$image_tag" == "snapshot" ]; then
+    REPO_CHANNEL="snapshot"
 fi
 
 export REPO_CHANNEL


### PR DESCRIPTION
Use special parameters to build an image based on OpenWrt snapshot. Snapshots can be used to test upcoming changes.

How to use:

1. build the image builder based on main branch:
   ```
   pushd builder
   OWRT_VERSION=snapshot ./build-builder
   popd
   ```
   This will create an image named `ghcr.io/nethserver/nethsecurity-builder:snapshot` than will be used to build the output image
2. build the image using the builder:
    ```
    IMAGE_TAG=snapshot ./run
    ```
    Since multiple versions of OpenWrt can't be build using the same directory, the snaphost build will use 
    different podman volume named with `_snapshot` suffix, like `nethsecurity-build_dir_snapshot`
