### PR TITLE
feat: add checkmk agent and Nethesis scripts

### DIFF
--- a/config/checkmk-agent.conf
+++ b/config/checkmk-agent.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_checkmk-agent=m

--- a/config/ns-checkmk-utils.conf
+++ b/config/ns-checkmk-utils.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_ns-checkmk-utils=m

--- a/packages/checkmk-agent/Makefile
+++ b/packages/checkmk-agent/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=checkmk-agent
+PKG_VERSION:=2.4.0p24
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/checkmk-agent-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Giacomo Sanchietti <giacomo.sanchietti@nethesis.it>
+PKG_LICENSE:=GPL-2.0-only
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/checkmk-agent
+	SECTION:=base
+	CATEGORY:=Administration
+	TITLE:=Check_MK monitoring agent
+	URL:=https://github.com/Checkmk/checkmk
+	DEPENDS:=+socat
+	PKGARCH:=all
+endef
+
+define Package/checkmk-agent/description
+	Check_MK monitoring agent
+endef
+
+
+# Download the Check_MK agent binary
+define Download/checkmk-agent-binary
+  URL:=https://raw.githubusercontent.com/Checkmk/checkmk/v$(PKG_VERSION)/agents
+  URL_FILE:=check_mk_agent.openwrt
+  FILE:=check_mk_agent.openwrt
+  HASH:=skip
+endef
+$(eval $(call Download,checkmk-agent-binary))
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	$(CP) $(DL_DIR)/check_mk_agent.openwrt $(PKG_BUILD_DIR)/check_mk_agent
+endef
+
+define Build/Configure
+	true
+endef
+
+define Build/Compile
+	true
+endef
+
+define Package/checkmk-agent/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_mk_agent $(1)/usr/sbin/check_mk_agent
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/check_mk_agent.init $(1)/etc/init.d/check_mk_agent
+endef
+
+$(eval $(call BuildPackage,checkmk-agent))

