### PR TITLE
fix(mwan3): fix wrong traffic routing with specific metrics

### DIFF
--- a/packages/mwan3/Makefile
+++ b/packages/mwan3/Makefile
@@ -102,6 +102,8 @@ define Package/mwan3/install
 		$(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/mwan3track \
 		$(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usr/sbin/mwan3routertraffic \
+		$(1)/usr/sbin/
 
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_BIN) ./files/etc/mwan3.user \
@@ -111,6 +113,8 @@ define Package/mwan3/install
 
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_DATA) ./files/etc/uci-defaults/mwan3-migrate-flush_conntrack \
+		$(1)/etc/uci-defaults/
+	$(INSTALL_DATA) ./files/etc/uci-defaults/mwan3-addroutertraffic-execution \
 		$(1)/etc/uci-defaults/
 endef
 

--- a/packages/mwan3/Makefile
+++ b/packages/mwan3/Makefile
@@ -97,7 +97,7 @@ define Package/mwan3/install
 		$(1)/usr/libexec/rpcd/
 	$(INSTALL_DIR) $(1)/usr/libexec
 	$(INSTALL_BIN) ./files/usr/libexec/mwan3routertraffic \
-		$(1)/usr/libexec/rpcd/
+		$(1)/usr/libexec
 
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/usr/sbin/mwan3 \

--- a/packages/mwan3/Makefile
+++ b/packages/mwan3/Makefile
@@ -8,9 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-# version 2.11.17 is from Nethesis: it clears the mwan3 config
 PKG_VERSION:=2.11.17
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \
 		Aaron Goodman <aaronjg@alumni.stanford.edu>
 PKG_LICENSE:=GPL-2.0

--- a/packages/mwan3/Makefile
+++ b/packages/mwan3/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
+# from version 2.11.17 is Nethesis fork: it clears the mwan3 config
 PKG_VERSION:=2.11.17
 PKG_RELEASE:=7
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>, \

