### PR TITLE
fix(scan): fixed name resolution

### DIFF
--- a/packages/ns-api/files/ns.scan
+++ b/packages/ns-api/files/ns.scan
@@ -43,7 +43,7 @@ def scan(device):
             if len(parts) < 2:
                 continue
             try:
-                hostname = socket.getnameinfo((parts[1], 0), 0)[0]
+                hostname = socket.getnameinfo((parts[0], 0), 0)[0]
             except:
                 hostname = ""
             ret.append({"mac": parts[1], "ip": parts[0], "hostname": hostname, "description": parts[2] if len(parts) > 2 else ""})


### PR DESCRIPTION
Seems that we were using the mac address in the `1` position instead of the ip (in position `0`). Could be something changed when the package updated? Maybe @gsanchietti knows something more.

Closes: https://github.com/NethServer/nethsecurity/issues/1401

