### PR TITLE
fix(ns.ovpntunnel): enhance certificate extraction logic to support role labels

### DIFF
--- a/packages/ns-api/files/ns.ovpntunnel
+++ b/packages/ns-api/files/ns.ovpntunnel
@@ -65,7 +65,7 @@ def remove_files(file_list):
         except OSError:
             pass
 
-def get_certificates_from_pem(pem_path):
+def get_certificates_from_pem(pem_path, role_label=None):
     """Extract certificate CN and expiration date from PEM file containing one or more certificates"""
     try:
         with open(pem_path, 'r') as f:
@@ -109,10 +109,17 @@ def get_certificates_from_pem(pem_path):
                         except:
                             pass
 
-                # Map NethSec CN to CA
-                if cn == 'NethSec':
-                    cn = 'CA'
-                certificates[cn] = expiry_ts
+                # server peer: use role_label for server
+                if role_label:
+                    label = role_label
+                else:
+                    # client peer: use 'client' if CN=client, 'CA' otherwise to client
+                    if cn == 'client':
+                        label = 'client'
+                    else:
+                        label = 'CA'
+                
+                certificates[label] = expiry_ts
             except:
                 pass
 
@@ -418,11 +425,11 @@ def list_tunnels():
 
             certificates = {}
             if vpn.get('cert'):
-                certificates = get_certificates_from_pem(vpn.get('cert'))
+                certificates.update(get_certificates_from_pem(vpn.get('cert'), 'server'))
                 client_crt = vpn.get('cert').replace('/issued/server.crt', '/issued/client.crt')
-                certificates.update(get_certificates_from_pem(client_crt))
+                certificates.update(get_certificates_from_pem(client_crt, 'client'))
             if vpn.get('ca'):
-                certificates.update(get_certificates_from_pem(vpn.get('ca')))
+                certificates.update(get_certificates_from_pem(vpn.get('ca'), 'CA'))
             server["certificates"] = certificates
 
             servers.append(server)


### PR DESCRIPTION
This pull request refactors how certificate roles are labeled and managed when extracting certificate information from PEM files in the `ns.ovpntunnel` module. The changes improve clarity and consistency in how server, client, and CA certificates are labeled and handled, especially to manage case where the hostname is not arbitrary "NethSec".

**Certificate handling improvements:**

* The `get_certificates_from_pem` function now accepts an optional `role_label` parameter to explicitly assign a role label (e.g., 'server', 'client', 'CA') to extracted certificates, improving clarity and flexibility.
* The logic for assigning certificate labels has been updated: when `role_label` is provided, it's used directly; otherwise, the label defaults to 'client' for client certificates and 'CA' for others, replacing the previous logic that mapped the CN 'NethSec' to 'CA'.

**Integration with VPN tunnel listing:**

* In the `list_tunnels` function, certificate extraction now consistently uses the new `role_label` parameter to assign 'server', 'client', or 'CA' labels when updating the certificates dictionary for each VPN tunnel. This ensures the correct association of certificate roles in the output. In particular:
    - ```server peer```: use ```role_label``` parameter to force certificate key on response payload
    - ```client peer```: use ```client``` if CN is equal to ```client```, ```CA``` otherwise. In this case, the two certificates are contained inside the same file (```/etc/openvpn/{instance}/pki/cert.pem```).