### PR TITLE
fix(ns-api): mark templates file as non-config

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -27,7 +27,6 @@ endef
 
 define Package/ns-api/conffiles
 /etc/config/ns-api
-/etc/config/templates
 endef
  
 define Package/ns-api/description


### PR DESCRIPTION
During an update the /etc/config/templates was renamed to /etc/config/templates-opkg: this will break
expectations of packages which are using the templates for automatic configuration (eg. migration, wireguard)