### PR TITLE
Enhance interface filtering and ensure uniqueness in netifyd configuration

### DIFF
--- a/packages/ns-dpi/README.md
+++ b/packages/ns-dpi/README.md
@@ -23,6 +23,7 @@ Global options:
 - `firewall_exemption`: can be `0` or `1`, if set to `1` all firewall IP addresses will be
   added to global exemption list and will not match DPI rules
 - `popular_filters`: list of filters that will be returned to from `api-cli ns.dpi list-popular` call.
+- `exclude`: list of network interface exclusions in Netifyd that will be returned by `uci show netifyd.@netifyd[0].exclude`
 
 Rule options:
 
@@ -144,4 +145,34 @@ The placeholders will be replaced with systemd id and secret from `ns-plug`.
 Example:
 ```
 HOST=http://__USER__:__PASSWORD__@sp.gs.nethserver.net dpi-update
+```
+
+## Managing Interface Exclusions in Netifyd
+
+By default, Netifyd monitors all interfaces. To exclude specific interfaces, you can define an exclusion list. Below are commands to add, modify, or remove excluded interfaces.
+
+- Add interfaces to exclusion list
+```
+uci add_list netifyd.@netifyd[0].exclude='eth1'
+uci add_list netifyd.@netifyd[0].exclude='tun'
+uci add_list netifyd.@netifyd[0].exclude='wg'
+uci commit netifyd
+```
+
+- Modify exclusion list
+```
+uci delete netifyd.@netifyd[0].exclude='eth1'
+uci add_list netifyd.@netifyd[0].exclude='eth2'
+uci commit netifyd
+```
+
+- Clear exclusion list
+```
+uci delete netifyd.@netifyd[0].exclude
+uci commit netifyd
+```
+
+- Return the exclusion list
+```
+uci show netifyd.@netifyd[0].exclude
 ```


### PR DESCRIPTION
Improve the filtering of network interfaces by excluding specified patterns and ensure that internal and external interfaces are unique and sorted in the netifyd configuration.

https://github.com/NethServer/nethsecurity/issues/929

we can remove by the cli some interface (we look by startswith, so `wg` == `wg*`
- how to add an exclusion list 
```
uci add_list netifyd.@netifyd[0].exclude='eth1'
uci add_list netifyd.@netifyd[0].exclude='tun'
uci add_list netifyd.@netifyd[0].exclude='wg'
uci commit netifyd
```
- how to add and remove item of the exclusion list 
```
uci delete netifyd.@netifyd[0].exclude='eth1'
uci add_list netifyd.@netifyd[0].exclude='eth2'
uci commit netifyd
```
- how to remove completely the exclusion list
```
uci delete netifyd.@netifyd[0].exclude
uci commit netifyd
```