### PR TITLE
perf(ns-ui): halving load time for UI using gzip

### DIFF
--- a/packages/ns-ui/files/ns-ui
+++ b/packages/ns-ui/files/ns-ui
@@ -47,6 +47,8 @@ server {
 
 	# enable NS UI
 	location / {
+	  gzip on;
+	  gzip_types text/html text/css application/javascript image/svg+xml;
 		root /www-ns;
 		try_files \$uri \$uri/ /index.html;
 	}


### PR DESCRIPTION
Using gzip in nginx, we halve the load time for the ui, this applies to good and bad connection situations.
