### PR TITLE
fix(api): better cert chain validation

### DIFF
--- a/packages/ns-api/files/ns.reverseproxy
+++ b/packages/ns-api/files/ns.reverseproxy
@@ -21,7 +21,7 @@ from nethsec.utils import ValidationError
 
 
 
-def __validate_certificate_pem(cert_path):
+def __validate_certificate_pem(cert_path, cert_type='certificate_path'):
     """
     Validates that the certificate file is a valid PEM X.509 certificate.
     Raises ValidationError if validation fails.
@@ -31,7 +31,7 @@ def __validate_certificate_pem(cert_path):
         capture_output=True, text=True
     )
     if result.returncode != 0:
-        raise ValidationError('certificate_path', 'invalid_format', cert_path)
+        raise ValidationError(cert_type, 'invalid_format', cert_path)
 
 
 def __validate_key_pem(key_path):


### PR DESCRIPTION
Previously, the validation of a bad chain file
error was returning 'certificate_path' as parameter. As a consequence, the UI was putting the error label on the wrong field.


Before:
<img width="545" height="811" alt="Screenshot From 2026-04-30 11-05-04" src="https://github.com/user-attachments/assets/0d2a4514-3ffc-4107-92bf-cfe4ebd92923" />

After:
<img width="545" height="811" alt="Screenshot From 2026-04-30 11-04-53" src="https://github.com/user-attachments/assets/4e0f1153-2917-4fdc-9517-2540aad8c543" />


Issue #1618 