### PR TITLE
chore(ns-api): bump minor release

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-api
-PKG_VERSION:=2.0.3
+PKG_VERSION:=2.1.0
 PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-api-$(PKG_VERSION)


### PR DESCRIPTION
Updating `ns-api` version due to Monitoring changes, this helps controller to recognise the changes and prompt confirmation for access.

