### PR TITLE
Remove keepalive option from PPPoE

### DIFF
--- a/files/etc/uci-defaults/99-nethsec-pppoe
+++ b/files/etc/uci-defaults/99-nethsec-pppoe
@@ -1,0 +1,1 @@
+/usr/share/ns-api/remove-pppoe-keepalive

--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -39,6 +39,7 @@ define Package/ns-api/postinst
 if [ -z "$${IPKG_INSTROOT}" ]; then
   /etc/init.d/rpcd restart
 fi
+/usr/share/ns-api/remove-pppoe-keepalive
 exit 0
 endef
 
@@ -58,6 +59,7 @@ endef
 define Package/ns-api/install
 	$(INSTALL_DIR) $(1)/usr/libexec/rpcd/
 	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_DIR) $(1)/usr/share/ns-api/
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/usr/libexec/ns-api/
@@ -167,6 +169,7 @@ define Package/ns-api/install
 	$(INSTALL_BIN) ./files/pre-commit/update-objects.py $(1)/usr/libexec/ns-api/pre-commit
 	$(INSTALL_BIN) ./files/post-commit/configure-netifyd.py $(1)/usr/libexec/ns-api/post-commit
 	$(INSTALL_BIN) ./files/post-commit/reload-ipsets.py $(1)/usr/libexec/ns-api/post-commit
+	$(INSTALL_BIN) ./files/remove-pppoe-keepalive $(1)/usr/share/ns-api
 endef
  
 $(eval $(call BuildPackage,ns-api))

--- a/packages/ns-api/files/ns.devices
+++ b/packages/ns-api/files/ns.devices
@@ -652,7 +652,6 @@ def set_network_configuration(device_type, interface_name, logical_type, interfa
         elif protocol == 'pppoe':
             values['username'] = pppoe_username
             values['password'] = pppoe_password
-            values['keepalive'] = '0 1'
             if ip6_enabled:
                 values['ipv6'] = 'auto'
         elif protocol in ['dhcp', 'dhcpv6']:

--- a/packages/ns-api/files/remove-pppoe-keepalive
+++ b/packages/ns-api/files/remove-pppoe-keepalive
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Remove PPPoE keepalive option: issue #843
+sed -i "/option keepalive '0 1'/d" /etc/config/network


### PR DESCRIPTION
The PPPoE connection does not reconnect after a disconnection when the keepalive option is set.

Please note that the change is not applied until a network interface restart is executed.

#843 