### PR TITLE
fix:(ns-ui): remove nginx warning

### DIFF
--- a/packages/ns-ui/files/ns-ui
+++ b/packages/ns-ui/files/ns-ui
@@ -48,7 +48,7 @@ server {
 	# enable NS UI
 	location / {
 		gzip on;
-		gzip_types text/html text/css application/javascript image/svg+xml;
+		gzip_types text/css application/javascript image/svg+xml;
 		root /www-ns;
 		try_files \$uri \$uri/ /index.html;
 	}


### PR DESCRIPTION
On every nginx restart a warning line is logged:

[warn] 9230#0: duplicate MIME type "text/html" in /etc/nginx/conf.d/ns-ui.conf:15

The text/html MIME type is always compressed. See: https://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types