### PR TITLE
fix(ns-api): fix threat shield dns apis

### DIFF
--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -5978,6 +5978,23 @@ Response example:
 {"message": "success"}
 ```
 
+### dns-list-zones
+
+List firewall zones that can be configured on Threat shield DNS (all zones but WAN):
+```
+api-cli ns.threatshield dns-list-zones
+```
+
+Response example:
+```json
+{
+  "data": [
+    "lan",
+    "myzone"
+  ]
+}
+```
+
 ### dns-list-allowed
 
 List domains always allowed:

--- a/packages/ns-api/files/ns.threatshield
+++ b/packages/ns-api/files/ns.threatshield
@@ -14,7 +14,7 @@ import urllib.request
 import urllib.error
 from euci import EUci
 from nethsec.utils import ValidationError
-from nethsec import utils
+from nethsec import utils, firewall
 import base64
 import time
 import subprocess
@@ -397,6 +397,13 @@ def dns_edit_blocklist(e_uci, payload):
     e_uci.save('adblock')
     return {'message': 'success'}
 
+def dns_list_zones(e_uci):
+    zones_no_wan = {zone_name: zone for zone_name, zone in firewall.list_zones_no_aliases(e_uci).items() if zone['name'] != 'wan'}
+    zones = []
+    for zone in zones_no_wan.values():
+        zones.append(zone['name'])
+    return { 'data': zones }
+
 def dns_list_settings(e_uci):
     ts_enabled = e_uci.get('adblock', 'global', 'ts_enabled', default='0')
     try:
@@ -411,6 +418,8 @@ def dns_list_settings(e_uci):
 
 def dns_edit_settings(e_uci, payload):
     if payload['enabled']:
+        if 'zones' in payload and 'wan' in payload['zones']:
+            raise ValidationError('zones', 'wan_zone_not_allowed', payload['zones'])
         e_uci.set('adblock', 'global', 'ts_enabled', '1')
         e_uci.set('adblock', 'global', 'adb_enabled', '1')
         e_uci.set('adblock', 'global', 'adb_backup', '1')
@@ -557,6 +566,7 @@ if cmd == 'list':
         'dns-list-blocklist': {},
         'dns-edit-blocklist': { "blocklist": "blocklist_name", "enabled": True },
         'dns-list-settings': {},
+        'dns-list-zones': {},
         'dns-edit-settings': { 'enabled': True, 'zones': ["lan"], "ports": ["53", "853"] },
         'dns-list-allowed': {},
         'dns-add-allowed': { 'address': 'test.org' , 'description': 'optional'},
@@ -617,6 +627,8 @@ elif cmd == 'call':
         elif action == 'dns-edit-settings':
             payload = json.loads(sys.stdin.read())
             ret = dns_edit_settings(e_uci, payload)
+        elif action == 'dns-list-zones':
+            ret = dns_list_zones(e_uci)
         elif action == 'dns-add-allowed':
             payload = json.loads(sys.stdin.read())
             ret = dns_add_allowed(payload)

--- a/packages/ns-api/files/ns.threatshield
+++ b/packages/ns-api/files/ns.threatshield
@@ -93,6 +93,14 @@ def write_allow_list(allow_list, file='/etc/banip/banip.allowlist'):
             f.write('\n')
     subprocess.run(["/etc/init.d/banip", "reload"], capture_output=True)
 
+def dns_write_local_list(local_list, file):
+    with open(file, 'w') as f:
+        for x in local_list:
+            f.write(x['address'])
+            if x['description']:
+                f.write(' #' + x['description'])
+            f.write('\n')
+    subprocess.run(["/etc/init.d/adblock", "restart"], capture_output=True)
 
 def write_block_list(block_list):
     write_allow_list(block_list, '/etc/banip/banip.blocklist')
@@ -428,7 +436,7 @@ def dns_add_allowed(payload):
     if payload['address'] in [x['address'] for x in cur]:
         raise ValidationError('address', 'address_already_present', payload['address'])
     cur.append({ "address": payload['address'], "description": payload['description'] })
-    write_allow_list(cur, '/etc/adblock/adblock.whitelist')
+    dns_write_local_list(cur, '/etc/adblock/adblock.whitelist')
     return {'message': 'success'}
 
 def dns_add_blocked(payload):
@@ -437,7 +445,7 @@ def dns_add_blocked(payload):
     if payload['address'] in [x['address'] for x in cur]:
         raise ValidationError('address', 'address_already_present', payload['address'])
     cur.append({ "address": payload['address'], "description": payload.get('description') })
-    write_allow_list(cur, '/etc/adblock/adblock.blacklist')
+    dns_write_local_list(cur, '/etc/adblock/adblock.blacklist')
     return {'message': 'success'}
 
 def dns_edit_allowed(payload):
@@ -448,7 +456,7 @@ def dns_edit_allowed(payload):
         if cur[i]['address'] == payload['address']:
             cur[i]['description'] = payload['description']
             break
-    write_allow_list(cur, '/etc/adblock/adblock.whitelist')
+    dns_write_local_list(cur, '/etc/adblock/adblock.whitelist')
     return {'message': 'success'}
 
 def dns_edit_blocked(payload):
@@ -459,7 +467,7 @@ def dns_edit_blocked(payload):
         if cur[i]['address'] == payload['address']:
             cur[i]['description'] = payload.get('description')
             break
-    write_allow_list(cur, '/etc/adblock/adblock.blacklist')
+    dns_write_local_list(cur, '/etc/adblock/adblock.blacklist')
     return {'message': 'success'}
 
 def dns_delete_allowed(payload):

--- a/packages/ns-api/files/ns.threatshield
+++ b/packages/ns-api/files/ns.threatshield
@@ -479,7 +479,7 @@ def dns_delete_allowed(payload):
         if cur[i]['address'] == payload['address']:
             del cur[i]
             break
-    write_allow_list(cur, '/etc/adblock/adblock.whitelist')
+    dns_write_local_list(cur, '/etc/adblock/adblock.whitelist')
     return {'message': 'success'}
 
 def dns_delete_blocked(payload):
@@ -491,7 +491,7 @@ def dns_delete_blocked(payload):
         if cur[i]['address'] == payload['address']:
             del cur[i]
             break
-    write_allow_list(cur, '/etc/adblock/adblock.blacklist')
+    dns_write_local_list(cur, '/etc/adblock/adblock.blacklist')
     return {'message': 'success'}
 
 def dns_list_bypass(e_uci):


### PR DESCRIPTION
- Restart `adblock` service at the end of the following `ns.threatshield` apis: `dns-add-blocked`,  `dns-edit-blocked`, `dns-add-allowed`,  `dns-edit-allowed`
- Add `dns-list-zones` api
- Prevent `wan` zone in `dns-edit-settings`

Ref:
- https://github.com/NethServer/nethsecurity/issues/906