### PR TITLE
fix(ns-api): dashboard, improve internet check

### DIFF
--- a/packages/ns-api/files/ns.dashboard
+++ b/packages/ns-api/files/ns.dashboard
@@ -95,7 +95,7 @@ def check_internet():
     hosts = ("8.8.8.8", "one.one.one.one", "www.nethserver.org", "gstatic.com")
     for host in hosts:
         try:
-            subprocess.check_output(["ping", "-c", "1", host])
+            subprocess.run(["ping", "-c", "1", host], check=True, capture_output=True)
             success = success + 1
             if success >= (len(hosts) / 2):
                 return "ok"


### PR DESCRIPTION
Do not output anything on stderr if some
hosts fail to be resolved.

#945 