### PR TITLE
fix(snort): removed default network, fixed fetch of default homenet

### DIFF
--- a/packages/ns-api/files/ns.snort
+++ b/packages/ns-api/files/ns.snort
@@ -187,10 +187,10 @@ def __save_settings():
 def __settings():
     e_uci = EUci()
     try:
-        home_net = e_uci.get('snort', 'snort', 'home_net', default='').split(' ')
+        home_net = e_uci.get('snort', 'snort', 'home_net', default=None).split(' ')
     except:
         home_net = []
-    if not home_net:
+    if len(home_net) < 1:
         home_net = get_snort_homenet(e_uci, include_vpn=False)
 
     return {

--- a/packages/snort3/files/snort.config
+++ b/packages/snort3/files/snort.config
@@ -52,7 +52,6 @@ config snort 'snort'
 	option enabled         '0'              # one of [0, 1]
 	option manual          '1'              # one of [0, 1]
 	option oinkcode        ''               # a string
-	option home_net        '192.168.1.0/24' # a string
 	option external_net    'any'            # a string
 	option config_dir      '/etc/snort'     # a path string
 	option temp_dir        '/var/snort.d'   # a path string


### PR DESCRIPTION
When snort hasn't been set up yet, the default network is `192.168.1.0/24`, removing this default for new installations.
Solved an issue where `get_snort_homenet` function was never being called due to always being not `None`.
