### PR TITLE
feat(snort): adding API for UI

### DIFF
--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -7792,6 +7792,65 @@ If `include_vpn` is `true`, the API will include the VPN networks in the `HOME_N
 The `ns_policy` can be `balanced`, `security` or `connectivity` or `max-detect`.
 The `ns_disabled_rules` is a list of SIDs (integer) of rules to be disabled.
 
+### status
+
+Returns the configuration set for `snort`.
+
+```bash
+api-cli ns.snort status
+```
+
+Response example:
+
+```json
+{
+  "enabled": true,
+  "ns_policy": "connectivity",
+  "oinkcode": "123456789"
+}
+```
+
+### save
+
+Set `snort` configuration
+
+```bash
+api-cli ns.snort save --data '{"enabled": true, "ns_policy": "balanced", "oinkcode": "123456789"}'
+```
+
+### check-oinkcode
+
+Checks if the provided oinkcode is valid
+
+```bash
+api-cli ns.snort check-oinkcode --data '{"oinkcode": "123456789"}'
+```
+
+Response example:
+
+```json
+{
+  "status": "success"
+}
+```
+
+or 
+
+```json
+{
+  "validation": {
+    "errors": [
+      {
+        "message": "invalid",
+        "parameter": "oinkcode",
+        "value": ""
+      }
+    ]
+  }
+}
+```
+
+
 ## ns.wireguard
 
 Configure WireGuard VPN both in Road Warrior and site-to-site mode.

--- a/packages/ns-api/files/ns.snort
+++ b/packages/ns-api/files/ns.snort
@@ -107,7 +107,7 @@ def remove_download_cron_job():
                 f.write(line)
 
 
-def setup(enabled, set_home_net=False, include_vpn=False, ns_policy='balanced'):
+def __setup(enabled, set_home_net=False, include_vpn=False, ns_policy='balanced'):
     uci = EUci()
 
     # first setup
@@ -145,7 +145,6 @@ cmd = sys.argv[1]
 
 if cmd == 'list':
     print(json.dumps({
-        "setup": {"enabled": True, "set_home_net": True, "include_vpn": False, "ns_policy": "balanced"},
         "status": {
             "enabled": True,
             "ns_policy": "balanced",
@@ -157,12 +156,7 @@ if cmd == 'list':
 else:
     try:
         action = sys.argv[2]
-        if action == "setup":
-            data = json.JSONDecoder().decode(sys.stdin.read())
-            setup(data.get('enabled', True), data.get('set_home_net', True), data.get('include_vpn', False),
-                  data.get('ns_policy', 'connectivity'), data.get('ns_disabled_rules', []))
-            print(json.dumps({"status": "success"}))
-        elif action == "status":
+        if action == "status":
             e_uci = EUci()
             response = {
                 "enabled": e_uci.get('snort', 'snort', 'enabled', dtype=bool, default=False),
@@ -181,7 +175,7 @@ else:
             if data['ns_policy'] not in ['connectivity', 'balanced', 'security']:
                 raise ValidationError('ns_policy', 'invalid')
 
-            setup(data.get('enabled'), ns_policy=data.get('ns_policy'))
+            __setup(data.get('enabled'), ns_policy=data.get('ns_policy'))
             e_uci = EUci()
             e_uci.set('snort', 'snort', 'oinkcode', data.get('oinkcode', ''))
             e_uci.save('snort')

--- a/packages/ns-api/files/ns.snort
+++ b/packages/ns-api/files/ns.snort
@@ -8,13 +8,14 @@
 # Read SSH authorized keys
 
 import os
-import json
 import subprocess
 import json
 import sys
 import ipaddress
 from nethsec import utils
 from euci import EUci
+from nethsec.utils import ValidationError
+
 
 # Retrieve all non-WAN interfaces and their IP addresses
 # It also return the IP address of VPN interfaces
@@ -105,7 +106,8 @@ def remove_download_cron_job():
             if 'ns-snort-rules' not in line:
                 f.write(line)
 
-def setup(enabled, set_home_net = False, include_vpn = False, ns_policy = 'balanced', ns_disabled_rules = []):
+
+def setup(enabled, set_home_net=False, include_vpn=False, ns_policy='balanced'):
     uci = EUci()
 
     # first setup
@@ -129,7 +131,6 @@ def setup(enabled, set_home_net = False, include_vpn = False, ns_policy = 'balan
         uci.set('snort', 'snort', 'home_net', get_snort_homenet(uci, include_vpn))
 
     uci.set('snort', 'snort', 'ns_policy', ns_policy)
-    uci.set('snort', 'snort', 'ns_disabled_rules', ns_disabled_rules)
 
     if enabled:
         uci.set('snort', 'snort', 'enabled', '1')
@@ -144,12 +145,63 @@ cmd = sys.argv[1]
 
 if cmd == 'list':
     print(json.dumps({
-        "setup": {"enabled": True, "set_home_net": True, "include_vpn": False, "ns_policy": "balanced", "ns_disabled_rules": []},
+        "setup": {"enabled": True, "set_home_net": True, "include_vpn": False, "ns_policy": "balanced"},
+        "status": {
+            "enabled": True,
+            "ns_policy": "balanced",
+            "oinkcode": "1234567890",
+        },
+        "save": {"enabled": True, "ns_policy": "balanced", "oinkcode": "1234567890"},
+        "check-oinkcode": {},
         }))
 else:
-    action = sys.argv[2]
-    if action == "setup":
-        data = json.JSONDecoder().decode(sys.stdin.read())
-        setup(data.get('enabled', True), data.get('set_home_net', True), data.get('include_vpn', False), data.get('ns_policy', 'connectivity'), data.get('ns_disabled_rules', []))
-        print(json.dumps({"status": "success"}))
-        
+    try:
+        action = sys.argv[2]
+        if action == "setup":
+            data = json.JSONDecoder().decode(sys.stdin.read())
+            setup(data.get('enabled', True), data.get('set_home_net', True), data.get('include_vpn', False),
+                  data.get('ns_policy', 'connectivity'), data.get('ns_disabled_rules', []))
+            print(json.dumps({"status": "success"}))
+        elif action == "status":
+            e_uci = EUci()
+            response = {
+                "enabled": e_uci.get('snort', 'snort', 'enabled', dtype=bool, default=False),
+                "ns_policy": e_uci.get('snort', 'snort', 'ns_policy', default='connectivity'),
+                "oinkcode": e_uci.get('snort', 'snort', 'oinkcode', default=''),
+            }
+            print(json.dumps(response))
+        elif action == "save":
+            data = json.load(sys.stdin)
+            if 'enabled' not in data:
+                raise ValidationError('enabled', 'required')
+            if not isinstance(data['enabled'], bool):
+                raise ValidationError('enabled', 'invalid')
+            if 'ns_policy' not in data:
+                raise ValidationError('ns_policy', 'required')
+            if data['ns_policy'] not in ['connectivity', 'balanced', 'security']:
+                raise ValidationError('ns_policy', 'invalid')
+
+            setup(data.get('enabled'), ns_policy=data.get('ns_policy'))
+            e_uci = EUci()
+            e_uci.set('snort', 'snort', 'oinkcode', data.get('oinkcode', ''))
+            e_uci.save('snort')
+        elif action == "check-oinkcode":
+            data = json.load(sys.stdin)
+            if 'oinkcode' not in data:
+                raise ValidationError('oinkcode', 'required')
+            res = subprocess.run([
+                "curl",
+                "--fail",
+                "--location",
+                "--output",
+                "/dev/null",
+                # remember to change the URL even in the `ns-snort-rules` script
+                f"https://www.snort.org/rules/snortrules-snapshot-31470.tar.gz?oinkcode={data.get('oinkcode')}"],
+                capture_output=True)
+            if res.returncode != 0:
+                raise ValidationError('oinkcode', 'invalid')
+            print(json.dumps({"status": "success"}))
+        else:
+            utils.validation_error('action', 'invalid')
+    except ValidationError as e:
+        print(json.dumps(utils.validation_error(e.parameter, e.message, e.value)))

--- a/packages/ns-api/files/ns.snort
+++ b/packages/ns-api/files/ns.snort
@@ -202,6 +202,6 @@ else:
                 raise ValidationError('oinkcode', 'invalid')
             print(json.dumps({"status": "success"}))
         else:
-            utils.validation_error('action', 'invalid')
+            print(json.dumps(utils.generic_error(f"Unknown action: {action}")))
     except ValidationError as e:
         print(json.dumps(utils.validation_error(e.parameter, e.message, e.value)))

--- a/packages/snort3/files/ns-snort-rules
+++ b/packages/snort3/files/ns-snort-rules
@@ -56,6 +56,7 @@ def generate_testing_rules():
 def download_official_rules(oinkcode):
     if oinkcode:
         log("Downloading subscriber rules...")
+        # remember to change the URL even in the `ns.snort` script
         url = f"https://www.snort.org/rules/snortrules-snapshot-31470.tar.gz?oinkcode={oinkcode}"
         archive_loc = f"snortrules-snapshot-{oinkcode}"
     else:

--- a/packages/snort3/files/snort.init
+++ b/packages/snort3/files/snort.init
@@ -26,33 +26,33 @@ update_bypass_set() {
 	else
 		echo -n "elements = {" > $set_file
 		for ip in $ips; do
-			 echo -n "$(echo "$ip" | cut -d, -f1)," >> $set_file
+			echo -n "$(echo "$ip" | cut -d, -f1)," >> $set_file
 		done
 		echo " }" >> $set_file
-    fi
+	fi
 }
 
 download_rules () {
-  oinkcode="$(uci -q get snort.snort.oinkcode)"
-  if [ -n "$oinkcode" ]; then
-    rm -f /var/ns-snort/*community-rules.tar.gz
-    rules="$(find /var/ns-snort -type f -name "snortrules-*.tar.gz")"
-    [ -n "$rules" ] && return
-  else
-    rm -f /var/ns-snort/snortrules-*.tar.gz
-    rules="$(find /var/ns-snort/ -type f -name "*community-rules.tar.gz")"
-    [ -n "$rules" ] && return
-  fi
-  # this is done every time the service is started
-  attempt=0
-  until /usr/bin/ns-snort-rules --download; do
-    attempt=$((attempt + 1))
-    if [ "$attempt" -ge 6 ]; then
-      echo "Error: failed to download snort rules after 6 attempts (1 minute)."
-      break
-    fi
-    sleep 10
-  done
+	oinkcode="$(uci -q get snort.snort.oinkcode)"
+	if [ -n "$oinkcode" ]; then
+		rm -f /var/ns-snort/*community-rules.tar.gz
+		rules="$(find /var/ns-snort -type f -name "snortrules-*.tar.gz")"
+		[ -n "$rules" ] && return
+	else
+		rm -f /var/ns-snort/snortrules-*.tar.gz
+		rules="$(find /var/ns-snort/ -type f -name "*community-rules.tar.gz")"
+		[ -n "$rules" ] && return
+	fi
+	# this is done every time the service is started
+	attempt=0
+	until /usr/bin/ns-snort-rules --download; do
+		attempt=$((attempt + 1))
+		if [ "$attempt" -ge 6 ]; then
+			echo "Error: failed to download snort rules after 6 attempts (1 minute)."
+			break
+		fi
+		sleep 10
+	done
 }
 
 setup_tweaks() {
@@ -76,7 +76,7 @@ start_service() {
 	# output.logdir, in the snort lua config, determines the PID file location.
 	# Add '--create-pidfile' to the 'command', below.
 
-        local enabled
+	local enabled
 	local manual
 	local config_dir
 	local interface
@@ -94,17 +94,17 @@ start_service() {
 		setup_tweaks
 	fi
 
-        validate_snort_section snort || {
-                echo "Validation failed, try 'snort-mgr check'."
-                return 1
-        }
+	validate_snort_section snort || {
+		echo "Validation failed, try 'snort-mgr check'."
+		return 1
+	}
 
 	[ "$enabled" = 0 ] && return
 
 	procd_open_instance
 	if [ "$manual" = 0 ]; then
 		local config_file=$($MGR setup)
-	        maxlen=$(uci -q get snort.nfq.queue_maxlen)
+		maxlen=$(uci -q get snort.nfq.queue_maxlen)
 		if [ -z "${maxlen}" ]; then
 			maxlen=1024
 		fi
@@ -134,6 +134,6 @@ service_triggers()
 
 reload_service()
 {
-  stop
-  start
+	stop
+	start
 }

--- a/packages/snort3/files/snort.init
+++ b/packages/snort3/files/snort.init
@@ -33,6 +33,14 @@ update_bypass_set() {
 }
 
 download_rules () {
+  oinkcode="$(uci -q get snort.snort.oinkcode)"
+  if [ -z "$oinkcode" ]; then
+    rules="$(find /var/ns-snort -type f -name "snortrules-*.tar.gz")"
+    [ -n "$rules" ] && return
+  else
+    rules="$(find /var/ns-snort/ -type f -name "*community-rules.tar.gz")"
+    [ -n "$rules" ] && return
+  fi
   # this is done every time the service is started
   attempt=0
   until /usr/bin/ns-snort-rules --download; do

--- a/packages/snort3/files/snort.init
+++ b/packages/snort3/files/snort.init
@@ -34,10 +34,12 @@ update_bypass_set() {
 
 download_rules () {
   oinkcode="$(uci -q get snort.snort.oinkcode)"
-  if [ -z "$oinkcode" ]; then
+  if [ -n "$oinkcode" ]; then
+    rm -f /var/ns-snort/*community-rules.tar.gz
     rules="$(find /var/ns-snort -type f -name "snortrules-*.tar.gz")"
     [ -n "$rules" ] && return
   else
+    rm -f /var/ns-snort/snortrules-*.tar.gz
     rules="$(find /var/ns-snort/ -type f -name "*community-rules.tar.gz")"
     [ -n "$rules" ] && return
   fi

--- a/packages/snort3/files/snort.init
+++ b/packages/snort3/files/snort.init
@@ -32,19 +32,17 @@ update_bypass_set() {
     fi
 }
 
-download_rules_if_needed () {
-	if ! find /var/ns-snort/rules/ -type f -name "*.rules" | grep -q . ; then
-		# no rules file found, start downloaded loop
-		attempt=0
-		until /usr/bin/ns-snort-rules --download; do
-			attempt=$((attempt + 1))
-			if [ "$attempt" -ge 6 ]; then
-				echo "Error: failed to download snort rules after 6 attempts (1 minute)."
-				break
-			fi
-			sleep 10
-		done
-	fi
+download_rules () {
+  # this is done every time the service is started
+  attempt=0
+  until /usr/bin/ns-snort-rules --download; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 6 ]; then
+      echo "Error: failed to download snort rules after 6 attempts (1 minute)."
+      break
+    fi
+    sleep 10
+  done
 }
 
 setup_tweaks() {
@@ -82,7 +80,7 @@ start_service() {
 		update_bypass_set "bypass_dst_v4"
 		update_bypass_set "bypass_src_v6"
 		update_bypass_set "bypass_dst_v6"
-		download_rules_if_needed
+		download_rules
 		setup_tweaks
 	fi
 
@@ -122,4 +120,10 @@ service_triggers()
 {
 	procd_add_reload_trigger "snort"
 	procd_add_validation validate_snort_section
+}
+
+reload_service()
+{
+  stop
+  start
 }

--- a/packages/snort3/files/snort.init
+++ b/packages/snort3/files/snort.init
@@ -26,7 +26,7 @@ update_bypass_set() {
 	else
 		echo -n "elements = {" > $set_file
 		for ip in $ips; do
-			echo -n " $ip," >> $set_file
+			 echo -n "$(echo "$ip" | cut -d, -f1)," >> $set_file
 		done
 		echo " }" >> $set_file
     fi


### PR DESCRIPTION
Changes:
- Added API to read configuration
- Added API to check oinkcode (this is done by downloading the registered rules, not efficient but the only way)
- Removed `ns_disabled_rules` from `setup` API, this will need a separate API.
- Now service restarts at every change in `snort` config
- Added ability to comment bypasses 

~~NOTE: now the service downloads the new rules at every restart. It's not optimal, but:~~
~~1. checking if the files in `rules` exists, is not a indicator of the need the rules again (I.E. if you are a community user and then add the "oinkcode" later), this locks the user to the old rules until the cronjob applies~~
~~2. there's no way to know what changed in the configuration, this was useful in case we want to re-download the rules and reapply them, only if the oinkcode changed.~~

~~If you think that point 1 can be overruled and it's fine, I can revert the [change](https://github.com/NethServer/nethsecurity/pull/1011/files#diff-793a7bc7e42088934e22255570bc234ffbc9b7d5945eb52d5ab46176b36a2e4eR35) no problem.~~

Now we check if the rules need to be downloaded by referring to the downloaded file. Rules are deleted when oinkode is present or not, so that when you add a code, fresh rules are downloaded.

Ref:
- https://github.com/NethServer/nethsecurity/issues/1010