--- a/packages/mwan3/Makefile
+++ b/packages/mwan3/Makefile
@@ -95,6 +95,9 @@ define Package/mwan3/install
 	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
 	$(INSTALL_BIN) ./files/usr/libexec/rpcd/mwan3 \
 		$(1)/usr/libexec/rpcd/
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) ./files/usr/libexec/mwan3routertraffic \
+		$(1)/usr/libexec/rpcd/
 
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/usr/sbin/mwan3 \
@@ -102,8 +105,6 @@ define Package/mwan3/install
 	$(INSTALL_BIN) ./files/usr/sbin/mwan3rtmon \
 		$(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/mwan3track \
-		$(1)/usr/sbin/
-	$(INSTALL_BIN) ./files/usr/sbin/mwan3routertraffic \
 		$(1)/usr/sbin/
 
 	$(INSTALL_DIR) $(1)/etc

--- a/packages/mwan3/files/etc/init.d/mwan3
+++ b/packages/mwan3/files/etc/init.d/mwan3
@@ -77,7 +77,7 @@ stop_service() {
 			$IP route flush table $tid &> /dev/null
 		done
 
-		for rule in $($IP rule list | grep -E '^[1-3][0-9]{3}:' | cut -d ':' -f 1); do
+		for rule in $($IP rule list | grep -E '^[1-3][0-9]{3}\:' | cut -d ':' -f 1); do
 			$IP rule del pref $rule &> /dev/null
 		done
 		table="$($IPT -S)"

--- a/packages/mwan3/files/etc/uci-defaults/mwan3-addroutertraffic-execution
+++ b/packages/mwan3/files/etc/uci-defaults/mwan3-addroutertraffic-execution
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+grep -q "/usr/sbin/mwan3routertraffic \$INTERFACE \$ACTION" /etc/mwan3.user || echo "/usr/sbin/mwan3routertraffic \$INTERFACE \$ACTION" >> /etc/mwan3.user

--- a/packages/mwan3/files/etc/uci-defaults/mwan3-addroutertraffic-execution
+++ b/packages/mwan3/files/etc/uci-defaults/mwan3-addroutertraffic-execution
@@ -5,4 +5,4 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-grep -q "/usr/sbin/mwan3routertraffic \$INTERFACE \$ACTION" /etc/mwan3.user || echo "/usr/sbin/mwan3routertraffic \$INTERFACE \$ACTION" >> /etc/mwan3.user
+grep -q "/usr/libexec/mwan3routertraffic \$INTERFACE \$ACTION" /etc/mwan3.user || echo "/usr/libexec/mwan3routertraffic \$INTERFACE \$ACTION" >> /etc/mwan3.user

--- a/packages/mwan3/files/lib/mwan3/mwan3.sh
+++ b/packages/mwan3/files/lib/mwan3/mwan3.sh
@@ -527,10 +527,7 @@ mwan3_create_iface_rules()
 
 	mwan3_delete_iface_rules "$1"
 
-	network_get_ipaddr wan_addr "${1}"
-
 	$IP rule add pref $((id+1000)) iif "$2" lookup "$id"
-	$IP rule add pref $((id+1500)) from ${wan_addr} lookup "$id"
 	$IP rule add pref $((id+2000)) fwmark "$(mwan3_id2mask id MMX_MASK)/$MMX_MASK" lookup "$id"
 	$IP rule add pref $((id+3000)) fwmark "$(mwan3_id2mask id MMX_MASK)/$MMX_MASK" unreachable
 }

--- a/packages/mwan3/files/usr/libexec/mwan3routertraffic
+++ b/packages/mwan3/files/usr/libexec/mwan3routertraffic
@@ -15,8 +15,8 @@
 . /lib/mwan3/mwan3.sh
 
 # check for passed parameters, if empty use environment variables
-interface_name="${1:-$INTERFACE}"
-action_name="${2:-$ACTION}"
+interface_name="${1:?Interface name is required}"
+action_name="${2:-?Action is required}"
 
 config_load mwan3
 

--- a/packages/mwan3/files/usr/sbin/mwan3routertraffic
+++ b/packages/mwan3/files/usr/sbin/mwan3routertraffic
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# This script is intended to be used inside the /etc/mwan.user file, please beware of usage outside of it
+# Params are
+# $interface_name: interface name (passed by $INTERFACE)
+# $2: action name (passed by $ACTION)
+
+. /lib/functions.sh
+. /lib/functions/network.sh
+. /lib/mwan3/mwan3.sh
+
+# check for passed parameters, if empty use environment variables
+interface_name="${1:-$INTERFACE}"
+action_name="${2:-$ACTION}"
+
+config_load mwan3
+
+# Get the id of the interface handled by mwan3, if empty, exit
+id=""
+mwan3_get_iface_id id "$interface_name"
+[ -n "$id" ] || return 0
+
+# Get family of the interface
+family=""
+wan_addr=""
+config_get family "$interface_name" family ipv4
+# exit if the interface is not supported
+if [ "$family" = "ipv4" ]; then
+  IP="$IP4"
+  network_get_ipaddr wan_addr "${1}"
+elif [ "$family" = "ipv6" ] && [ $NO_IPV6 -eq 0 ]; then
+  IP="$IP6"
+  network_get_ipaddr6 wan_addr "${1}"
+else
+  return 1
+fi
+
+if [ "$action_name" = "connected" ]
+then
+  # Add the rule to the routing table
+  $IP rule add pref $((id+1500)) from "$wan_addr" lookup "$id"
+elif [ "$action_name" = "disconnected" ]
+then
+  # Remove the rule from the routing table
+  $IP rule del pref $((id+1500))
+fi
+
+
+
+

--- a/packages/mwan3/files/usr/sbin/mwan3routertraffic
+++ b/packages/mwan3/files/usr/sbin/mwan3routertraffic
@@ -23,7 +23,7 @@ config_load mwan3
 # Get the id of the interface handled by mwan3, if empty, exit
 id=""
 mwan3_get_iface_id id "$interface_name"
-[ -n "$id" ] || return 0
+[ -n "$id" ] || exit 0
 
 # Get family of the interface
 family=""
@@ -37,7 +37,7 @@ elif [ "$family" = "ipv6" ] && [ $NO_IPV6 -eq 0 ]; then
   IP="$IP6"
   network_get_ipaddr6 wan_addr "${1}"
 else
-  return 1
+  exit 1
 fi
 
 if [ "$action_name" = "connected" ]
@@ -49,7 +49,3 @@ then
   # Remove the rule from the routing table
   $IP rule del pref $((id+1500))
 fi
-
-
-
-


### PR DESCRIPTION
By leveraging /etc/mwan3.user, we can generate ip rules that force traffic to be routed to specific interfaces. This PR reverts 05fbb03d1d1fae30f2fe486dcffde3772c2d76f4 and implements back the functionality.

Ref:
- https://github.com/NethServer/nethsecurity/issues/1126