--- a/packages/checkmk-agent/README.md
+++ b/packages/checkmk-agent/README.md
@@ -1,0 +1,106 @@
+# checkmk-agent
+
+Official Check_MK monitoring agent for OpenWrt-based systems.
+
+## Description
+
+This package provides the official Check_MK agent binary along with service management for NethSecurity. The agent is exposed via TCP port 6556 using socat, enabling remote monitoring server connections.
+
+For NethSecurity-specific plugins and utilities, install the complementary `ns-checkmk-utils` package.
+
+## Features
+
+- Official Check_MK agent binary from upstream project
+- Procd-managed service with automatic restart on failure
+- TCP listener on port 6556 via socat
+- Starts automatically on boot (START=98)
+- Low dependency footprint
+
+## Dependencies
+
+- `socat`: Used to expose the agent via TCP socket and manage keepalive connections
+
+## Installation
+
+```bash
+# Install the package
+opkg install checkmk-agent
+
+# Start the service
+/etc/init.d/check_mk_agent start
+
+# Enable on boot
+/etc/init.d/check_mk_agent enable
+```
+
+## Service Management
+
+The agent is managed by procd and monitored for failures.
+
+```bash
+# Start/stop the service
+/etc/init.d/check_mk_agent start
+/etc/init.d/check_mk_agent stop
+
+# Restart the service
+/etc/init.d/check_mk_agent restart
+
+# Enable/disable on boot
+/etc/init.d/check_mk_agent enable
+/etc/init.d/check_mk_agent disable
+
+# View service status
+/etc/init.d/check_mk_agent status
+```
+
+## Testing
+
+Test the agent locally or remotely:
+
+```bash
+# Run agent directly to verify it works
+/usr/sbin/check_mk_agent
+
+# Test via TCP from the monitoring server
+echo "" | nc <firewall-ip> 6556
+
+```
+
+## Firewall Rules
+
+Port 6656 is open only from LAN by default. To allow monitoring server access, add a firewall rule to permit incoming connections on TCP port 6556 from the monitoring server's IP address or subnet.
+Ensure your Check_MK monitoring server can reach the firewall on TCP port 6556:
+
+```bash
+# Allow connections from monitoring server (example)
+uci add firewall rule
+uci set firewall.@rule[-1].name='Allow Check_MK'
+uci set firewall.@rule[-1].src='wan'
+uci set firewall.@rule[-1].proto='tcp'
+uci set firewall.@rule[-1].dest_port='6556'
+uci set firewall.@rule[-1].target='ACCEPT'
+uci commit firewall
+```
+
+## Extending with Plugins
+
+To add NethSecurity-specific plugins and utilities, install the `ns-checkmk-utils` package:
+
+```bash
+opkg install ns-checkmk-utils
+```
+
+Plugins are stored in `/usr/lib/check_mk_agent/local` and are automatically executed by the agent.
+
+## Troubleshooting
+
+**Agent not responding on port 6556:**
+- Verify the service is running: `/etc/init.d/check_mk_agent status`
+- Check firewall rules allow inbound traffic on port 6556
+- Test locally: `/usr/sbin/check_mk_agent`
+
+## See Also
+
+- [ns-checkmk-utils](../ns-checkmk-utils/): NethSecurity-specific plugins and utilities
+- [Checkmk Documentation](https://docs.checkmk.com/): Official Checkmk documentation
+- [Checkmk GitHub](https://github.com/Checkmk/checkmk): Checkmk project repository

--- a/packages/checkmk-agent/files/check_mk_agent.init
+++ b/packages/checkmk-agent/files/check_mk_agent.init
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+START=98
+STOP=10
+USE_PROCD=1
+
+PROG=/usr/sbin/check_mk_agent
+
+start_service() {
+    procd_open_instance
+    procd_set_param respawn
+    procd_set_param command socat TCP-LISTEN:6556,reuseaddr,fork,keepalive EXEC:$PROG
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+}

--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -1,0 +1,180 @@
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ns-checkmk-utils
+# renovate: datasource=github-tags depName=nethesis/checkmk-tools
+PKG_VERSION:=0.0.5
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/ns-checkmk-utils-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Tommaso Bailetti <tommaso.bailetti@nethesis.it>
+PKG_LICENSE:=GPL-3.0-only
+
+# Base URL for downloads
+NS_CHECKMK_UTILS_BASE_URL:=https://raw.githubusercontent.com/nethesis/checkmk-tools/v$(PKG_VERSION)/script-check-nsec8/full
+
+include $(INCLUDE_DIR)/package.mk
+
+define Download/check_dhcp_leases
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_dhcp_leases.py
+	FILE:=check_dhcp_leases.py
+	HASH:=9e8cfe4d51b58bdf35e6d07f051cc532fe4c0ac415dd2c3a797a3b7dcf338b27
+endef
+$(eval $(call Download,check_dhcp_leases))
+
+define Download/check_dns_resolution
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_dns_resolution.py
+	FILE:=check_dns_resolution.py
+	HASH:=b6e8a71db472aedf8087ff18fc88428918e6821cf36c45433848554e44f4dd9b
+endef
+$(eval $(call Download,check_dns_resolution))
+
+define Download/check_firewall_connections
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_firewall_connections.py
+	FILE:=check_firewall_connections.py
+	HASH:=00acc920b71c327ed6a5474dc13fdb74f38cc18ff669b721a9e61059116b192a
+endef
+$(eval $(call Download,check_firewall_connections))
+
+define Download/check_firewall_rules
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_firewall_rules.py
+	FILE:=check_firewall_rules.py
+	HASH:=c3fd4b338889779bdddbdefd56af763d7a6c553c5e7afe30f2c67f4d4daa2a56
+endef
+$(eval $(call Download,check_firewall_rules))
+
+define Download/check_firewall_traffic
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_firewall_traffic.py
+	FILE:=check_firewall_traffic.py
+	HASH:=fd76b8856a709898c05ec5b1468a028df8c5d292cbdc8890d75d47c061970bdd
+endef
+$(eval $(call Download,check_firewall_traffic))
+
+define Download/check_martian_packets
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_martian_packets.py
+	FILE:=check_martian_packets.py
+	HASH:=8a9120c201880a42b928a6cb30318636077329392a989c27f2c4bf59cce8612e
+endef
+$(eval $(call Download,check_martian_packets))
+
+define Download/check_opkg_packages
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_opkg_packages.py
+	FILE:=check_opkg_packages.py
+	HASH:=a2dacd1f06b9ea639f2884fff1c9331c7f3f02ce645b566407bd52a237ef7c94
+endef
+$(eval $(call Download,check_opkg_packages))
+
+define Download/check_ovpn_host2net
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_ovpn_host2net.py
+	FILE:=check_ovpn_host2net.py
+	HASH:=47c07a279bdba18a110ce06e8b0b6bcbb57b1899f9854dcba44e51ad4323ceec
+endef
+$(eval $(call Download,check_ovpn_host2net))
+
+define Download/check_root_access
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_root_access.py
+	FILE:=check_root_access.py
+	HASH:=9151c85628121b5941dcf1e1a8f32f00b92c004d97e9e07a95c816abbe4bc800
+endef
+$(eval $(call Download,check_root_access))
+
+define Download/check_uptime
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_uptime.py
+	FILE:=check_uptime.py
+	HASH:=ad67d9824a598d06f9c8c7f74f1f0ff295645f1e6780ab745a3fd956005d630d
+endef
+$(eval $(call Download,check_uptime))
+
+define Download/check_vpn_tunnels
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_vpn_tunnels.py
+	FILE:=check_vpn_tunnels.py
+	HASH:=992d94c7bf5cc5329e4ef877b5ea0a3c56a247d687d9017c28add069be4886da
+endef
+$(eval $(call Download,check_vpn_tunnels))
+
+define Download/check_wan_status
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_wan_status.py
+	FILE:=check_wan_status.py
+	HASH:=848ee2dc5526be9d193ad5f7aa23dec3f217c8bc93e7eee7a5e0efa71f83535f
+endef
+$(eval $(call Download,check_wan_status))
+
+define Download/check_wan_throughput
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_wan_throughput.py
+	FILE:=check_wan_throughput.py
+	HASH:=90b4f106f1a8027cc696217c2da40c35bf6e766aa06b2fc534704824332dfe47
+endef
+$(eval $(call Download,check_wan_throughput))
+
+define Package/ns-checkmk-utils
+	SECTION:=base
+	CATEGORY:=NethSecurity
+	TITLE:=Check_MK NethSecurity utilities and plugins
+	URL:=https://github.com/nethesis/checkmk-tools
+	DEPENDS:=+checkmk-agent
+	PKGARCH:=all
+endef
+
+define Package/ns-checkmk-utils/description
+	NethSecurity-specific plugins and utilities for the Check_MK agent.
+	This package extends the base checkmk-agent package with custom monitoring plugins
+	tailored for NethSecurity firewall systems.
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	$(CP) $(DL_DIR)/check_dhcp_leases.py $(PKG_BUILD_DIR)/check_dhcp_leases.py
+	$(CP) $(DL_DIR)/check_dns_resolution.py $(PKG_BUILD_DIR)/check_dns_resolution.py
+	$(CP) $(DL_DIR)/check_firewall_connections.py $(PKG_BUILD_DIR)/check_firewall_connections.py
+	$(CP) $(DL_DIR)/check_firewall_rules.py $(PKG_BUILD_DIR)/check_firewall_rules.py
+	$(CP) $(DL_DIR)/check_firewall_traffic.py $(PKG_BUILD_DIR)/check_firewall_traffic.py
+	$(CP) $(DL_DIR)/check_martian_packets.py $(PKG_BUILD_DIR)/check_martian_packets.py
+	$(CP) $(DL_DIR)/check_opkg_packages.py $(PKG_BUILD_DIR)/check_opkg_packages.py
+	$(CP) $(DL_DIR)/check_ovpn_host2net.py $(PKG_BUILD_DIR)/check_ovpn_host2net.py
+	$(CP) $(DL_DIR)/check_root_access.py $(PKG_BUILD_DIR)/check_root_access.py
+	$(CP) $(DL_DIR)/check_uptime.py $(PKG_BUILD_DIR)/check_uptime.py
+	$(CP) $(DL_DIR)/check_vpn_tunnels.py $(PKG_BUILD_DIR)/check_vpn_tunnels.py
+	$(CP) $(DL_DIR)/check_wan_status.py $(PKG_BUILD_DIR)/check_wan_status.py
+	$(CP) $(DL_DIR)/check_wan_throughput.py $(PKG_BUILD_DIR)/check_wan_throughput.py
+endef
+
+define Build/Compile
+	true
+endef
+
+define Package/ns-checkmk-utils/install
+	$(INSTALL_DIR) $(1)/usr/lib/check_mk_agent/local
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_dhcp_leases.py $(1)/usr/lib/check_mk_agent/local/check_dhcp_leases
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_dns_resolution.py $(1)/usr/lib/check_mk_agent/local/check_dns_resolution
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_firewall_connections.py $(1)/usr/lib/check_mk_agent/local/check_firewall_connections
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_firewall_rules.py $(1)/usr/lib/check_mk_agent/local/check_firewall_rules
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_firewall_traffic.py $(1)/usr/lib/check_mk_agent/local/check_firewall_traffic
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_martian_packets.py $(1)/usr/lib/check_mk_agent/local/check_martian_packets
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_opkg_packages.py $(1)/usr/lib/check_mk_agent/local/check_opkg_packages
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_ovpn_host2net.py $(1)/usr/lib/check_mk_agent/local/check_ovpn_host2net
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_root_access.py $(1)/usr/lib/check_mk_agent/local/check_root_access
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_uptime.py $(1)/usr/lib/check_mk_agent/local/check_uptime
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_vpn_tunnels.py $(1)/usr/lib/check_mk_agent/local/check_vpn_tunnels
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_wan_status.py $(1)/usr/lib/check_mk_agent/local/check_wan_status
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_wan_throughput.py $(1)/usr/lib/check_mk_agent/local/check_wan_throughput
+endef
+
+$(eval $(call BuildPackage,ns-checkmk-utils))

--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -24,7 +24,7 @@ define Download/check_dhcp_leases
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dhcp_leases.py
 	FILE:=check_dhcp_leases.py
-	HASH:=skip
+	HASH:=f168703fa052f84a7f10c5dfceb3f566c18a8accf36767b0ace7eeecb70b5887
 endef
 $(eval $(call Download,check_dhcp_leases))
 
@@ -32,7 +32,7 @@ define Download/check_dns_resolution
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dns_resolution.py
 	FILE:=check_dns_resolution.py
-	HASH:=skip
+	HASH:=a06de9d22df448800a1faf7cdb0a5580e0d2cfcbd3b20473e275f0ebd9086fcc
 endef
 $(eval $(call Download,check_dns_resolution))
 
@@ -40,7 +40,7 @@ define Download/check_firewall_connections
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_connections.py
 	FILE:=check_firewall_connections.py
-	HASH:=skip
+	HASH:=9aff21e3586cb36e72461f508bf7e4ececcefa1c956b07aa8dbba9d2163d3c48
 endef
 $(eval $(call Download,check_firewall_connections))
 
@@ -48,7 +48,7 @@ define Download/check_firewall_rules
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_rules.py
 	FILE:=check_firewall_rules.py
-	HASH:=skip
+	HASH:=db030f004c14955564e57ecc4e60f8b991c8e41ef090eba3b1c066bd4dfb8236
 endef
 $(eval $(call Download,check_firewall_rules))
 
@@ -56,7 +56,7 @@ define Download/check_firewall_traffic
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_traffic.py
 	FILE:=check_firewall_traffic.py
-	HASH:=skip
+	HASH:=fd76b8856a709898c05ec5b1468a028df8c5d292cbdc8890d75d47c061970bdd
 endef
 $(eval $(call Download,check_firewall_traffic))
 
@@ -64,7 +64,7 @@ define Download/check_martian_packets
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_martian_packets.py
 	FILE:=check_martian_packets.py
-	HASH:=skip
+	HASH:=577060f8c53f1c43bd216de4be921ac0a06fe91de1052d45b176f6d74805c71a
 endef
 $(eval $(call Download,check_martian_packets))
 
@@ -72,7 +72,7 @@ define Download/check_opkg_packages
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_opkg_packages.py
 	FILE:=check_opkg_packages.py
-	HASH:=skip
+	HASH:=ea8908e519e557dcd813138ae351becc75a2d6815d04e7a8a6de2479c244219d
 endef
 $(eval $(call Download,check_opkg_packages))
 
@@ -80,7 +80,7 @@ define Download/check_ovpn_host2net
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_ovpn_host2net.py
 	FILE:=check_ovpn_host2net.py
-	HASH:=skip
+	HASH:=ecf4f3240276fad68e33f4124c50f41a61fcb4afc4a64914791825a0574f7c57
 endef
 $(eval $(call Download,check_ovpn_host2net))
 
@@ -88,7 +88,7 @@ define Download/check_root_access
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_root_access.py
 	FILE:=check_root_access.py
-	HASH:=skip
+	HASH:=086dbbbdb30b4b8bbf77bf3bf0f0c5b7daa07c04bcf1acefb9771ebc79aa9b98
 endef
 $(eval $(call Download,check_root_access))
 
@@ -96,7 +96,7 @@ define Download/check_uptime
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_uptime.py
 	FILE:=check_uptime.py
-	HASH:=skip
+	HASH:=ad67d9824a598d06f9c8c7f74f1f0ff295645f1e6780ab745a3fd956005d630d
 endef
 $(eval $(call Download,check_uptime))
 
@@ -104,7 +104,7 @@ define Download/check_vpn_tunnels
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_vpn_tunnels.py
 	FILE:=check_vpn_tunnels.py
-	HASH:=skip
+	HASH:=992d94c7bf5cc5329e4ef877b5ea0a3c56a247d687d9017c28add069be4886da
 endef
 $(eval $(call Download,check_vpn_tunnels))
 
@@ -112,7 +112,7 @@ define Download/check_wan_status
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_status.py
 	FILE:=check_wan_status.py
-	HASH:=skip
+	HASH:=848ee2dc5526be9d193ad5f7aa23dec3f217c8bc93e7eee7a5e0efa71f83535f
 endef
 $(eval $(call Download,check_wan_status))
 
@@ -120,7 +120,7 @@ define Download/check_wan_throughput
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_throughput.py
 	FILE:=check_wan_throughput.py
-	HASH:=skip
+	HASH:=90b4f106f1a8027cc696217c2da40c35bf6e766aa06b2fc534704824332dfe47
 endef
 $(eval $(call Download,check_wan_throughput))
 

--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -24,7 +24,7 @@ define Download/check_dhcp_leases
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dhcp_leases.py
 	FILE:=check_dhcp_leases.py
-	HASH:=9e8cfe4d51b58bdf35e6d07f051cc532fe4c0ac415dd2c3a797a3b7dcf338b27
+	HASH:=skip
 endef
 $(eval $(call Download,check_dhcp_leases))
 
@@ -32,7 +32,7 @@ define Download/check_dns_resolution
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dns_resolution.py
 	FILE:=check_dns_resolution.py
-	HASH:=b6e8a71db472aedf8087ff18fc88428918e6821cf36c45433848554e44f4dd9b
+	HASH:=skip
 endef
 $(eval $(call Download,check_dns_resolution))
 
@@ -40,7 +40,7 @@ define Download/check_firewall_connections
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_connections.py
 	FILE:=check_firewall_connections.py
-	HASH:=00acc920b71c327ed6a5474dc13fdb74f38cc18ff669b721a9e61059116b192a
+	HASH:=skip
 endef
 $(eval $(call Download,check_firewall_connections))
 
@@ -48,7 +48,7 @@ define Download/check_firewall_rules
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_rules.py
 	FILE:=check_firewall_rules.py
-	HASH:=c3fd4b338889779bdddbdefd56af763d7a6c553c5e7afe30f2c67f4d4daa2a56
+	HASH:=skip
 endef
 $(eval $(call Download,check_firewall_rules))
 
@@ -56,7 +56,7 @@ define Download/check_firewall_traffic
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_traffic.py
 	FILE:=check_firewall_traffic.py
-	HASH:=fd76b8856a709898c05ec5b1468a028df8c5d292cbdc8890d75d47c061970bdd
+	HASH:=skip
 endef
 $(eval $(call Download,check_firewall_traffic))
 
@@ -64,7 +64,7 @@ define Download/check_martian_packets
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_martian_packets.py
 	FILE:=check_martian_packets.py
-	HASH:=8a9120c201880a42b928a6cb30318636077329392a989c27f2c4bf59cce8612e
+	HASH:=skip
 endef
 $(eval $(call Download,check_martian_packets))
 
@@ -72,7 +72,7 @@ define Download/check_opkg_packages
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_opkg_packages.py
 	FILE:=check_opkg_packages.py
-	HASH:=a2dacd1f06b9ea639f2884fff1c9331c7f3f02ce645b566407bd52a237ef7c94
+	HASH:=skip
 endef
 $(eval $(call Download,check_opkg_packages))
 
@@ -80,7 +80,7 @@ define Download/check_ovpn_host2net
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_ovpn_host2net.py
 	FILE:=check_ovpn_host2net.py
-	HASH:=47c07a279bdba18a110ce06e8b0b6bcbb57b1899f9854dcba44e51ad4323ceec
+	HASH:=skip
 endef
 $(eval $(call Download,check_ovpn_host2net))
 
@@ -88,7 +88,7 @@ define Download/check_root_access
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_root_access.py
 	FILE:=check_root_access.py
-	HASH:=9151c85628121b5941dcf1e1a8f32f00b92c004d97e9e07a95c816abbe4bc800
+	HASH:=skip
 endef
 $(eval $(call Download,check_root_access))
 
@@ -96,7 +96,7 @@ define Download/check_uptime
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_uptime.py
 	FILE:=check_uptime.py
-	HASH:=ad67d9824a598d06f9c8c7f74f1f0ff295645f1e6780ab745a3fd956005d630d
+	HASH:=skip
 endef
 $(eval $(call Download,check_uptime))
 
@@ -104,7 +104,7 @@ define Download/check_vpn_tunnels
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_vpn_tunnels.py
 	FILE:=check_vpn_tunnels.py
-	HASH:=992d94c7bf5cc5329e4ef877b5ea0a3c56a247d687d9017c28add069be4886da
+	HASH:=skip
 endef
 $(eval $(call Download,check_vpn_tunnels))
 
@@ -112,7 +112,7 @@ define Download/check_wan_status
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_status.py
 	FILE:=check_wan_status.py
-	HASH:=848ee2dc5526be9d193ad5f7aa23dec3f217c8bc93e7eee7a5e0efa71f83535f
+	HASH:=skip
 endef
 $(eval $(call Download,check_wan_status))
 
@@ -120,7 +120,7 @@ define Download/check_wan_throughput
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_throughput.py
 	FILE:=check_wan_throughput.py
-	HASH:=90b4f106f1a8027cc696217c2da40c35bf6e766aa06b2fc534704824332dfe47
+	HASH:=skip
 endef
 $(eval $(call Download,check_wan_throughput))
 

--- a/packages/ns-checkmk-utils/README.md
+++ b/packages/ns-checkmk-utils/README.md
@@ -1,0 +1,9 @@
+# ns-checkmk-utils
+
+NethSecurity-specific Checkmk local checks and utilities.
+
+This package installs the scripts in `/usr/lib/check_mk_agent/local/` and is meant to be used together with [checkmk-agent](../checkmk-agent/).
+
+## Included checks
+
+The package currently provides the NethSecurity 8 checks from `script-check-nsec8/full/` in the upstream [checkmk-tools](https://github.com/nethesis/checkmk-tools) repository.


### PR DESCRIPTION
Allow to monitor the firewall using Checkmk.
This is part of the Cyber360 project.

This pull request introduces two new packages for NethSecurity:
- `checkmk-agent` from checkmk prject
- `ns-checkmk-utils` package containing NethSecurity-specific monitoring plugins

Both packages are built as modules and are not included inside the image

Implements https://github.com/NethServer/nethsecurity/issues/1582
Replaces #1511 