### PR TITLE
HA: minor fixes

### DIFF
--- a/packages/ns-api/files/ns.ha
+++ b/packages/ns-api/files/ns.ha
@@ -642,6 +642,8 @@ def init_local(role, primary_node_ip, backup_node_ip, virtual_ip, pubkey = "", p
     subprocess.run(['/etc/init.d/conntrackd', 'enable'], capture_output=True)
     subprocess.run(['/etc/init.d/conntrackd', 'restart'], capture_output=True)
 
+    # Enable keepalived if previously disabled by reset API
+    subprocess.run(['/etc/init.d/keepalived', 'enable'], capture_output=True)
     # Sometimes keepalived does not start correctly, so we need to restart it
     subprocess.run(['/etc/init.d/keepalived', 'restart'], capture_output=True)
 

--- a/packages/ns-api/files/ns.ha
+++ b/packages/ns-api/files/ns.ha
@@ -1033,6 +1033,9 @@ def remove_interface(role, interface):
         return { "success": True }
 
 def upgrade_remote(image):
+    if not os.path.isfile(image):
+        return utils.generic_error("image_file_not_found")
+
     # Upload the image to the backup node
     if not upload_remote_file(image, "/var/run/ns-api-server/uploads/upgrade.img"):
         return utils.generic_error("error_uploading_image_to_backup_node")

--- a/packages/ns-ha/files/ns-ha-config
+++ b/packages/ns-ha/files/ns-ha-config
@@ -509,11 +509,11 @@ upgrade_remote() {
   fi
 
   echo -n "Upgrading remote node... "
-  OUTPUT=$(echo '{"image": "'$IMAGE'"}' | /usr/libexec/rpcd/ns.ha call upgrade-remote | jq -r '.success')
+  OUTPUT=$(echo '{"image": "'$IMAGE'"}' | /usr/libexec/rpcd/ns.ha call upgrade-remote)
 
-  if [[ $? -ne 0 ]]; then
+  if [[ $(echo $OUTPUT | jq -r .result) != "success" ]]; then
     error
-    echo "Failed to upgrade the remote node."
+    echo "Failed to upgrade the remote node: "$(echo $OUTPUT | jq -r .error)
     exit 1
   fi
   success


### PR DESCRIPTION
Changes:
* [`packages/ns-api/files/ns.ha`](diffhunk://#diff-2f5f54847acc6115b8ec5a04723bd54d8adabb9531d13a55035429739fd9ac43R645-R646): Added a step to enable `keepalived` in the `init_local` function to ensure it is active if previously disabled by the reset API.
* [`packages/ns-api/files/ns.ha`](diffhunk://#diff-2f5f54847acc6115b8ec5a04723bd54d8adabb9531d13a55035429739fd9ac43R1036-R1038): Added a check in the `upgrade_remote` function to return an error if the specified image file does not exist, preventing further processing.
* [`packages/ns-ha/files/ns-ha-config`](diffhunk://#diff-14ec4f5b2ddfbdd40330ebb3510b8526c067fefcd004a50d67f21f4a81d4f70aL512-R516): Updated the `ns-ha-config` script to provide detailed error messages by parsing and displaying the error field from the RPC response when the upgrade fails.