### PR TITLE
fix(ns-dpi): updated crontab entries for dpi updates

### DIFF
--- a/packages/ns-dpi/Makefile
+++ b/packages/ns-dpi/Makefile
@@ -47,7 +47,7 @@ endef
 define Package/ns-dpi/prerm
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-	crontab -l | grep -v "/usr/sbin/dpi-update" | sort | uniq | crontab -
+	crontab -l | grep -v "/usr/sbin/dpi-update" | grep -v "/etc/init.d/dpi-license-update" | grep -v "/etc/init.d/dpi-data-update" | sort | uniq | crontab -
 fi
 exit 0
 endef

--- a/packages/ns-dpi/files/99-dpi-data-update-cron.uci-defaults
+++ b/packages/ns-dpi/files/99-dpi-data-update-cron.uci-defaults
@@ -9,6 +9,11 @@
 # DPI Data Update: Add cron job if missing
 #
 
+# temporary fix for old cron job, remove if exists
+if grep -q '/usr/bin/dpi-data-update' /etc/crontabs/root; then
+  grep -v '/usr/bin/dpi-data-update' /etc/crontabs/root | sort | uniq | crontab -
+fi
+
 if ! grep -q '/etc/init.d/dpi-data-update' /etc/crontabs/root; then
   echo '8 4 * * * sleep $(( RANDOM % 1800 )); /etc/init.d/dpi-data-update start' >> /etc/crontabs/root
 fi

--- a/packages/ns-dpi/files/99-dpi-data-update-cron.uci-defaults
+++ b/packages/ns-dpi/files/99-dpi-data-update-cron.uci-defaults
@@ -10,7 +10,7 @@
 #
 
 if ! grep -q '/etc/init.d/dpi-data-update' /etc/crontabs/root; then
-    echo '0 0 * * * sleep $(( RANDOM % 300 )); /etc/init.d/dpi-data-update start' >> /etc/crontabs/root
+  echo '8 4 * * * sleep $(( RANDOM % 1800 )); /etc/init.d/dpi-data-update start' >> /etc/crontabs/root
 fi
 
 # Ensure dpi-data-update service is enabled at boot

--- a/packages/ns-dpi/files/99-dpi-license-update-cron.uci-defaults
+++ b/packages/ns-dpi/files/99-dpi-license-update-cron.uci-defaults
@@ -10,7 +10,7 @@
 #
 
 if ! grep -q '/etc/init.d/dpi-license-update' /etc/crontabs/root; then
-    echo '0 0 * * * sleep $(( RANDOM % 300 )); /etc/init.d/dpi-license-update start' >> /etc/crontabs/root
+  echo '0 7,14 * * * sleep $(( RANDOM % 1800 )); /etc/init.d/dpi-license-update start' >> /etc/crontabs/root
 fi
 
 # Ensure dpi-license-update service is enabled at boot

--- a/packages/ns-dpi/files/99-dpi-license-update-cron.uci-defaults
+++ b/packages/ns-dpi/files/99-dpi-license-update-cron.uci-defaults
@@ -9,6 +9,11 @@
 # DPI License Renewal: Add cron job if missing
 #
 
+# temporary fix for old cron job, remove if exists
+if grep -q '/usr/bin/dpi-license-update' /etc/crontabs/root; then
+  grep -v '/usr/bin/dpi-license-update' /etc/crontabs/root | sort | uniq | crontab -
+fi
+
 if ! grep -q '/etc/init.d/dpi-license-update' /etc/crontabs/root; then
   echo '0 7,14 * * * sleep $(( RANDOM % 1800 )); /etc/init.d/dpi-license-update start' >> /etc/crontabs/root
 fi


### PR DESCRIPTION
While developing latest netifyd features, seems I've underestimated how download is actually very heavy and data intensive for `distfeed`. 
These changes allow to remove crons and re-add them with better time management on update.
> The license cron runs every 3 hours since failing to have a valid license incurs in netifyd not working properly throughout the system. And the license is a download that we can easily do since it's cached upstream.