### PR TITLE
fix(workflow): status update only for open issues

### DIFF
--- a/.github/workflows/change-status-on-labels.yml
+++ b/.github/workflows/change-status-on-labels.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   update-project-status:
+    if: ${{ github.event.issue.state == 'open' }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -52,7 +53,7 @@ jobs:
           fi
       - name: Set new status
         id: status
-        if: ${{ steps.labeled.outputs.status != 'skip' || steps.unlabeled.outputs.status != 'skip' }}
+        if: ${{ steps.labeled.outputs.status && steps.labeled.outputs.status != 'skip' || steps.unlabeled.outputs.status && steps.unlabeled.outputs.status != 'skip' }}
         run: |
           scripts/update_issue_status.sh --owner "$OWNER" --repo "$REPO" --issue-number "$ISSUE_NUMBER" --new-status "$NEW_STATUS"
         env:


### PR DESCRIPTION
Add condition to check if the issue is open before running the
`update-project-status` job. This prevents unnecessary operations on
closed issues. Also, refine the condition for setting the new status
to ensure it only runs when a valid status is present.
