### PR TITLE
fix(api): ovpn_rw, cleanup pki dir

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -238,8 +238,9 @@ def add_instance():
         return utils.validation_error("instance", "instance_already_exists", instance)
 
     tun = f'tunrw{next_instance}'
-    if os.path.isdir(f'/etc/openvpn/{instance}'):
-        return utils.validation_error("instance", "pki_dir_already_exists", instance)
+    if os.path.isdir(f'/etc/openvpn/{instance}') and instance not in instances:
+        # cleanup pki dir: the directory may contain rubbish on some corner cases
+        shutil.rmtree(f"/etc/openvpn/{instance}", ignore_errors=True)
 
     zone_link = ""
     fw_link = f"openvpn/{instance}"


### PR DESCRIPTION
Sometimes the pki dir may contain rubbish, just delete it when not needed.
The condition is hardly reproducible but it has been found on several existing machines.

How to reproduce:
- Execute: `mkdir /etc/openvpn/ns_roadwarrior1`
- Access the OpenVPN Road Warrior page and try to create a new server


Fixes: https://github.com/NethServer/nethsecurity/issues/1492