### PR TITLE
Snort: support queue_maxlen

### DIFF
--- a/packages/ns-api/files/ns.snort
+++ b/packages/ns-api/files/ns.snort
@@ -118,6 +118,7 @@ def setup(enabled, set_home_net = False, include_vpn = False, ns_policy = 'balan
         uci.set('snort', 'snort', 'method', 'nfq')
         uci.set('snort', 'snort', 'external_net', '!$HOME_NET')
         uci.set('snort', 'nfq', 'chain_type', 'forward')
+        uci.set('snort', 'nfq', 'queue_maxlen', '4096')
 
     # always set the number of threads to the number of CPUs
     # if the hardware changes, a new setup is required

--- a/packages/snort3/files/snort.init
+++ b/packages/snort3/files/snort.init
@@ -96,7 +96,11 @@ start_service() {
 	procd_open_instance
 	if [ "$manual" = 0 ]; then
 		local config_file=$($MGR setup)
-		procd_set_param command "$PROG" -c "${config_file}" --tweaks ns_local
+	        maxlen=$(uci -q get snort.nfq.queue_maxlen)
+		if [ -z "${maxlen}" ]; then
+			maxlen=1024
+		fi
+		procd_set_param command "$PROG" -c "${config_file}" --tweaks ns_local --daq nfq --daq-var queue_maxlen=${maxlen}
 	else
 		procd_set_param command $PROG -q -i "$interface" -c "${config_dir%/}/snort.lua" --tweaks local
 		procd_set_param env SNORT_LUA_PATH="$config_dir"


### PR DESCRIPTION
Changes:
- setup queue_maxlen as startup parameter
- set as queue_maxlen to 4096 during the first configuration, the value can be changed later manually using uci command line
