### PR TITLE
fix: fixed duplicate data push to controller

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-api
-PKG_VERSION:=3.4.4
+PKG_VERSION:=3.4.5
 PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-api-$(PKG_VERSION)

--- a/packages/ns-api/files/ns.controller
+++ b/packages/ns-api/files/ns.controller
@@ -242,12 +242,22 @@ def dump_dpi_stats():
     ret = []
     for file, timestamp in find_recent_files("/var/run/dpireport", 20):
         # parse the filename to get the date client
-        tmp = file.removeprefix('/var/run/dpireport/').split('/')
+        file_split = file.removeprefix('/var/run/dpireport/').split('/')
+        year = int(file_split[0])
+        month = int(file_split[1])
+        day = int(file_split[2])
+        client_address = file_split[3]
+        hour = int(file_split[4].replace('.json', ''))
+
         with open(file, "r") as f:
             data = json.load(f)
         for key in ("protocol", "host", "application"):
             for el in data.get(key, {}):
-                ret.append({"timestamp": int(timestamp), "client_address": tmp[3], "client_name": reverse_dns(tmp[3]), key: el, "bytes": data[key][el]})
+                ret.append({
+                    "timestamp": int(datetime(year, month, day, hour, 0, 0).timestamp()),
+                    "client_address": client_address, "client_name": reverse_dns(client_address), key: el,
+                    "bytes": data[key][el]
+                })
     return {"data": ret}
 
 def dump_openvpn_connections():

--- a/packages/ns-report/Makefile
+++ b/packages/ns-report/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-report
-PKG_VERSION:=0.0.4
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-report-$(PKG_VERSION)

--- a/packages/ns-report/files/dpireport
+++ b/packages/ns-report/files/dpireport
@@ -20,7 +20,7 @@ import traceback
 from datetime import datetime, date
 
 flow_stale_timeout = int(os.environ.get("FLOW_STALE_TIMEOUT", 3600))
-dump_timeout = int(os.environ.get("DUMP_TIMEOUT", 120))
+dump_timeout = int(os.environ.get("DUMP_TIMEOUT", 60))
 last_hour = datetime.now().strftime("%H")
 last_date = datetime.today()
 run = True


### PR DESCRIPTION
The `ns.controller` when generating the data to push upstream, could aggregate data from different hours which caused issues with reports mismatch between the local machine and the controller. Now the data sent is being synced to the time of the json underneath, which associates correctly the data with the time.

Additionally made the `dpireport` component dump out the data every 60 seconds, so that when sent up to the controller should always be up to date. 

Closes: https://github.com/NethServer/nethsecurity/issues/1471