### PR TITLE
feat(ns-api): add firewall-apply-default-logging

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -164,6 +164,7 @@ define Package/ns-api/install
 	$(INSTALL_CONF) files/nat-helpers.keep $(1)/lib/upgrade/keep.d/nat-helpers
 	$(LN) /usr/bin/msmtp $(1)/usr/sbin/sendmail
 	$(INSTALL_BIN) ./files/load-kernel-modules $(1)/usr/sbin/load-kernel-modules
+	$(INSTALL_BIN) ./files/firewall-apply-default-logging $(1)/usr/sbin/firewall-apply-default-logging
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/config $(1)/etc/config/ns-api
 	$(INSTALL_CONF) ./files/templates $(1)/etc/config/

--- a/packages/ns-api/files/firewall-apply-default-logging
+++ b/packages/ns-api/files/firewall-apply-default-logging
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+from nethsec import firewall
+from euci import EUci
+import subprocess
+
+uci = EUci()
+firewall.apply_default_logging_options(uci)
+uci.commit('firewall')
+# note: a reload is not enough to apply new limits to zones
+subprocess.run(["/sbin/fw4", "restart"], check=True)

--- a/packages/ns-api/files/ns.redirects
+++ b/packages/ns-api/files/ns.redirects
@@ -144,9 +144,14 @@ def add_redirect(args):
         u.set('firewall', rname, 'src', 'wan')
         u.set('firewall', rname, 'target', 'DNAT')
         restrict = args.pop('restrict', '')
+        log = args.pop('log', '0')
         if restrict:
             sname = add_ipset(u, rname, restrict)
             u.set('firewall', rname, 'ipset', sname)
+        if log == '1':
+            log_opts = firewall.get_default_logging_options(u)
+            u.set('firewall', rname, 'log', '1')
+            u.set('firewall', rname, 'log_limit', log_opts['redirect_log_limit'])
         for a in args:
             u.set('firewall', rname, a, args.get(a))
         firewall.update_redirect_rules(u) # expand objects and save firewall config
@@ -165,6 +170,7 @@ def edit_redirect(args):
             return utils.generic_error("ns_dst_invalid_object_type")
     rname = args.pop('id')
     restrict = args.pop('restrict', '')
+    log = args.pop('log', '0')
     try:
         # try to convert from single IP to ipset
         u.delete('firewall', rname, 'src_ip')
@@ -178,6 +184,17 @@ def edit_redirect(args):
         try:
            u.delete('firewall', f"{rname}_ipset")
            u.delete("firewall", rname, "ipset")
+        except:
+            pass
+    if log == '1':
+        log_opts = firewall.get_default_logging_options(u)
+        u.set('firewall', rname, 'log', '1')
+        if u.get('firewall', 'config', 'log_limit', default=None) is None:
+            u.set('firewall', rname, 'log_limit', log_opts['redirect_log_limit'])
+    else:
+        try:
+            u.delete('firewall', rname, 'log')
+            u.delete('firewall', rname, 'log_limit')
         except:
             pass
     try:

--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=python3-nethsec
-PKG_VERSION:=0.0.97
+PKG_VERSION:=0.0.98
 PKG_RELEASE:=1
  
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>


### PR DESCRIPTION
Add script to apply log limit to all existing rules where logging is enabled.
The script will add the limit to:

- forward rules
- redirect rules
- zones

Usage:
```
uci set firewall.ns_defaults.zone_log_limit="10/s"
uci commit firewall
firewall-apply-default-logging
```

You can ignore the following warnings on firewall reload:
```
Section ns_defaults specifies unknown option 'rule_log_limit'
Section ns_defaults specifies unknown option 'zone_log_limit'
Section ns_defaults specifies unknown option 'redirect_log_limit'
```

Requires: NethServer/python3-nethsec#93
Refs:
- NethServer/nethsecurity#1105
- NethServer/nethsecurity-docs#154