### PR TITLE
chore(base-files): Better TERM for serial console

### DIFF
--- a/files/usr/libexec/login.sh
+++ b/files/usr/libexec/login.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
 
-[ "$(uci -q get system.@system[0].ttylogin)" = 1 ] || exec /bin/ash --login
+[ -t 0 ] && {
+	tty_dev=$(readlink /proc/self/fd/0)
+	case "$tty_dev" in
+		/dev/console|/dev/tty[0-9]*)
+			export TERM=${TERM:-linux}
+			;;
+		/dev/*)
+			export TERM=vt102
+			;;
+	esac
+}
+
+[ "$(uci -q get system.@system[0].ttylogin)" = 1 ] || exec /bin/login -f root
 
 [ -f /etc/keymap ] && /sbin/loadkmap < /usr/share/keymaps/$(/bin/cat /etc/keymap).map.bin 2>/dev/null
 


### PR DESCRIPTION
Use "vt102" for serial console terminal
See https://github.com/openwrt/openwrt/commit/1310e4f1aecef6c2c1b68227216ba7cc04006002 for details.