### PR TITLE
feat(ns-api): using default ns_dnsmasq instance for dhcps

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -187,6 +187,7 @@ define Package/ns-api/install
 	$(INSTALL_BIN) ./files/uci-defaults/99-ns-api.dropbear $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/uci-defaults/19-ns-api.wizard $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/uci-defaults/99-ns-api.synflood $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/uci-defaults/99-ns-api.dnsmasq $(1)/etc/uci-defaults
 endef
  
 $(eval $(call BuildPackage,ns-api))

--- a/packages/ns-api/files/ns.dhcp
+++ b/packages/ns-api/files/ns.dhcp
@@ -154,6 +154,7 @@ def edit_interface(args):
     u.set("dhcp", dhcp_id, "leasetime", args["leasetime"])
     u.set("dhcp", dhcp_id, "interface", args['interface'])
     u.set("dhcp", dhcp_id, "force", '1' if args.get('force', False) else '0')
+    u.set("dhcp", dhcp_id, "instance", "ns_dnsmasq")
     if 'ns_binding' in args:
         u.set("dhcp", dhcp_id, "ns_binding", args.get('ns_binding'))
     opts = []

--- a/packages/ns-api/files/uci-defaults/99-ns-api.dnsmasq
+++ b/packages/ns-api/files/uci-defaults/99-ns-api.dnsmasq
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# setting a default name for the main dnsmasq instance
+# Issue: https://github.com/NethServer/nethsecurity/issues/1287
+
+if ! uci -q get dhcp.ns_dnsmasq > /dev/null && [ "$(uci -q get dhcp.@dnsmasq[0])" = "dnsmasq" ]; then
+  uci rename dhcp.@dnsmasq[0]=ns_dnsmasq > /dev/null
+fi
+
+if [ "$(uci -q get dhcp.ns_dnsmasq)" = "dnsmasq" ]; then
+  for i in $(uci show dhcp | grep -Po '^dhcp\.([^=]+)(?==dhcp$)'); do
+    uci -q set "$i.instance=ns_dnsmasq" > /dev/null
+  done
+fi
+
+uci commit dhcp


### PR DESCRIPTION
This will make also obsolete the flag of set a custom DNS server when using flashstart.

Closes https://github.com/NethServer/nethsecurity/issues/1287
