### PR TITLE
fix(ns-api): banip, fix regression

### DIFF
--- a/packages/ns-api/files/ns.threatshield
+++ b/packages/ns-api/files/ns.threatshield
@@ -192,8 +192,7 @@ def edit_blocklist(e_uci, payload):
     if not payload['enabled'] and payload['blocklist'] in enabled:
         enabled.remove(payload['blocklist'])
     # cleanup invalid feeds
-    has_bl = has_bl_entitlement(e_uci)
-    feeds = list_feeds(has_bl)
+    feeds = list_feeds()
     enabled = [feed for feed in enabled if feed in feeds]
     e_uci.set('banip', 'global', 'ban_feed', enabled)
     e_uci.save('banip')


### PR DESCRIPTION
Regression introduced by ba2892a988e7c5eecbd4ca0d37792f1b51909b1e

Fix error:
```
  File "/usr/libexec/rpcd/ns.threatshield", line 196, in edit_blocklist
    feeds = list_feeds(has_bl)
            ^^^^^^^^^^^^^^^^^^
```

NethServer/nethsecurity#1172