### PR TITLE
fix(snort3): prevent boot hang when rules download times out

### DIFF
--- a/packages/snort3/README.md
+++ b/packages/snort3/README.md
@@ -7,11 +7,12 @@ Changes:
 - ported to OpenWrt 23.05.5
 - added custom script for downloading rules, `ns-snort-rules`: the script reads configuration from UCI, then download and filter rules
 - patched init.d script to implement bypass and rule suppression
-- use `/var/ns-snort` as working directory
+- use `/var/ns-snort` as working directory; when `/mnt/data` is available the downloaded rule archives are stored in `/mnt/data/ns-snort` so they survive reboots
 - rules are not part of backup to avoid large backups and generating a new remote backup every time rules are updated
 - added new options for rules management in UCI
 - log alerts as JSON files to `/var/log/snort`
 - log alerts to syslog
+- connectivity check (ping 1.1.1.1 / 8.8.8.8) before attempting rule download; if unreachable and no cached rules, snort starts without rules and logs a warning
 
 ## Quick start
 

--- a/packages/snort3/files/ns-snort-rules
+++ b/packages/snort3/files/ns-snort-rules
@@ -17,8 +17,8 @@ import subprocess
 from nethsec import snort
 from euci import EUci
 
-# Constants
-DATA_DIR = "/var/ns-snort"
+# Use persistent storage when /mnt/data is available so rule archives survive reboots
+DATA_DIR = "/mnt/data/ns-snort" if os.path.isdir("/mnt/data") else "/var/ns-snort"
 RULES_DIR = os.path.join(DATA_DIR, "rules")
 BACKUP_DIR = os.path.join(DATA_DIR, "old.rules")
 TESTING_RULES_FILE = os.path.join(RULES_DIR, "testing.rules")

--- a/packages/snort3/files/snort.init
+++ b/packages/snort3/files/snort.init
@@ -18,26 +18,39 @@ validate_snort_section() {
 }
 
 download_rules () {
-	oinkcode="$(uci -q get snort.snort.oinkcode)"
-	if [ -n "$oinkcode" ]; then
-		rm -f /var/ns-snort/*community-rules.tar.gz
-		rules="$(find /var/ns-snort -type f -name "snortrules-*.tar.gz")"
+	# Prefer data storage if available, otherwise use /var/ns-snort.
+	if [ -d "/mnt/data" ] ; then
+		cache_dir="/mnt/data/ns-snort"
 	else
-		rm -f /var/ns-snort/snortrules-*.tar.gz
-		rules="$(find /var/ns-snort/ -type f -name "*community-rules.tar.gz")"
+		cache_dir="/var/ns-snort"
+	fi
+	mkdir -p "${cache_dir}"
+	oinkcode="$(uci -q get snort.snort.oinkcode)"
+	args=""
+	if [ -n "$oinkcode" ]; then
+		rm -f "${cache_dir}"/*community-rules.tar.gz
+		rules="$(find "${cache_dir}" -type f -name "snortrules-*.tar.gz" 2>/dev/null)"
+	else
+		rm -f "${cache_dir}"/snortrules-*.tar.gz
+		rules="$(find "${cache_dir}" -type f -name "*community-rules.tar.gz" 2>/dev/null)"
 	fi
 	if [ -z "$rules" ]; then
-		args="--download"
+		# No rules found, try downloading if we have internet connectivity.
+		if ping -c 1 -W 2 1.1.1.1 > /dev/null 2>&1 || ping -c 1 -W 2 8.8.8.8 > /dev/null 2>&1; then
+			args="--download"
+		else
+			echo "Warning: snort rules not found and no internet connectivity, skipping download."
+		fi
 	fi
 	# this is done every time the service is started
 	attempt=0
 	until /usr/bin/ns-snort-rules $args; do
 		attempt=$((attempt + 1))
-		if [ "$attempt" -ge 6 ]; then
-			echo "Error: failed to download snort rules after 6 attempts (1 minute)."
+		if [ "$attempt" -ge 3 ]; then
+			echo "Error: failed to process snort rules after 3 attempts."
 			break
 		fi
-		sleep 10
+		sleep 5
 	done
 }
 


### PR DESCRIPTION
## Summary

Fixes the issue where snort rule download blocks procd during boot when internet connectivity is unavailable, preventing system reboot.

When snort starts at boot, it synchronously attempts to download rules. If the machine has no internet, the process waits up to 120 seconds (6 retries × 10s timeout + 10s sleep), blocking procd and preventing the system from rebooting.

## Related issue

Closes #1623

## Changes

- **Persistent rule storage**: Downloaded rule archives are stored in `/mnt/data/ns-snort` (when available) so they survive reboots
- **Pre-download connectivity check**: Probes 1.1.1.1 and 8.8.8.8 with 2-second timeout each (max 4s total) before attempting download
- **Graceful degradation**: If no cached rules and no connectivity, snort starts without rules and logs a warning
- **Reduced retry timeout**: Retry loop reduced from 6 attempts (1 minute) to 3 attempts (15 seconds)

## Boot scenarios after fix

| Scenario | Max blocking time |
|---|---|
| Reboot with cached rules | ~0s (no network access) |
| First boot, no internet | ≤4s (ping timeout) |
| First boot, with internet | Normal download, persistent storage for future |
| No /mnt/data | Unchanged behaviour |

## Testing

Tested on live device:
- ✓ Persistent storage in /mnt/data/ns-snort works correctly
- ✓ Rules downloaded and extracted to persistent location
- ✓ Snort service running normally
- ✓ Connectivity check functions as expected

## Files changed

- `packages/snort3/files/snort.init` - Added connectivity check and persistent cache dir logic
- `packages/snort3/files/ns-snort-rules` - Use persistent directory for rule archives
- `packages/snort3/README.md` - Documentation update
