### PR TITLE
mwan3: run user scripts in backgorund

### DIFF
--- a/packages/ns-plug/files/40_ns-plug_mwan_hooks
+++ b/packages/ns-plug/files/40_ns-plug_mwan_hooks
@@ -1,2 +1,3 @@
 # setup mwan3 custom scripts
-grep -q '/usr/libexec/ns-plug/mwan-hooks' /etc/mwan3.user || echo '/usr/libexec/ns-plug/mwan-hooks' >> /etc/mwan3.user
+grep -q '/usr/libexec/ns-plug/mwan-hooks &' /etc/mwan3.user || echo '/usr/libexec/ns-plug/mwan-hooks &' >> /etc/mwan3.user
+sed -i 's#^/usr/libexec/ns-plug/mwan-hooks$#/usr/libexec/ns-plug/mwan-hooks \&#' /etc/mwan3.user


### PR DESCRIPTION
/etc/mwan3.user should finish in a timely manner.
See https://openwrt.org/docs/guide-user/network/wan/multiwan/mwan3#alertsnotifications
As of today, the only script is send-mwan-alert which can take 3 minutes.

https://github.com/NethServer/nethsecurity/issues/1014