### PR TITLE
fix(ns.qos): invert bandwidth for non-WAN interfaces in QoS settings

### DIFF
--- a/packages/ns-api/files/ns.qos
+++ b/packages/ns-api/files/ns.qos
@@ -83,7 +83,9 @@ elif cmd == 'call':
                 download = int(interface['bandwidth_down'].removesuffix('mbit'))
                 # invert if not WAN interface
                 if not is_wan_interface(e_uci, key):
-                    upload, download = download, upload
+                    temp = upload
+                    upload = download
+                    download = temp
                 result.append({
                     'interface': key,
                     'device': device,
@@ -103,7 +105,9 @@ elif cmd == 'call':
 
             # invert bandwidth for non-WAN interfaces before saving
             if not is_wan_interface(e_uci, data['interface']):
-                data['upload'], data['download'] = data['download'], data['upload']
+                upload = data['upload']
+                data['upload'] = data['download']
+                data['download'] = upload
 
             e_uci.set('qosify', data['interface'], 'interface')
             e_uci.set('qosify', data['interface'], 'name', data['interface'])
@@ -150,7 +154,9 @@ elif cmd == 'call':
 
             # invert bandwidth for non-WAN interfaces before saving
             if not is_wan_interface(e_uci, data['interface']):
-                data['upload'], data['download'] = data['download'], data['upload']
+                upload = data['upload']
+                data['upload'] = data['download']
+                data['download'] = upload
 
             e_uci.set('qosify', data['interface'], 'disabled', data['disabled'])
             e_uci.set('qosify', data['interface'], 'bandwidth_up', f'{data["upload"]}mbit')


### PR DESCRIPTION
This pull request improves how bandwidth values are handled for WAN and non-WAN interfaces in the `ns.qos` API logic. The main change is to ensure that upload and download bandwidth values are correctly assigned based on the interface type, preventing incorrect bandwidth inversion for non-WAN interfaces. A helper function is introduced to reliably identify WAN interfaces, and the logic for retrieving and saving bandwidth values is updated accordingly.

**Bandwidth handling improvements:**

* Added a new helper function `is_wan_interface` to determine if a given interface is a WAN interface, defaulting to WAN if the interface type is unknown.
* When retrieving interface bandwidths, now inverts upload and download values for non-WAN interfaces to ensure values are reported correctly on the UI.
* When saving bandwidth settings for an interface (both on create and update), now inverts upload and download values for non-WAN interfaces before saving to configuration, ensuring consistent data storage.

Closes: https://github.com/NethServer/nethsecurity/issues/1524