### PR TITLE
fix(ns-api): restarting fw4 when ipset changes

### DIFF
--- a/packages/ns-api/files/post-commit/reload-ipsets.py
+++ b/packages/ns-api/files/post-commit/reload-ipsets.py
@@ -18,4 +18,4 @@ if 'firewall' in changes:
             break
 
 if force_reload:
-    subprocess.run(["/sbin/fw4", "reload-sets"])
+    subprocess.run(["/sbin/fw4", "restart"])


### PR DESCRIPTION
Due to a unkown issue, if an ipset is being changed in uci and committed, no changes are triggered in the nft definitions. This is the only way to enforce such change. It appears that the previous `reload-sets` reloads only the files attached to the ipsets definitions.

Refs:
- https://forum.openwrt.org/t/add-ip-to-ipset-in-fw4-do-not-work/160334
- https://github.com/NethServer/nethsecurity/issues/896
