### PR TITLE
ns-plug: mwan3 hooks needs bash

### DIFF
--- a/packages/ns-plug/files/mwan-hooks
+++ b/packages/ns-plug/files/mwan-hooks
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Copyright (C) 2024 Nethesis S.r.l.


### PR DESCRIPTION
The script uses a bash-only syntax. Using bash gives the following error: /usr/libexec/ns-plug/mwan-hooks: line 17: failed_count++: not found