### PR TITLE
fix(ns-api): edit dhcp doesn't check correctly for duplicates

### DIFF
--- a/packages/ns-api/files/ns.dhcp
+++ b/packages/ns-api/files/ns.dhcp
@@ -301,7 +301,8 @@ def edit_static_lease(args):
     # exclude the lease we are editing from MAC duplication check
     if is_reserved(u, args["macaddr"], args["lease"]):
         return utils.validation_error("mac", "mac_already_reserved", args["macaddr"])
-    if count_ip_occurrences(u, args["ipaddr"]) > 1:
+    # check if the IP address is already reserved, but not for the current lease
+    if count_ip_occurrences(u, args["ipaddr"]) > 0 and u.get('dhcp', args['lease'], 'ip', default='') != args["ipaddr"]:
         return utils.validation_error("ipaddr", "ip_already_reserved", args["ipaddr"])
     lname = args["lease"]
     u.set('dhcp', lname, 'host')


### PR DESCRIPTION
Fixes issue where edit could overlap existing IPs reservations.

Discussion: https://mattermost.nethesis.it/nethesis/pl/85xrrxbstj8pdr1yfjex1hhaze
Ticket: https://helpdesk.nethesis.it/a/tickets/192800
