### PR TITLE
fix(ns-plug): overwrite gpg signed backup if already exists

### DIFF
--- a/packages/ns-plug/files/send-backup
+++ b/packages/ns-plug/files/send-backup
@@ -19,7 +19,7 @@ PASSPHRASE="/etc/backup.pass"
 function send {
     if [ -s $PASSPHRASE ]; then
         # send encrypted backup
-        gpg --batch -c --passphrase-file $PASSPHRASE $BACKUP
+        gpg --batch -c --yes --passphrase-file $PASSPHRASE $BACKUP
         remote-backup upload "$BACKUP.gpg"
     else
         remote-backup upload "$BACKUP"


### PR DESCRIPTION
If a connection issue happens while the backup is being sent, the script will fail every time the backup starts because GPG refuses to overwrite signed file.
Force gpg to overwrite such file, even if the command fails.

Discussion: https://mattermost.nethesis.it/nethesis/pl/bxzf3z5g1jfuubrpa3du7itmhy
