### PR TITLE
fix(ovpnrw-rw): remove error print statements in certificate renewal functions

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -1084,7 +1084,6 @@ def renew_server_certificate(ovpninstance):
         subprocess.run(["/usr/sbin/ns-openvpn-renew-server", ovpninstance], check=True, capture_output=True)
         subprocess.run(["/etc/init.d/openvpn", "restart", ovpninstance], check=False, capture_output=True)
     except Exception as e:
-        print(e, file=sys.stderr)
         return utils.validation_error("instance", "server_certificate_renewal_failed", ovpninstance)
     return {"result": "success"}
 
@@ -1093,7 +1092,6 @@ def regenerate_all_certificates(ovpninstance):
         subprocess.run(["/usr/sbin/ns-openvpn-renew-ca", ovpninstance], check=True, capture_output=True)
         subprocess.run(["/etc/init.d/openvpn", "restart", ovpninstance], check=False, capture_output=True)
     except Exception as e:
-        print(e, file=sys.stderr)
         return utils.validation_error("instance", "certificates_regeneration_failed", ovpninstance)
     return {"result": "success"}
 


### PR DESCRIPTION
This pull request makes a minor change to error handling in the `ns.ovpnrw` file by removing the printing of exception details to standard error when certificate renewal or regeneration fails. This results in cleaner error handling output without exposing internal exception messages, avoiding UI problems when an error occurs (actually the UI won't show the error but a 200 OK response code).