### PR TITLE
fix(openvpn-rw): update server key path handling for migrated systems

### DIFF
--- a/packages/ns-openvpn/files/ns-openvpn-renew-ca
+++ b/packages/ns-openvpn/files/ns-openvpn-renew-ca
@@ -34,4 +34,7 @@ if [ -f /etc/openvpn/$instance/pki/ca.crt ]; then
             /usr/bin/easyrsa build-client-full "$name" nopass
         done
     )
+    # change server key path in migrated systems
+    uci set openvpn.$instance.key="/etc/openvpn/$instance/pki/private/server.key"
+    uci commit openvpn
 fi

--- a/packages/ns-openvpn/files/ns-openvpn-renew-server
+++ b/packages/ns-openvpn/files/ns-openvpn-renew-server
@@ -29,4 +29,7 @@ if [ -f /etc/openvpn/$instance/pki/ca.crt ]; then
         /usr/bin/easyrsa gen-crl
         /usr/bin/easyrsa build-server-full server nopass
     )
+    # change server key path in migrated systems
+    uci set openvpn.$instance.key="/etc/openvpn/$instance/pki/private/server.key"
+    uci commit openvpn
 fi


### PR DESCRIPTION
This pull request updates the OpenVPN CA and server renewal scripts to ensure that the server key path is correctly set in migrated systems. This helps maintain compatibility and prevents configuration issues after migration.

OpenVPN key path update:

* Both `ns-openvpn-renew-ca` and `ns-openvpn-renew-server` scripts now explicitly set the `openvpn.$instance.key` UCI configuration to `/etc/openvpn/$instance/pki/private/server.key` for migrated systems, followed by a commit to persist the change.

Closes: https://github.com/NethServer/nethsecurity/issues/1612