### PR TITLE
fix(banip): remove non-existing lists

### DIFF
--- a/packages/banip/files/banip.feeds
+++ b/packages/banip/files/banip.feeds
@@ -1,59 +1,21 @@
 {
-	"adaway":{
-		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/adaway-ipv4.txt",
-		"url_6": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/adaway-ipv6.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "adaway IPs",
-		"flag": "tcp 80 443"
-	},
-	"adguard":{
-		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/adguard-ipv4.txt",
-		"url_6": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/adguard-ipv6.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "adguard IPs",
-		"flag": "tcp 80 443"
-	},
-	"adguardtrackers":{
-		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/adguardtrackers-ipv4.txt",
-		"url_6": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/adguardtrackers-ipv6.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "adguardtracker IPs",
-		"flag": "tcp 80 443"
-	},
-	"antipopads":{
-		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/antipopads-ipv4.txt",
-		"url_6": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/antipopads-ipv6.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "antipopads IPs",
-		"flag": "tcp 80 443"
-	},
-	"asn":{
-		"url_4": "https://asn.ipinfo.app/api/text/list/",
-		"url_6": "https://asn.ipinfo.app/api/text/list/",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
-		"descr": "ASN IP segments"
-	},
 	"backscatterer":{
 		"url_4": "http://wget-mirrors.uceprotect.net/rbldnsd-all/ips.backscatterer.org.gz",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "backscatterer IPs",
 		"flag": "gz"
 	},
 	"becyber":{
-		"url_4": "https://raw.githubusercontent.com/duggytuxy/malicious_ip_addresses/main/botnets_zombies_scanner_spam_ips.txt",
-		"url_6": "https://raw.githubusercontent.com/duggytuxy/malicious_ip_addresses/main/botnets_zombies_scanner_spam_ips_ipv6.txt",
+		"url_4": "https://raw.githubusercontent.com/duggytuxy/Intelligence_IPv4_Blocklists/refs/heads/main/agressive_ips_dst_fr_be_blocklist.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "malicious attacker IPs"
 	},
 	"binarydefense":{
 		"url_4": "https://iplists.firehol.org/files/bds_atif.ipset",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "binary defense banlist"
 	},
 	"bogon":{
@@ -61,16 +23,19 @@
 		"url_6": "https://www.team-cymru.org/Services/Bogons/fullbogons-ipv6.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "bogon prefixes"
 	},
 	"bruteforceblock":{
 		"url_4": "https://danger.rulez.sk/projects/bruteforceblocker/blist.php",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "bruteforceblocker IPs"
 	},
 	"cinsscore":{
 		"url_4": "https://cinsscore.com/list/ci-badguys.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "suspicious attacker IPs"
 	},
 	"country":{
@@ -78,6 +43,7 @@
 		"url_6": "https://www.ipdeny.com/ipv6/ipaddresses/aggregated/",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "country blocks"
 	},
 	"debl":{
@@ -85,6 +51,7 @@
 		"url_6": "https://lists.blocklist.de/lists/all.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "fail2ban IP blocklist"
 	},
 	"doh":{
@@ -92,140 +59,121 @@
 		"url_6": "https://raw.githubusercontent.com/dibdot/DoH-IP-blocklists/master/doh-ipv6.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
+		"chain": "out",
 		"descr": "public DoH-Provider",
-		"flag": "tcp 80 443"
+		"flag": "tcp udp 80 443"
 	},
 	"drop":{
 		"url_4": "https://www.spamhaus.org/drop/drop.txt",
 		"url_6": "https://www.spamhaus.org/drop/dropv6.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "spamhaus drop compilation"
 	},
 	"dshield":{
 		"url_4": "https://feeds.dshield.org/block.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s/%s,\\n\",$1,$3}",
+		"chain": "in",
 		"descr": "dshield IP blocklist"
 	},
 	"etcompromised":{
 		"url_4": "https://iplists.firehol.org/files/et_compromised.ipset",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "ET compromised hosts"
 	},
 	"feodo":{
 		"url_4": "https://feodotracker.abuse.ch/downloads/ipblocklist.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "feodo tracker"
 	},
 	"firehol1":{
 		"url_4": "https://iplists.firehol.org/files/firehol_level1.netset",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "firehol level 1 compilation"
 	},
 	"firehol2":{
 		"url_4": "https://iplists.firehol.org/files/firehol_level2.netset",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "firehol level 2 compilation"
 	},
 	"firehol3":{
 		"url_4": "https://iplists.firehol.org/files/firehol_level3.netset",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "firehol level 3 compilation"
 	},
 	"firehol4":{
 		"url_4": "https://iplists.firehol.org/files/firehol_level4.netset",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{if(!seen[$1]++)printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "firehol level 4 compilation"
 	},
 	"greensnow":{
 		"url_4": "https://blocklist.greensnow.co/greensnow.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "suspicious server IPs"
 	},
 	"hagezi":{
 		"url_4": "https://raw.githubusercontent.com/hagezi/dns-blocklists/refs/heads/main/ips/tif.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "out",
 		"descr": "Threat IP blocklist",
-		"flag": "tcp 80 443"
+		"flag": "tcp udp 80 443"
 	},
 	"ipblackhole":{
 		"url_4": "https://blackhole.s-e-r-v-e-r.pw/blackhole-today",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "blackhole IP blocklist"
 	},
 	"ipsum":{
 		"url_4": "https://raw.githubusercontent.com/stamparm/ipsum/master/levels/3.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[-[:space:]]?/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "malicious IPs"
 	},
 	"ipthreat":{
 		"url_4": "https://lists.ipthreat.net/file/ipthreat-lists/threat/threat-30.txt.gz",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[-[:space:]]?/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "hacker and botnet IPs",
 		"flag": "gz"
 	},
-	"myip":{
-		"url_4": "https://myip.ms/files/blacklist/general/latest_blacklist.txt",
-		"url_6": "https://myip.ms/files/blacklist/general/latest_blacklist.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "real-time IP blocklist"
-	},
-	"oisdbig":{
-		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/oisdbig-ipv4.txt",
-		"url_6": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/oisdbig-ipv6.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "OISD-big IPs",
-		"flag": "tcp 80 443"
-	},
-	"oisdnsfw":{
-		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/oisdnsfw-ipv4.txt",
-		"url_6": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/oisdnsfw-ipv6.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "OISD-nsfw IPs",
-		"flag": "tcp 80 443"
-	},
-	"oisdsmall":{
-		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/oisdsmall-ipv4.txt",
-		"url_6": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/oisdsmall-ipv6.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "OISD-small IPs",
-		"flag": "tcp 80 443"
+	"nixspam":{
+		"url_4": "https://www.nixspam.net/download/nixspam-ip.dump.gz",
+		"rule_4": "/127\\./{next}/(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$2}",
+		"chain": "in",
+		"descr": "iX spam protection",
+		"flag": "gz"
 	},
 	"pallebone":{
 		"url_4": "https://raw.githubusercontent.com/pallebone/StrictBlockPAllebone/master/BlockIP.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "curated IP blocklist"
 	},
 	"proxy":{
 		"url_4": "https://iplists.firehol.org/files/proxylists.ipset",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "open proxies"
-	},
-	"sslbl":{
-		"url_4": "https://sslbl.abuse.ch/blacklist/sslipblacklist.csv",
-		"rule_4": "BEGIN{FS=\",\"}/127\\./{next}/(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)/{printf \"%s,\\n\",$2}",
-		"descr": "SSL botnet IPs"
-	},
-	"stevenblack":{
-		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/stevenblack-ipv4.txt",
-		"url_6": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/stevenblack-ipv6.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "stevenblack IPs",
-		"flag": "tcp 80 443"
 	},
 	"threat":{
 		"url_4": "https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "emerging threats"
 	},
 	"threatview":{
 		"url_4": "https://threatview.io/Downloads/IP-High-Confidence-Feed.txt",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "malicious IPs"
 	},
 	"tor":{
@@ -233,57 +181,72 @@
 		"url_6": "https://www.dan.me.uk/torlist/?exit",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
 		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "tor exit nodes"
 	},
 	"turris":{
-		"url_4":"https://view.sentinel.turris.cz/greylist-data/greylist-latest.csv",
-		"rule_4":"BEGIN{FS=\",\"}/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)/{printf \"%s,\\n\",$1}",
-		"descr":"turris sentinel blocklist"
+		"url_4": "https://view.sentinel.turris.cz/greylist-data/greylist-latest.csv",
+		"url_6": "https://view.sentinel.turris.cz/greylist-data/greylist-latest.csv",
+		"rule_4": "BEGIN{FS=\",\"}/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)/{printf \"%s,\\n\",$1}",
+		"rule_6": "BEGIN{FS=\",\"}/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)/{printf \"%s,\\n\",$1}",
+		"chain": "in",
+		"descr": "turris sentinel blocklist"
 	},
 	"uceprotect1":{
 		"url_4": "http://wget-mirrors.uceprotect.net/rbldnsd-all/dnsbl-1.uceprotect.net.gz",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "spam protection level 1",
 		"flag": "gz"
 	},
 	"uceprotect2":{
 		"url_4": "http://wget-mirrors.uceprotect.net/rbldnsd-all/dnsbl-2.uceprotect.net.gz",
 		"rule_4": "BEGIN{IGNORECASE=1}/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]NET)/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "spam protection level 2",
 		"flag": "gz"
 	},
 	"uceprotect3":{
 		"url_4": "http://wget-mirrors.uceprotect.net/rbldnsd-all/dnsbl-3.uceprotect.net.gz",
 		"rule_4": "BEGIN{IGNORECASE=1}/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]]YOUR)/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "spam protection level 3",
 		"flag": "gz"
 	},
 	"urlhaus":{
 		"url_4": "https://urlhaus.abuse.ch/downloads/ids/",
 		"rule_4": "BEGIN{FS=\";\"}/content:\"127\\./{next}/(content:\"([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\")/{printf \"%s,\\n\",substr($10,11,length($10)-11)}",
+		"chain": "in",
 		"descr": "urlhaus IDS IPs"
 	},
 	"urlvir":{
 		"url_4": "https://iplists.firehol.org/files/urlvir.ipset",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "malware related IPs"
 	},
 	"voip":{
 		"url_4": "https://voipbl.org/update/",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "VoIP fraud blocklist"
+	},
+	"vpn":{
+		"url_4": "https://raw.githubusercontent.com/X4BNet/lists_vpn/refs/heads/main/output/vpn/ipv4.txt",
+		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
+		"descr": "vpn IPs"
+	},
+	"vpndc":{
+		"url_4": "https://raw.githubusercontent.com/X4BNet/lists_vpn/refs/heads/main/output/datacenter/ipv4.txt",
+		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
+		"descr": "vpn datacenter IPs"
 	},
 	"webclient":{
 		"url_4": "https://iplists.firehol.org/files/firehol_webclient.netset",
 		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)$/{printf \"%s,\\n\",$1}",
+		"chain": "in",
 		"descr": "malware related IPs"
-	},
-	"yoyo":{
-		"url_4": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/yoyo-ipv4.txt",
-		"url_6": "https://raw.githubusercontent.com/dibdot/banIP-IP-blocklists/main/yoyo-ipv6.txt",
-		"rule_4": "/^127\\./{next}/^(([1-9][0-9]{0,2}\\.){1}([0-9]{1,3}\\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\\/(1?[0-9]|2?[0-9]|3?[0-2]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"rule_6": "/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\\/(1?[0-2][0-8]|[0-9][0-9]))?)[[:space:]]/{printf \"%s,\\n\",$1}",
-		"descr": "yoyo IPs",
-		"flag": "tcp 80 443"
 	}
 }


### PR DESCRIPTION
When banip can't download a list, it remains stack for many minutes.
As result, the first configuration seems not working at all from the user perspective.

Changes:
- grab latest releases from upstream: https://github.com/openwrt/packages/commit/7383b4817b2482dab24b15c91311c83cd7fbdea9
- delete non-working lists