### PR TITLE
ns-storage: fix named section after upgrade

### DIFF
--- a/packages/ns-api/files/ns.storage
+++ b/packages/ns-api/files/ns.storage
@@ -20,6 +20,12 @@ def run(cmd):
     except:
         return utils.generic_error("command_failed")
 
+def get_storage_info(u):
+    for section in utils.get_all_by_type(u, 'fstab', 'mount'):
+        if u.get('fstab', section, 'target', default='') == '/mnt/data':
+            return u.get_all('fstab', section)
+    return None
+
 def list_devices():
     devices = []
     p = subprocess.run(["/usr/bin/lsblk", "--json", "-b", "--output-all"], check=True, capture_output=True, text=True)
@@ -63,7 +69,7 @@ def get_configuration():
 
     ret = {"name": None, "size": None, "path": None, "model": None, "vendor": None}
     try:
-        info = u.get_all("fstab", "ns_data")
+        info = get_storage_info(u)
         p = subprocess.run(["/usr/bin/lsblk", "--json", "-b", "--output-all"], check=True, capture_output=True, text=True)
         data = json.loads(p.stdout)
         cur = None

--- a/packages/ns-api/files/ns.storage
+++ b/packages/ns-api/files/ns.storage
@@ -21,10 +21,17 @@ def run(cmd):
         return utils.generic_error("command_failed")
 
 def get_storage_info(u):
+    ret = None
     for section in utils.get_all_by_type(u, 'fstab', 'mount'):
         if u.get('fstab', section, 'target', default='') == '/mnt/data':
-            return u.get_all('fstab', section)
-    return None
+            ret = u.get_all('fstab', section)
+            if section != 'ns_data':
+                # Fix section name that get lost during the upgrade:
+                # the section name is used by remove-storage script
+                u.rename('fstab', section, 'ns_data')
+                u.commit('fstab')
+            break
+    return ret
 
 def list_devices():
     devices = []


### PR DESCRIPTION
This pull request introduces a new function to improve how storage information is retrieved and used in the `ns.storage` module. It also makes sure that the fstab section is always named `ns_data`.

#960 