### PR TITLE
fix(ns-ha): do not start interfaces on boot on S

### DIFF
--- a/packages/ns-ha/files/ns-ha-import
+++ b/packages/ns-ha/files/ns-ha-import
@@ -25,6 +25,7 @@ def import_interfaces(file):
     for interface, options in interfaces.items():
         u.set('network', interface, 'interface')
         u.set('network', interface, 'ns_tag', ['ha'])
+        u.set('network', interface, 'auto', '0')
         for opt in options:
             u.set('network', interface, opt, options[opt])
     u.commit('network')


### PR DESCRIPTION
All interfaces except those managed by keepalived are not started on boot on the backup system (auto=0).