### PR TITLE
fix(ns-plug): hide backup-encryption-alert output

### DIFF
--- a/packages/ns-plug/files/backup-encryption-alert
+++ b/packages/ns-plug/files/backup-encryption-alert
@@ -33,4 +33,4 @@ payload='{"lk": "'$lk'", "alert_id": "'$alert_id'", "status": "'$status'"}'
 
 /usr/bin/curl -m 30 --retry 3 -L -s \
     --header "Authorization: token ${secret}"  --header "Content-Type: application/json" --header "Accept: application/json"  \
-    --data-raw "${payload}" ${url}
+    --data-raw "${payload}" ${url} > /dev/null


### PR DESCRIPTION
Avoid unwanted output during cron execution

See #1119 