### PR TITLE
fix(ns-api): get total memory from meminfo

### DIFF
--- a/packages/ns-api/files/ns.dashboard
+++ b/packages/ns-api/files/ns.dashboard
@@ -68,19 +68,26 @@ def _get_avail_bytes(path):
         return 0
 
 def get_memory():
-    mem_info = {}
     try:
+        mem_total = None
+        mem_available = None
         with open('/proc/meminfo', 'r') as f:
             for line in f:
-                if ':' in line:
-                    key, value = line.split(':', 1)
-                    mem_info[key.strip()] = int(value.strip().split()[0]) * 1024
+                if line.startswith('MemTotal:'):
+                    mem_total = int(line.split()[1]) * 1024
+                elif line.startswith('MemAvailable:'):
+                    mem_available = int(line.split()[1]) * 1024
+                if mem_total is not None and mem_available is not None:
+                    break
+        return {
+            "mem_total": mem_total if mem_total is not None else 0,
+            "mem_available": mem_available if mem_available is not None else 0
+        }
     except:
-        pass
-    return {
-        "MemTotal": mem_info.get('MemTotal', 0),
-        "MemAvailable": mem_info.get('MemAvailable', 0)
-    }
+        return {
+            "mem_total": 0,
+            "mem_available": 0
+        }
 
 def get_storage():
     return {


### PR DESCRIPTION
The total amount of memory should be read from /proc/meminfo.