### PR TITLE
feat(ns-api): redirects, show all supported protocols

### DIFF
--- a/packages/ns-api/files/ns.redirects
+++ b/packages/ns-api/files/ns.redirects
@@ -206,7 +206,15 @@ def edit_redirect(args):
         return utils.generic_error("redirect_not_modified")
 
 def list_protocols():
-    return {"protocols": ["tcp", "udp", "udplite", "icmp", "esp", "ah", "sctp"]}
+    protocols = []
+    with open('/etc/protocols', 'r') as fp:
+        for line in fp:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = re.split(r'\s+', line)
+            protocols.append(parts[0])
+    return {"protocols": sorted(protocols)}
 
 def get_device_ips():
     ret = {}


### PR DESCRIPTION
Return all protocols from `/etc/protocols`

NethServer/nethsecurity#1069


From manual, the `proto` field supports the following:
> Match incoming traffic using the given protocol. Can be one (or several when using list syntax) of tcp, udp, udplite, icmp, esp, ah, sctp, or all or it can be a numeric value, representing one of these protocols or a different one. A protocol name from /etc/protocols is also allowed. The number 0 is equivalent to all.

See https://openwrt.org/docs/guide-user/firewall/firewall_configuration