### PR TITLE
feat(snort): add max_inspect_bytes nftables rule for large file handling

### DIFF
--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -8037,16 +8037,18 @@ Response example:
   "enabled": true,
   "ns_policy": "balanced",
   "oinkcode": "123456789",
-  "home_net": ["192.168.1.0/24", "10.0.0.0/8"]
+  "home_net": ["192.168.1.0/24", "10.0.0.0/8"],
+  "max_inspect_bytes": 1048576
 }
 ```
 
 ### save-settings
 
 Set `snort` configuration. The `home_net` field is a list of IPv4 CIDRs representing the protected networks.
+The optional `max_inspect_bytes` field sets how many bytes per connection are forwarded to snort for inspection; use `0` for unlimited (default: `1048576`).
 
 ```bash
-api-cli ns.snort save-settings --data '{"enabled": true, "ns_policy": "balanced", "oinkcode": "123456789", "home_net": ["192.168.1.0/24"]}'
+api-cli ns.snort save-settings --data '{"enabled": true, "ns_policy": "balanced", "oinkcode": "123456789", "home_net": ["192.168.1.0/24"], "max_inspect_bytes": 1048576}'
 ```
 
 ### check-oinkcode

--- a/packages/ns-api/files/ns.snort
+++ b/packages/ns-api/files/ns.snort
@@ -181,6 +181,10 @@ def __save_settings():
     e_uci = EUci()
     e_uci.set('snort', 'snort', 'oinkcode', data.get('oinkcode', ''))
     e_uci.set('snort', 'snort', 'home_net', ' '.join(home_net))
+    max_inspect_bytes = data.get('max_inspect_bytes', 1048576)
+    if not isinstance(max_inspect_bytes, int) or max_inspect_bytes < 0:
+        raise ValidationError('max_inspect_bytes', 'invalid')
+    e_uci.set('snort', 'nfq', 'max_inspect_bytes', str(max_inspect_bytes))
     e_uci.save('snort')
 
 
@@ -198,6 +202,7 @@ def __settings():
         "ns_policy": e_uci.get('snort', 'snort', 'ns_policy', default='connectivity'),
         "oinkcode": e_uci.get('snort', 'snort', 'oinkcode', default=''),
         "home_net": home_net,
+        "max_inspect_bytes": int(e_uci.get('snort', 'nfq', 'max_inspect_bytes', default='1048576')),
     }
 
 
@@ -461,8 +466,9 @@ if cmd == 'list':
             "ns_policy": "balanced",
             "oinkcode": "1234567890",
             "home_net": ["192.168.1.0/24"],
+            "max_inspect_bytes": 1048576,
         },
-        "save-settings": {"enabled": True, "ns_policy": "balanced", "oinkcode": "1234567890", "home_net": ["192.168.1.0/24"]},
+        "save-settings": {"enabled": True, "ns_policy": "balanced", "oinkcode": "1234567890", "home_net": ["192.168.1.0/24"], "max_inspect_bytes": 1048576},
         "check-oinkcode": {},
         "list-bypasses": {},
         "create-bypass": {"protocol": "ipv4", "ip": "*.*.*.*", "description": "Description"},

--- a/packages/snort3/README.md
+++ b/packages/snort3/README.md
@@ -39,6 +39,7 @@ This package also adds the following extra UCI options under the `nfq` section:
 - `bypass_src_v4` - bypass IDS for source IPv4 addresses
 - `bypass_dst_v6` - bypass IDS for destination IPv6 addresses
 - `bypass_src_v6` - bypass IDS for source IPv6 addresses
+- `max_inspect_bytes` - maximum number of bytes per connection forwarded to snort for inspection. Connections that have already transferred more than this many bytes are accepted directly by nftables without further inspection. Set to `0` to disable the limit and inspect all traffic. Default is `1048576` (1 MB).
 
 ## Download rules
 

--- a/packages/snort3/files/main.uc
+++ b/packages/snort3/files/main.uc
@@ -116,14 +116,15 @@ const snort_config = {
 };
 
 const nfq_config = {
-	queue_count:     config_item("range", [ 1, 16 ], 4),           // Count of queues to allocate in nft chain when method=nfq, usually 2-8.
-	queue_start:     config_item("range", [ 1, 32768], 4),         // Start of queue numbers in nftables.
-	queue_maxlen:    config_item("range", [ 1024, 65536 ], 1024),  // --daq-var queue_maxlen=int
-	fanout_type:     config_item("enum",  [ "hash", "lb", "cpu", "rollover", "rnd", "qm"], "hash"), // See below.
-	thread_count:    config_item("range", [ 0, 32 ], 0),           // 0 = use cpu count
-	chain_type:      config_item("enum",  [ "prerouting", "input", "forward", "output", "postrouting" ], "input"),
-	chain_priority:  config_item("enum",  [ "raw", "filter", "300"], "filter"),
-	include:         config_item("path",  [ "" ]),                 // User-defined rules to include inside queue chain.
+	queue_count:       config_item("range", [ 1, 16 ], 4),              // Count of queues to allocate in nft chain when method=nfq, usually 2-8.
+	queue_start:       config_item("range", [ 1, 32768], 4),            // Start of queue numbers in nftables.
+	queue_maxlen:      config_item("range", [ 1024, 65536 ], 1024),     // --daq-var queue_maxlen=int
+	fanout_type:       config_item("enum",  [ "hash", "lb", "cpu", "rollover", "rnd", "qm"], "hash"), // See below.
+	thread_count:      config_item("range", [ 0, 32 ], 0),              // 0 = use cpu count
+	chain_type:        config_item("enum",  [ "prerouting", "input", "forward", "output", "postrouting" ], "input"),
+	chain_priority:    config_item("enum",  [ "raw", "filter", "300"], "filter"),
+	include:           config_item("path",  [ "" ]),                    // User-defined rules to include inside queue chain.
+	max_inspect_bytes: config_item("range", [ 0, 2147483648 ], 1048576), // Max bytes per connection sent to snort; 0 = unlimited.
 };
 
 
@@ -170,9 +171,14 @@ nfq - https://github.com/snort3/libdaq/blob/master/modules/nfq/README.nfq.md
     thread_count    - int snort.-z: <count> maximum number of packet threads
                       (same as --max-packet-threads); 0 gets the number of
                       CPU cores reported by the system; default is 1 { 0:max32 }
-    chain_type      - Chain type when generating nft output
-    chain_priority  - Chain priority when generating nft output
-    include         - Full path to user-defined extra rules to include inside queue chain
+    chain_type          - Chain type when generating nft output
+    chain_priority      - Chain priority when generating nft output
+    include             - Full path to user-defined extra rules to include inside queue chain
+    max_inspect_bytes   - Maximum bytes per connection forwarded to snort for inspection.
+                          Connections that have already transferred more than this many bytes
+                          are accepted directly by nftables without further inspection.
+                          Set to 0 to disable this limit (inspect all traffic).
+                          Default is 1048576 (1 MB).
 
     * - for details on fanout_type, see these pages:
         https://github.com/florincoras/daq/blob/master/README

--- a/packages/snort3/files/nftables.uc
+++ b/packages/snort3/files/nftables.uc
@@ -22,6 +22,9 @@ table inet snort {
 	chain {{ chain_type }}_{{ snort.mode }} {
 		type filter  hook {{ chain_type }}  priority {{ nfq.chain_priority }}
 		policy accept
+		{% if (int(nfq.max_inspect_bytes) > 0): %}
+		ct bytes > {{ nfq.max_inspect_bytes }} accept
+		{% endif %}
 		ip saddr @bypass_v4 counter accept
 		ip daddr @bypass_v4 counter accept
 		ip6 saddr @bypass_v6 counter accept

--- a/packages/snort3/files/snort.config
+++ b/packages/snort3/files/snort.config
@@ -66,12 +66,13 @@ config snort 'snort'
 	option include         ''               # a path string
 
 config nfq 'nfq'
-	option queue_count     '4'              # 1 <= x <= 16
-	option queue_start     '4'              # 1 <= x <= 32768
-	option queue_maxlen    '1024'           # 1024 <= x <= 65536
-	option fanout_type     'hash'           # one of [hash, lb, cpu, rollover, rnd, qm]
-	option thread_count    '0'              # 0 <= x <= 32
-	option chain_type      'input'          # one of [prerouting, input, forward, output, postrouting]
-	option chain_priority  'filter'         # one of [raw, filter, 300]
-	option include         ''               # a path string
+	option queue_count        '4'              # 1 <= x <= 16
+	option queue_start        '4'              # 1 <= x <= 32768
+	option queue_maxlen       '1024'           # 1024 <= x <= 65536
+	option fanout_type        'hash'           # one of [hash, lb, cpu, rollover, rnd, qm]
+	option thread_count       '0'              # 0 <= x <= 32
+	option chain_type         'input'          # one of [prerouting, input, forward, output, postrouting]
+	option chain_priority     'filter'         # one of [raw, filter, 300]
+	option include            ''               # a path string
+	option max_inspect_bytes  '1048576'        # 0 = unlimited
 


### PR DESCRIPTION
## Summary

Add configurable nftables rule that skips snort inspection for connections that have already transferred N bytes, fixing large file download performance issues.

Fixes: https://github.com/NethServer/nethsecurity/issues/1624

## Details

Implements the performance improvement discussed in the team thread:
- Connections transferring >1MB bypass snort inspection (default)
- Reduces performance impact on large downloads while catching attacks in early-stage traffic
- Fully configurable: 0 = unlimited inspection, any other value = byte limit

## Changes

**snort3 package:**
- Added `max_inspect_bytes` UCI option to snort.nfq (range 0–2147483648, default 1048576)
- Generated nftables rule: `ct bytes > N accept` inserted before bypass-IP rules
- Rule is conditionally omitted when max_inspect_bytes=0
- Updated package README with documentation

**ns-api package:**
- Exposed `max_inspect_bytes` in ns.snort API (`settings`, `save-settings`, `list`)
- Updated API README with new field documentation
- Proper validation: accepts integer ≥ 0; rejects negative/invalid values

## How to test

1. SSH to a device with snort enabled
2. Check default nftables rule:
   ```bash
   nft list table inet snort
   # Should show: ct bytes > 1048576 accept
   ```
3. Toggle to unlimited inspection:
   ```bash
   uci set snort.nfq.max_inspect_bytes=0
   snort-mgr resetup
   nft list table inet snort
   # Should NOT show ct bytes rule
   ```
4. Set custom value via API:
   ```bash
   echo '{"enabled": true, "ns_policy": "connectivity", "oinkcode": "", "home_net": ["192.168.100.0/24"], "max_inspect_bytes": 0 }' | /usr/libexec/rpcd/ns.snort call save-settings
   ```
5. Verify via live device: large file downloads complete without stalls

## Testing notes

Check the following:
- Default value (1MB) generates correct nftables rule
- Setting to 0 omits rule entirely
- API save-settings accepts and persists custom values
- nftables reload applies changes immediately
