### PR TITLE
fix(flashstart): reverted rebind_protection logic

### DIFF
--- a/packages/ns-flashstart/Makefile
+++ b/packages/ns-flashstart/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-flashstart
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.0.1
 PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-flashstart-$(PKG_VERSION)

--- a/packages/ns-flashstart/README.md
+++ b/packages/ns-flashstart/README.md
@@ -42,11 +42,11 @@ reload_config
 
 ## DNS server customization
 
-You can disable `rebind_protection` or enable `logqueries` options for the DNS servers by setting the variables in the
+You can enable `rebind_protection` or enable `logqueries` options for the DNS servers by setting the variables in the
 `flashstart.global` section:
 
 ```
-uci set flashstart.global.rebind_protection="0"
+uci set flashstart.global.rebind_protection="1"
 uci set flashstart.global.logqueries="1"
 uci commit flashstart
 reload_config

--- a/packages/ns-flashstart/files/ns-flashstart
+++ b/packages/ns-flashstart/files/ns-flashstart
@@ -214,7 +214,7 @@ def __sync_pro_profiles():
 
 def __add_profile(port, profile):
     query_logging = e_uci.get('flashstart', 'global', 'logqueries', default=False, dtype=bool)
-    rebind_protection = e_uci.get('flashstart', 'global', 'rebind_protection', default=True, dtype=bool)
+    rebind_protection = e_uci.get('flashstart', 'global', 'rebind_protection', default=False, dtype=bool)
     if e_uci.get('dhcp', profile['id'], default=None) is None:
         logging.info(f'New profile found {profile["name"]}, creating instance {profile["id"]}.')
         e_uci.set('dhcp', profile['id'], 'dnsmasq')


### PR DESCRIPTION
Reverting rebind protection in flashstart, disabled by default.
