### PR TITLE
fix(ns-api): improve dpireport details

### DIFF
--- a/packages/ns-api/files/ns.dpireport
+++ b/packages/ns-api/files/ns.dpireport
@@ -205,6 +205,9 @@ def summary_v2(year=None, month=None, day=None, narrow_client=None, narrow_secti
             'traffic': raw_client_total_traffic
         })
 
+    # do not display empty values when seeing details
+    if narrow_section and narrow_value:
+        raw_clients = [client for client in raw_clients if client['traffic'] > 0]
     raw_clients.sort(key=lambda x: x['traffic'], reverse=True)
     final_clients = raw_clients[:limit]
 


### PR DESCRIPTION
When showing details of network traffic, do not
display hosts with 0 bytes of traffic

Before:
![Screenshot from 2024-12-06 09-13-23](https://github.com/user-attachments/assets/3bf8ded6-3745-4df7-bdc9-b45b5f5f21d5)


After:
![image](https://github.com/user-attachments/assets/ba798df4-47e6-4a01-a269-fbfa4e482bdd)
