### PR TITLE
build: add bnxt-en driver

### DIFF
--- a/config/ethernets.conf
+++ b/config/ethernets.conf
@@ -1,1 +1,0 @@
-CONFIG_PACKAGE_kmod-i40e=y

--- a/config/network_cards.conf
+++ b/config/network_cards.conf
@@ -8,3 +8,4 @@ CONFIG_PACKAGE_kmod-phylink=y
 CONFIG_PACKAGE_kmod-sfp=y
 CONFIG_PACKAGE_kmod-vmxnet3=y
 CONFIG_PACKAGE_kmod-bnxt-en=y
+CONFIG_PACKAGE_kmod-i40e=y


### PR DESCRIPTION
Support for Broadcom NetXtreme-C/E based Ethernet network chips like BCM573xx and BCM574xx.