### PR TITLE
fix(ovpnrw): ensure only enabled users are recorded on disconnection

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -626,9 +626,10 @@ def list_users(ovpninstance):
         # exclude users not enabled for OpenVPN
         if "openvpn_enabled" not in user:
             continue
-        if user['name'].lower() in connected_lower_case:
-             user["connected"] = True
-             user = user | connected_lower_case[user['name'].lower()]
+        is_enabled = user.get('openvpn_enabled', '0') == '1'
+        if is_enabled and user['name'].lower() in connected_lower_case:
+            user["connected"] = True
+            user = user | connected_lower_case[user['name'].lower()]
         else:
             user["connected"] = False
         user["expiration"] = ""
@@ -678,8 +679,7 @@ def disconnect_user(ovpninstance, username):
 
     try:
         subprocess.run(["/usr/bin/openvpn-kill", f'/var/run/openvpn_{ovpninstance}.socket', username], capture_output=True, check=True)
-    except Exception as e:
-        print(e, file=sys.stderr)
+    except:
         return utils.generic_error("user_disconnect_failed")
     return {"result": "success"}
 

--- a/packages/ns-openvpn/files/80-save-disconnection
+++ b/packages/ns-openvpn/files/80-save-disconnection
@@ -9,15 +9,16 @@ import os
 import sys
 import sqlite3
 from euci import EUci
+from nethsec import users
 
-def get_db_path(instance):
-    u = EUci()
+def get_db_path(u, instance):
     base_path = u.get('fstab', 'ns_data', 'target', default='')
     if not os.path.isdir(base_path):
         base_path = '/var'
     return os.path.join(base_path, 'openvpn', instance, 'connections.db')
 
-conn = sqlite3.connect(get_db_path(sys.argv[1]))
+uci = EUci()
+conn = sqlite3.connect(get_db_path(uci, sys.argv[1]))
 c = conn.cursor()
 
 env = os.environ
@@ -34,14 +35,25 @@ c.execute("UPDATE connections SET duration=?, bytes_received=?, bytes_sent=? WHE
 
 if c.rowcount == 0:
     # disconnection of a client whose connection record has been saved on storage that is not available now
-    # insert a new full record with all the data on /var
-    virtual_ip_addr = env.get('ifconfig_pool_remote_ip', '')
-    remote_ip_addr = env.get('untrusted_ip', '')
-    c.execute(
-        "INSERT INTO connections (common_name, virtual_ip_addr, remote_ip_addr, start_time, duration, bytes_received, bytes_sent) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (common_name, virtual_ip_addr, remote_ip_addr, start_time, duration, bytes_received, bytes_sent)
-    )
+    # insert a new full record with all the data on /var, but only if the user is currently enabled
+    # (avoid creating entries for disabled users that still generate disconnect events)
+    enabled = False
+    try:
+        db = uci.get('openvpn', sys.argv[1], 'ns_user_db', default=None)
+        user = users.get_user_by_name(uci, common_name, db) if db else None
+        enabled = user is not None and user.get('openvpn_enabled', '0') == '1'
+    except:
+        # on any error while checking UCI/users, assume disabled to be safe
+        pass
+
+    if enabled:
+        virtual_ip_addr = env.get('ifconfig_pool_remote_ip', '')
+        remote_ip_addr = env.get('untrusted_ip', '')
+        c.execute(
+            "INSERT INTO connections (common_name, virtual_ip_addr, remote_ip_addr, start_time, duration, bytes_received, bytes_sent) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (common_name, virtual_ip_addr, remote_ip_addr, start_time, duration, bytes_received, bytes_sent)
+        )
 
 conn.commit()
 conn.close()


### PR DESCRIPTION
This pull request improves the reliability and correctness of OpenVPN user connection tracking by ensuring that only enabled users are processed and recorded, and by making the code more robust in the face of errors. The changes focus on filtering out disabled users from connection records and handling user status checks more safely.

**User connection and disconnection handling:**

* In `list_users`, updated logic to only mark users as connected if they are explicitly enabled for OpenVPN, preventing disabled users from being reported as connected.
* In `disconnect_user`, simplified error handling by catching all exceptions and returning a generic error, making the function more robust.

**Connection record database management:**

* In `80-save-disconnection`, refactored the database path retrieval to require a `EUci` instance, improving clarity and consistency in how configuration is accessed.
* In the same script, added logic to only insert a new disconnection record if the user is currently enabled for OpenVPN, avoiding unnecessary entries for disabled users who generate disconnect events when trying to reconnect to the server. 

Closes: https://github.com/NethServer/nethsecurity/issues/1404