### PR TITLE
fix(ns-api): dhcp, set noresolv option

### DIFF
--- a/packages/ns-api/files/ns.dns
+++ b/packages/ns-api/files/ns.dns
@@ -149,6 +149,10 @@ def set_config(args):
            if type(val) == type(True):
                val = bool2str(val)
            u.set("dhcp", section, opt, val)
+        if 'server' in opt and len(args['server']) > 0:
+           u.set("dhcp", section, 'noresolv', '1')
+        else:
+           u.set("dhcp", section, 'noresolv', '0')
         u.save("dhcp")
     except:
         return utils.generic_error("config_write_error")


### PR DESCRIPTION
If no upstream DNS is configured, use DNS from WAN provider. Otherwise, make sure to use only configured DNS and do not include the one obtained with DHCP/PPPoE.

Note: the configuration is applied only from the web interface, configuration on existing machines will not be updated.

Fixes #1253 