### PR TITLE
fix(ns-ipsec): synchronize disabled state for existing routes in edit tunnel API

### DIFF
--- a/packages/ns-api/files/ns.ipsectunnel
+++ b/packages/ns-api/files/ns.ipsectunnel
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2026 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-2.0-only
 #
 


### PR DESCRIPTION
This pull request makes improvements to the management of route state when editing an IPsec tunnel in the `ns.ipsectunnel` module. The main focus is on ensuring that the enabled/disabled status of the tunnel is consistently applied to all associated routes.

Route state synchronization:

* Introduced the `route_disabled` variable to centralize the logic for determining route disabled state based on the tunnel's `enabled` argument.
* Updated route creation logic to use the new `route_disabled` variable for setting the disabled state, ensuring consistency.
* Added a loop to synchronize the disabled state across all existing routes linked to the tunnel, using `uci_set_if_changed` to update only when necessary.

Closes: https://github.com/NethServer/nethsecurity/issues/1558