### PR TITLE
fix(ns-api): fix ns.ovpnrw list-users

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -540,6 +540,8 @@ def list_users(ovpninstance):
     connected = ovpn.list_connected_clients(ovpninstance)
     expirations = list_user_expirations(ovpninstance)
     db = u.get("openvpn", ovpninstance, "ns_user_db", default=None)
+    if not db:
+        return {"users": []}
     db_users = users.list_users(u, db)
     try:
        tags = u.get_all("openvpn", ovpninstance, "ns_tag")


### PR DESCRIPTION
Fix `ns.ovpnrw list-users` API. If the OVPN instance exists but hasn't been configured, return an empty list. Previously, the `list-users`  would throw an exception in this scenario.

Ref:
- https://github.com/NethServer/nethsecurity/issues/943