### PR TITLE
feat(ns-plug): dual-send backup to my-new proxy

### DIFF
--- a/packages/ns-plug/files/remote-backup
+++ b/packages/ns-plug/files/remote-backup
@@ -54,6 +54,17 @@ case "$cmd" in
            exit_error "No file specified"
        fi
        curl $curl_args $base_url --upload-file $file
+       rc=$?
+       # Temporary dual-send to new my.nethesis.it via the translation
+       # proxy, same pattern used by send-heartbeat / send-inventory.
+       # To be removed once the migration is complete.
+       if [ "$TYPE" = "enterprise" ]; then
+           curl $curl_args -X POST \
+               -H "Content-Type: application/octet-stream" \
+               -H "X-Filename: $(basename "$file")" \
+               --data-binary "@$file" https://my.nethesis.it/proxy/backup >/dev/null || :
+       fi
+       exit $rc
        ;;
    delete)
        file=$2


### PR DESCRIPTION
## Summary

During the migration window, mirror every configuration-backup upload to the new **my.nethesis.it** platform via the translation proxy, in addition to the existing upload to the legacy `backupd.nethesis.it`. The mirror lives in `remote-backup`'s `upload` action so it covers *every* backup path (the nightly `send-backup` cron **and** manual backups triggered from the UI), and so the eventual cutover is a single localized change to the same file.

## Context

The new my.nethesis.it platform ships a first-class configuration-backup subsystem (ingest on `collect`, managed reads on `backend`, S3-compatible storage) — see the referenced issues. During the migration window NethSecurity keeps uploading to the legacy backupd *and* dual-sends to my-new via a translation proxy (`nethinfra` role). The proxy accepts the existing `system_id:secret` Basic Auth pair and translates it into the my-new `system_key:system_secret` as it forwards the request to `collect`, so nothing changes on the appliance in terms of UCI config or registration.

## What changes

`packages/ns-plug/files/remote-backup`, `upload` action only:

- After the primary `curl ... --upload-file` to the legacy backupd completes, its exit code is captured (`rc=$?`).
- If `ns-plug.config.type == enterprise`, the same encrypted blob is `POST`ed to `https://my.nethesis.it/proxy/backup` with `--data-binary "@$file"`, reusing the existing `$curl_args` (`--silent --location-trusted --user $SYSTEM_ID:$SYSTEM_SECRET` — the proxy translates that legacy pair). `Content-Type: application/octet-stream` and `X-Filename` are set so the blob and its user-facing name land as proper S3 object + metadata on my-new.
- The mirror is best-effort (`|| :`): a proxy outage must not fail the primary upload that already succeeded against backupd.
- The script then `exit $rc` — the **primary** backupd upload's exit status is what propagates to the caller, so `send-backup`'s `set -e` still aborts on a real legacy-upload failure and the md5 dedup marker is *not* advanced on a failed run (the backup is retried next night). The best-effort mirror never masks a primary failure.

`packages/ns-plug/files/send-backup` is **unchanged** (identical to `main`). Putting the dual-send in the transport layer (`remote-backup`) instead of the cron wrapper is what the review asked for, and it also means a backup triggered manually from the UI is mirrored too, not just the cron one.

Verified end-to-end on a real NethSecurity appliance: script runs under busybox/ash, `$curl_args` reuse works, a failing primary still fires the best-effort mirror, `rc`/`exit $rc` propagates the primary status, and the mirrored blob lands intact on my-new (matching SHA-256, `X-Filename` → object metadata, `application/octet-stream` content type).

## Not included

- Rewriting the legacy upload path — out of scope; happens in a later cycle once the new platform is promoted (the cutover then replaces this best-effort mirror block with the direct `collect` call, a single-file change to `remote-backup`).
- MY registration on the appliance — not needed: the proxy absorbs the credential difference.

Refs: NethServer/my#82 NethServer/my#83
