### PR TITLE
fix(ns-migration): limit tun name to 16 chars

### DIFF
--- a/packages/ns-migration/files/scripts/openvpn_tunnels
+++ b/packages/ns-migration/files/scripts/openvpn_tunnels
@@ -75,7 +75,7 @@ def import_tunnel(u, tunnel, ttype):
     # Add management socket
     u.set("openvpn", iname, 'management', f'/var/run/openvpn_{iname}.socket unix')
     # Setup the device with max 16 characters
-    device = f'tun{name}'[:16]
+    device = f'tun{name}'[:15]
     u.set("openvpn", iname, 'dev', device)
     # Add interface to LAN
     ovpn_interface = firewall.add_vpn_interface(u, name, device, link=f'openvpn/{iname}')


### PR DESCRIPTION
Previously, the limit was wrongly set to 17

Avoid errors during `fw4 reload` like:
```
/dev/stdin:54:13-30: Error: String exceeds maximum length of 16
		iifname { "tuntunnel-uffici", "tuntunnel-sr-ct" } jump input_openvpn comment "!fw4: Handle openvpn IPv4/IPv6 input traffic"
		          ^^^^^^^^^^^^^^^^^^
```

Ref: #1061 