### PR TITLE
fix(wireguard): mtu for peers and config adjustments

### DIFF
--- a/packages/ns-api/files/ns.wireguard
+++ b/packages/ns-api/files/ns.wireguard
@@ -27,6 +27,23 @@ def __next_instance():
     return None
 
 
+def __set_list_to_uci(e_uci: EUci, config: str, section: str, option: str, new_value: list):
+    """
+    Set the list to the UCI option only if the new value is different
+    from the current one to avoid unnecessary UCI commits.
+
+    Args:
+        e_uci: EUci instance
+        config: UCI config name
+        section: UCI section name
+        option: UCI option name
+        new_value: The new list value to set
+    """
+    current_value = set(e_uci.get(config, section, option, default=[], list=True, dtype=str))
+    if set(new_value) != current_value:
+        e_uci.set(config, section, option, new_value)
+
+
 def generate_wireguard_keys():
     private_key = subprocess.run(["wg", "genkey"], capture_output=True, text=True).stdout.strip()
     public_key = subprocess.run(["wg", "pubkey"], input=private_key, capture_output=True, text=True).stdout.strip()
@@ -327,14 +344,15 @@ def edit_server(args):
     e_uci.set('network', args['instance'], 'listen_port', args['listen_port'])
     interface_network = ipaddress.IPv4Network(args['network'])
     first_ip = str(list(interface_network.hosts())[0])
-    e_uci.set('network', args['instance'], 'addresses', [first_ip + '/'+ str(interface_network.prefixlen)])
+    addresses = [first_ip + '/'+ str(interface_network.prefixlen)]
+    __set_list_to_uci(e_uci, 'network', args['instance'], 'addresses', addresses)
     e_uci.set('network', args['instance'], 'ns_network', args['network'])
     if 'mtu' in args and args['mtu'] != '':
         e_uci.set('network', args['instance'], 'mtu', args['mtu'])
     else:
         e_uci.delete('network', args['instance'], 'mtu')
     filter_dns = list(filter(lambda x: x != "", args.get("dns", [])))
-    e_uci.set('network', args['instance'], 'ns_dns', filter_dns)
+    __set_list_to_uci(e_uci, 'network', args['instance'], 'ns_dns', filter_dns)
     e_uci.set('network', args['instance'], 'ns_public_endpoint', args['public_endpoint'])
     e_uci.set('network', args['instance'], 'ns_name', args['name'])
     e_uci.set('network', args['instance'], 'disabled', not args['enabled'])
@@ -494,13 +512,16 @@ def edit_peer(args):
         for net in args['local_networks']:
             if net != '':
                 networks.append(net)
-        e_uci.set('network', args['id'], 'ns_local_routes', networks)
+        __set_list_to_uci(e_uci, 'network', args['id'], 'ns_local_routes', networks)
+    else:
+        e_uci.delete('network', args['id'], 'ns_local_routes')
     networks = []
     for net in args['remote_networks']:
         if net != '':
             networks.append(net)
-    e_uci.set('network', args['id'], 'ns_routes', networks)
-    e_uci.set('network', args['id'], 'allowed_ips', networks + [args['reserved_ip'] + '/32'])
+    __set_list_to_uci(e_uci, 'network', args['id'], 'ns_routes', networks)
+    allowed_ips = networks + [args['reserved_ip'] + '/32']
+    __set_list_to_uci(e_uci, 'network', args['id'], 'allowed_ips', allowed_ips)
     e_uci.set('network', args['id'], 'ns_ip', args['reserved_ip'])
     if 'mtu' in args and args['mtu'] != '':
         e_uci.set('network', args['id'], 'ns_mtu', args['mtu'])
@@ -779,7 +800,8 @@ def edit_tunnel(args):
         return utils.validation_error('peer_id', 'invalid', args['peer_id'])
 
     e_uci.set('network', args['id'], 'private_key', args['peer_private_key'])
-    e_uci.set('network', args['id'], 'addresses', [args['reserved_ip']])
+    addresses = [args['reserved_ip']]
+    __set_list_to_uci(e_uci, 'network', args['id'], 'addresses', addresses)
     e_uci.set('network', args['id'], 'ns_name', args['name'])
     e_uci.set('network', args['id'], 'disabled', not args['enabled'])
 
@@ -796,13 +818,13 @@ def edit_tunnel(args):
     else:
         allowed_ips += args["network_routes"]
     e_uci.set('network', args['peer_id'], 'ns_name', args['name'])
-    e_uci.set('network', args['peer_id'], 'allowed_ips', allowed_ips)
+    __set_list_to_uci(e_uci, 'network', args['peer_id'], 'allowed_ips', allowed_ips)
     e_uci.set('network', args['peer_id'], 'reserved_ip', args['reserved_ip'])
     e_uci.set('network', args['peer_id'], 'endpoint_host', args['endpoint'])
     e_uci.set('network', args['peer_id'], 'endpoint_port', args['udp_port'])
     e_uci.set('network', args['peer_id'], 'persistent_keepalive', args.get('persistent_keepalive', '25'))
     if 'dns' in args:
-        e_uci.set('network', args['id'], 'dns', args['dns'])
+        __set_list_to_uci(e_uci, 'network', args['id'], 'dns', args['dns'])
     e_uci.save('network')
 
     return {"result": "success"}


### PR DESCRIPTION
- removed persistent keepalive from server
- fixed issue with empty string on allowed ips
- added mtu field for peers
- fixed issue where some fields were not deleted correctly during edit
- removed continuous setting of arrays if they not change

Closes: https://github.com/NethServer/nethsecurity/issues/1463
Closes: https://github.com/NethServer/nethsecurity/issues/1467
