### PR TITLE
fix(ns-api): removing kernel keyword from banip count

### DIFF
--- a/packages/ns-api/files/ns.report
+++ b/packages/ns-api/files/ns.report
@@ -91,7 +91,7 @@ def tsip_attack_report():
 
 def tsip_malware_report():
     file_paths = ['/var/log/messages.1.gz', '/var/log/messages']
-    keywords = ['kernel', 'banIP/.*/drop', 'banIP/.*/reject']
+    keywords = ['banIP/.*/drop', 'banIP/.*/reject']
 
     # Get the current date in the format '%b %e ' (e.g., 'Aug  8 ')
     date_str = datetime.now().strftime('%b %e ').rstrip()


### PR DESCRIPTION
Following [what happens when data is dumped to controller](https://github.com/NethServer/nethsecurity/blob/35346f89fe6a4df19cc7e2b6a628c9bd2695f530/packages/ns-api/files/ns.controller#L172), removed `kernel` keyword from filtering.

Ref:
- https://github.com/NethServer/nethsecurity/issues/1081
