### PR TITLE
fix: distfeed-setup was not setting dev channel

### DIFF
--- a/packages/ns-plug/files/distfeed-setup
+++ b/packages/ns-plug/files/distfeed-setup
@@ -24,6 +24,9 @@ if [ -z "$channel" ]; then
         fi
         base_url="$base_url/$channel"
     fi
+else
+    # Setup from env
+    base_url="$base_url/$channel"
 fi
 
 if [ -z "$owrt_version" ]; then


### PR DESCRIPTION
The CHANNEL option given from env was ignored.

This documentation can't be applied: https://dev.nethsecurity.org/design/distfeed/#customization-options