### PR TITLE
fix(ns-api): get public IP for PPPoE

### DIFF
--- a/packages/ns-api/files/ns.report
+++ b/packages/ns-api/files/ns.report
@@ -16,6 +16,7 @@ from datetime import datetime
 from collections import defaultdict
 from nethsec import utils
 import urllib.request
+from euci import EUci
 
 ## Utility functions
 
@@ -355,7 +356,13 @@ def latency_and_quality_report():
 
 
 def get_ip_addresses(device: str):
+    uci = EUci()
     devices = utils.get_all_device_ips()
+    interface = utils.get_interface_from_device(uci, device)
+    if interface:
+        proto = uci.get('network', interface, 'proto', default='')
+        if proto == 'pppoe':
+            device = f'pppoe-{interface}'
     for item in devices:
         if item == device:
             if len(devices[item]) > 0:


### PR DESCRIPTION
When checking for the public IP of a PPPoE device, the API must search for the real device name
which is like 'pppoe-<interface_name>'.
Before this fix, all PPPoE interfaces did not show the public IP address.

#1148 