### PR TITLE
fix(ns-plug): soft stop when deregistering the unit

### DIFF
--- a/packages/ns-plug/files/ns-plug.init
+++ b/packages/ns-plug/files/ns-plug.init
@@ -10,15 +10,25 @@ START=80
 USE_PROCD=1
 
 start_service() {
-    procd_open_instance
-    procd_set_param stdout 1
-    procd_set_param stderr 1
-    procd_set_param command '/usr/sbin/ns-plug'
-    procd_set_param respawn 3600 60 0
-    procd_close_instance
+		config_load ns-plug
+		local server unit_id token
+		config_get server config server
+		config_get unit_id config unit_id
+		config_get token config token
+
+		[ -z "$server" ] && return 1
+		[ -z "$unit_id" ] && return 2
+		[ -z "$token" ] && return 3
+
+		procd_open_instance
+		procd_set_param stdout 1
+		procd_set_param stderr 1
+		procd_set_param command '/usr/sbin/ns-plug'
+		procd_set_param respawn 3600 60 0
+		procd_close_instance
 }
 
 service_triggers()
 {
-    procd_add_reload_trigger "ns-plug"
+		procd_add_reload_trigger "ns-plug"
 }


### PR DESCRIPTION
When you `unregister` the unit from the controller, the `ns-plug` service is being restarted instead of stopped.
This worked before due to [these checks](https://github.com/NethServer/nethsecurity/blob/091435ffa5687649cfa2eaf1d1a743fff40046b2/packages/ns-plug/files/ns-plug#L23-L36) inside the `ns-plug` script. This however triggers a restart loop using the new procd restart.

Using the procd get config to stop the service before init so that no restart is actually made.

Ref: 
- https://github.com/NethServer/nethsecurity/issues/1084