### PR TITLE
feat(ns-dpi): supporting vlans

### DIFF
--- a/packages/ns-dpi/files/dpi-config
+++ b/packages/ns-dpi/files/dpi-config
@@ -102,9 +102,22 @@ for section in u.get_all('dpi'):
         else:
             criteria = f'({sources_s}) && ({applications_s}) ;'
 
+    device = rule.get('device', '*')
+    vlan_id = None
+    base_if = None
+    for item in utils.get_all_by_type(u, 'network', 'device').values():
+        if item.get('vid', None) is not None and item.get('name', '') == device:
+            vlan_id = item.get('vid', '')
+            base_if = item.get('ifname', '')
+            break
+
+    if vlan_id is not None:
+        criteria = f'vlan_id == {vlan_id} && {criteria}'
+        device = base_if
+
     config["actions"][f"rule{rcount}"] = {
         "enabled": rule['enabled'] == '1',
-        "interface": rule.get('device', '*'),
+        "interface": device,
         "criteria": criteria,
         "targets": [rule['action']],
         "exemptions": rule.get('exemption', [])

--- a/packages/ns-dpi/files/dpi-config
+++ b/packages/ns-dpi/files/dpi-config
@@ -107,11 +107,11 @@ for section in u.get_all('dpi'):
     base_if = None
     for item in utils.get_all_by_type(u, 'network', 'device').values():
         if item.get('vid', None) is not None and item.get('name', '') == device:
-            vlan_id = item.get('vid', '')
-            base_if = item.get('ifname', '')
+            vlan_id = item.get('vid', None)
+            base_if = item.get('ifname', None)
             break
 
-    if vlan_id is not None:
+    if vlan_id is not None and base_if is not None:
         criteria = f'vlan_id == {vlan_id} && {criteria}'
         device = base_if
 

--- a/packages/python3-nethsec/Makefile
+++ b/packages/python3-nethsec/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=python3-nethsec
-PKG_VERSION:=0.0.98
+PKG_VERSION:=1.0.0
 PKG_RELEASE:=1
  
 PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>


### PR DESCRIPTION
DPI filter lost the ability to filter vlans when de-duplication of analysis and traffic took place in https://github.com/NethServer/nethsecurity/issues/929. This PR aims to restore the functionality.

Requires: https://github.com/NethServer/python3-nethsec/pull/94

Ref:
- https://github.com/NethServer/nethsecurity/issues/1101
