### PR TITLE
fix(ns-api): gracefully handle error when checking for updates

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -21,7 +21,7 @@ define Package/ns-api
 	CATEGORY:=NethSecurity
 	TITLE:=NethSecurity REST API
 	URL:=https://github.com/NethServer/nethsecurity-controller/
-	DEPENDS:=+python3-nethsec +python3-openssl +python3-urllib +python3-idna
+	DEPENDS:=+python3-nethsec +python3-openssl +python3-urllib +python3-idna +python3-requests
 	PKGARCH:=all
 endef
 

--- a/packages/ns-api/files/ns.update
+++ b/packages/ns-api/files/ns.update
@@ -11,9 +11,8 @@ import os
 import sys
 import json
 import time
-import urllib
 import subprocess
-import urllib.request
+import requests
 from nethsec import utils
 from urllib.parse import urlparse
 from euci import EUci
@@ -89,19 +88,30 @@ def install_package_updates():
 def check_system_update():
     e_uci = EUci()
     current_version = get_system_version()
-    ret = {"currentVersion": f'NethSecurity {current_version}', "lastVersion": "", "scheduledAt": get_update_schedule()}
+    data = {"currentVersion": f'NethSecurity {current_version}', "lastVersion": "", "scheduledAt": get_update_schedule()}
+    url = e_uci.get('ns-plug', 'config', 'repository_url')
+    if e_uci.get('ns-plug', 'config', 'system_id', default=None) is None:
+        url = f"{url}/{get_distfeed_channel()}"
     try:
-        url = e_uci.get('ns-plug', 'config', 'repository_url')
-        if (e_uci.get('ns-plug', 'config', 'system_id', default=None) is None):
-            url = f"{url}/{get_distfeed_channel()}"
-
-        p = subprocess.run(["/usr/bin/curl", "-L", "-s", f"{url}/latest_release"], check=True, capture_output=True, text=True)
-        version = p.stdout.rstrip()
+        response = requests.get(f"{url}/latest_release", headers={"Accept": "application/json"}, timeout=5)
+        response.raise_for_status()
+        version = response.text.strip()
         if current_version != version:
-            ret["lastVersion"] = f'NethSecurity {version}'
-    except Exception as e:
-        print(e, file=sys.stderr)
-    return ret
+            data["lastVersion"] = f'NethSecurity {version}'
+    except requests.exceptions.ConnectionError:
+        return utils.generic_error("connection_error")
+    except requests.exceptions.RequestException as e:
+        match e.response.status_code:
+            case requests.codes.service_unavailable:
+                return utils.generic_error("maintenance")
+            case requests.codes.unauthorized:
+                return utils.generic_error("unauthorized")
+            case _:
+                return utils.generic_error("server_error")
+    except Exception:
+        return utils.generic_error("generic_error")
+
+    return data
 
 def schedule_system_update(timestamp):
     if timestamp < 0:

--- a/packages/ns-api/files/ns.update
+++ b/packages/ns-api/files/ns.update
@@ -89,7 +89,9 @@ def check_system_update():
     e_uci = EUci()
     current_version = get_system_version()
     data = {"currentVersion": f'NethSecurity {current_version}', "lastVersion": "", "scheduledAt": get_update_schedule()}
-    url = e_uci.get('ns-plug', 'config', 'repository_url')
+    url = e_uci.get('ns-plug', 'config', 'repository_url', default=None)
+    if url is None:
+        return utils.generic_error("repository_url_not_set")
     if e_uci.get('ns-plug', 'config', 'system_id', default=None) is None:
         url = f"{url}/{get_distfeed_channel()}"
     try:


### PR DESCRIPTION
If for any reason the upstream update server goes offline (both community and enterprise repositories), several issues arise while viewing the Updates page.
By adding the `python3-requests` package it's possible to figure what is going wrong and what happened to the request, leaving the UI with specific error messages that allows to tell the user exactly what is going on.