### PR TITLE
fix(netifyd): disabled coredumps

### DIFF
--- a/packages/netifyd/Makefile
+++ b/packages/netifyd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifyd
 PKG_VERSION:=2025.10.01-5.1.25
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Darryl Sokoloski <darryl@egloo.ca>
 PKG_LICENSE:=Unlicensed
 
@@ -178,6 +178,7 @@ define Package/netifyd/install
 	$(INSTALL_BIN) ./files/etc/uci-defaults/99-netify-v4-migrate.uci-default $(1)/etc/uci-defaults/99-netify-v4-migrate
 	$(INSTALL_BIN) ./files/etc/uci-defaults/99-netify-enable-nfqueue.uci-default $(1)/etc/uci-defaults/99-netify-enable-nfqueue
 	$(INSTALL_BIN) ./files/etc/uci-defaults/99-netify-disable-autoconfig.uci-default $(1)/etc/uci-defaults/99-netify-disable-autoconfig
+	$(INSTALL_BIN) ./files/etc/uci-defaults/99-netify-disable-coredumps.uci-default $(1)/etc/uci-defaults/99-netify-disable-coredumps
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/netifyd $(1)/usr/sbin/netifyd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/libnetifyd.so.4.0.0 $(1)/usr/lib/libnetifyd.so.4.0.0
 	$(INSTALL_DATA) ./files/usr/share/netifyd/functions.sh $(1)/usr/share/netifyd/functions.sh

--- a/packages/netifyd/files/etc/netifyd.conf
+++ b/packages/netifyd/files/etc/netifyd.conf
@@ -32,4 +32,7 @@ path_license_manager = ${path_plugin_libdir}/libnetify-plm.so
 # command-line parameters.
 auto_informatics = no
 
+# disabling coredumps
+enable_coredumps = no
+
 # vim: set ft=dosini :

--- a/packages/netifyd/files/etc/uci-defaults/99-netify-disable-coredumps.uci-default
+++ b/packages/netifyd/files/etc/uci-defaults/99-netify-disable-coredumps.uci-default
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# Add enable_coredumps = no to netifyd.conf if not already set
+if ! grep -q 'enable_coredumps' /etc/netifyd.conf; then
+    sed -i '/^# vim:/i enable_coredumps = no' /etc/netifyd.conf
+fi


### PR DESCRIPTION
Despite of what the configuration says, the `enable_coredumps` seems to have as it's defaults `on`, this causes issues in our installations since the tmpfs is very small and consistent crashes fill it up very quickly.

Settings: https://www.netify.ai/documentation/netify-agent/v5/configuration/settings 