### PR TITLE
chore(netifyd): bump release

### DIFF
--- a/packages/netifyd/Makefile
+++ b/packages/netifyd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifyd
 PKG_VERSION:=2025.10.01-5.1.25
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Darryl Sokoloski <darryl@egloo.ca>
 PKG_LICENSE:=Unlicensed
 


### PR DESCRIPTION
Force execution of new version of uci-default
which always enable the netifyd service


See also https://github.com/NethServer/nethsecurity/pull/1513