### PR TITLE
fix(nginx): using nohostname for logs

### DIFF
--- a/files/etc/uci-defaults/99-nethsec-nginx
+++ b/files/etc/uci-defaults/99-nethsec-nginx
@@ -1,6 +1,6 @@
 uci -q batch << EOI
-set nginx._lan.error_log=syslog:server=unix:/dev/log
-set nginx._lan.access_log=syslog:server=unix:/dev/log
+set nginx._lan.error_log=syslog:server=unix:/dev/log,nohostname
+set nginx._lan.access_log=syslog:server=unix:/dev/log,nohostname
 commit nginx
 EOI
 

--- a/packages/ns-ui/files/ns-ui
+++ b/packages/ns-ui/files/ns-ui
@@ -42,8 +42,8 @@ server {
 	ssl_certificate_key $key;
 	ssl_session_cache shared:SSL:32k;
 	ssl_session_timeout 64m;
-	error_log syslog:server=unix:/dev/log;
-	access_log syslog:server=unix:/dev/log;
+	error_log syslog:server=unix:/dev/log,nohostname;
+	access_log syslog:server=unix:/dev/log,nohostname;
 
 	# enable NS UI
 	location / {


### PR DESCRIPTION
The fix will be available on fresh installations or image upgrades due to the edit of a uci-defaults.
This doesn't apply to nginxs that have the reverse proxy on a different port due to the configuration overwrite.

Ref:
- https://github.com/NethServer/nethsecurity/issues/897
