### PR TITLE
feat(conf): add speedtestcpp package

### DIFF
--- a/config/speedtest.conf
+++ b/config/speedtest.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_speedtestcpp=y


### PR DESCRIPTION
Add the speedtestcpp package to run speed tests from the command-line.

Note: best server selection seems to fail sometimes, giving non-optimal results.
Try again with `speedtest --force-by-latency-test` to see if a different server is selected.
