### PR TITLE
feat(ns-api): add update-timezone script for post-commit processing

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2026 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
@@ -179,6 +179,7 @@ define Package/ns-api/install
 	$(INSTALL_BIN) ./files/pre-commit/update-objects.py $(1)/usr/libexec/ns-api/pre-commit
 	$(INSTALL_BIN) ./files/post-commit/reload-ipsets.py $(1)/usr/libexec/ns-api/post-commit
 	$(INSTALL_BIN) ./files/post-commit/restart-cron.py $(1)/usr/libexec/ns-api/post-commit
+	$(INSTALL_BIN) ./files/post-commit/update-timezone.py $(1)/usr/libexec/ns-api/post-commit
 	$(INSTALL_BIN) ./files/post-commit/restart-wireguard.py $(1)/usr/libexec/ns-api/post-commit
 	$(INSTALL_BIN) ./files/pre-commit/clean-network.py $(1)/usr/libexec/ns-api/pre-commit
 	$(INSTALL_BIN) ./files/remove-pppoe-keepalive $(1)/usr/share/ns-api

--- a/packages/ns-api/files/post-commit/update-timezone.py
+++ b/packages/ns-api/files/post-commit/update-timezone.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+import subprocess
+
+if 'system' in changes:
+    system_changes = changes['system']
+    timezone_value = None
+    zonename_value = None
+    
+    # extract timezone and zonename values from changes
+    for change in system_changes:
+        if len(change) >= 4:
+            if change[2] == 'timezone':
+                timezone_value = change[3]
+            elif change[2] == 'zonename':
+                zonename_value = change[3]
+    
+    # update symlink and TZ variable if changed
+    if zonename_value:
+        # replace spaces with underscores like /etc/init.d/system does
+        zonename_normalized = zonename_value.replace(' ', '_')
+        subprocess.run(["/bin/ln", "-sf", f"/usr/share/zoneinfo/{zonename_normalized}", "/etc/localtime"], check=True, capture_output=True)
+    
+    if timezone_value:
+        subprocess.run(["/bin/sh", "-c", f"echo '{timezone_value}' > /tmp/TZ"], check=True, capture_output=True)


### PR DESCRIPTION
This pull request adds timezone update functionality to the `ns-api` package. The main change is the introduction of a new post-commit hook script that updates the system timezone when relevant configuration changes are detected. Additionally, the installation process is updated to include this new script.

**Timezone update feature:**

* Added new post-commit hook `update-timezone.py` to update the `/etc/localtime` symlink and `/tmp/TZ` variable when system timezone or zonename changes are detected. (`packages/ns-api/files/post-commit/update-timezone.py`)
* Modified the installation process in the `Makefile` to install the new `update-timezone.py` script as part of the post-commit hooks. (`packages/ns-api/Makefile`)

Closes: https://github.com/NethServer/nethsecurity/issues/1454