### PR TITLE
feat(openvpn): add tun_mtu and mssfix configuration management for instances

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -589,10 +589,9 @@ def set_configuration(args):
     else:
         return utils.validation_error("ns_auth_mode", "invalid_auth_mode", args["ns_auth_mode"])
 
-    if args["tun_mtu"] and args["tun_mtu"] != u.get("openvpn", ovpninstance, "tun_mtu", default=''):
-        u.set("openvpn", ovpninstance, "tun_mtu", args.get("tun_mtu"))
-    if args["mssfix"] and args["mssfix"] != u.get("openvpn", ovpninstance, "mssfix", default=''):
-        u.set("openvpn", ovpninstance, "mssfix", args.get("mssfix"))
+    # MTU and MSSFix settings
+    u.set("openvpn", ovpninstance, "tun_mtu", args.get("tun_mtu"))
+    u.set("openvpn", ovpninstance, "mssfix", args.get("mssfix"))
 
     u.save("openvpn")
 

--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -589,6 +589,10 @@ def set_configuration(args):
     else:
         return utils.validation_error("ns_auth_mode", "invalid_auth_mode", args["ns_auth_mode"])
 
+    if args["tun_mtu"] and args["tun_mtu"] != u.get("openvpn", ovpninstance, "tun_mtu", default=''):
+        u.set("openvpn", ovpninstance, "tun_mtu", args.get("tun_mtu"))
+    if args["mssfix"] and args["mssfix"] != u.get("openvpn", ovpninstance, "mssfix", default=''):
+        u.set("openvpn", ovpninstance, "mssfix", args.get("mssfix"))
 
     u.save("openvpn")
 
@@ -1232,7 +1236,9 @@ if cmd == 'list':
             "ns_dhcp_options": [],
             "ns_public_ip": ["1.2.3.4"],
             "ns_user_db": "main",
-            "ifconfig_pool": ["10.166.54.4", "10.166.54.20"]
+            "ifconfig_pool": ["10.166.54.4", "10.166.54.20"],
+            "tun_mtu": "1500",
+            "mssfix": "1450",
             },
         "remove-instance": {"instance": "roadwarrior1"},
         "import-users": {"instance": "roadwarrior1"},

--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -333,6 +333,8 @@ def add_instance():
     u.set("openvpn", instance, 'tls_version_min','1.2')
     u.set("openvpn", instance, 'ns_auth_mode', 'certificate')
     u.set('openvpn', instance, 'ns_tag', ["automated"])
+    u.set('openvpn', instance, 'tun_mtu', '1500')
+    u.set('openvpn', instance, 'mssfix', '1450')
 
     # commit everything, otherwise a future revert will break the configuration
     # drawback: openvpn zone and network will be created even if the instance is not saved
@@ -949,6 +951,8 @@ def download_user_configuration(ovpninstance, username):
     config = config + "persist-tun\n"
     config = config + "nobind\n"
     config = config + "passtos\n"
+    config = config + f"tun-mtu {u.get('openvpn', ovpninstance, 'tun_mtu', default='1500')}\n"
+    config = config + f"mssfix {u.get('openvpn', ovpninstance, 'mssfix', default='1450')}\n"
 
     # add certificate verification if supported by certificate
     # this is not supported by migrated instances

--- a/packages/ns-api/files/ns.ovpntunnel
+++ b/packages/ns-api/files/ns.ovpntunnel
@@ -399,10 +399,8 @@ def list_tunnels():
                 "remote_host": vpn.get("remote", ""),
                 "remote_network": remote
             }
-            if vpn.get("tun_mtu"):
-                client["tun_mtu"] = vpn.get("tun_mtu")
-            if vpn.get("mssfix"):
-                client["mssfix"] = vpn.get("mssfix")
+            client["tun_mtu"] = vpn.get("tun_mtu", '1500')
+            client["mssfix"] = vpn.get("mssfix", '1450')
             if vpn.get('cert'):
                 client["certificates"] = get_certificates_from_pem(vpn.get('cert'))
             clients.append(client)
@@ -434,10 +432,8 @@ def list_tunnels():
                 "remote_network": remote,
                 "vpn_network": net,
             }
-            if vpn.get("tun_mtu"):
-                server["tun_mtu"] = vpn.get("tun_mtu")
-            if vpn.get("mssfix"):
-                server["mssfix"] = vpn.get("mssfix")
+            client["tun_mtu"] = vpn.get("tun_mtu", '1500')
+            client["mssfix"] = vpn.get("mssfix", '1450')
 
             certificates = {}
             if vpn.get('cert'):

--- a/packages/ns-api/files/ns.ovpntunnel
+++ b/packages/ns-api/files/ns.ovpntunnel
@@ -191,6 +191,10 @@ def import_client(tunnel):
 
     # Add management socket
     u.set("openvpn", iname, 'management', f'/var/run/openvpn_{iname}.socket unix')
+    
+    # set tun_mtu and mss_fix to default values if not provided by client config
+    u.set("openvpn", iname, 'tun_mtu', tunnel.get('TunMtu', '') or '1500')
+    u.set("openvpn", iname, 'mssfix', tunnel.get('Mssfix', '') or '1450')
 
     u.save('openvpn')
     
@@ -235,6 +239,8 @@ def setup_server(u, iname, tunnel):
     u.set("openvpn", iname, "persist_key", "1")
     u.set("openvpn", iname, "keepalive", "10 60")
     u.set("openvpn", iname, "lport", tunnel['port'])
+    u.set('openvpn', iname, 'tun_mtu', '1500')
+    u.set('openvpn', iname, 'mssfix', '1450')
     if tunnel['proto'] == "tcp":
         u.set("openvpn", iname, "proto", "tcp-server")
     else:
@@ -324,6 +330,8 @@ def export_client(name):
         "Cipher": u.get("openvpn", name, "cipher", default=""),
         "Topology": u.get("openvpn", name, "topology", default=""),
         "Protocol": proto,
+        "TunMtu": u.get("openvpn", name, "tun_mtu", default="1500"),
+        "Mssfix": u.get("openvpn", name, "mssfix", default="1450"),
     }
     remotes = []
     for r in u.get("openvpn", name, "push", default=[], list=True):
@@ -391,6 +399,10 @@ def list_tunnels():
                 "remote_host": vpn.get("remote", ""),
                 "remote_network": remote
             }
+            if vpn.get("tun_mtu"):
+                client["tun_mtu"] = vpn.get("tun_mtu")
+            if vpn.get("mssfix"):
+                client["mssfix"] = vpn.get("mssfix")
             if vpn.get('cert'):
                 client["certificates"] = get_certificates_from_pem(vpn.get('cert'))
             clients.append(client)
@@ -422,6 +434,10 @@ def list_tunnels():
                 "remote_network": remote,
                 "vpn_network": net,
             }
+            if vpn.get("tun_mtu"):
+                server["tun_mtu"] = vpn.get("tun_mtu")
+            if vpn.get("mssfix"):
+                server["mssfix"] = vpn.get("mssfix")
 
             certificates = {}
             if vpn.get('cert'):
@@ -608,6 +624,8 @@ def setup_client(u, iname, args):
     u.set('openvpn', iname, 'passtos', '1')
     u.set('openvpn', iname, 'verb', '3')
     u.set('openvpn', iname, 'keepalive', '10 60')
+    u.set('openvpn', iname, 'tun_mtu', '1500')
+    u.set('openvpn', iname, 'mssfix', '1450')
 
     for opt in ['cipher', 'compress', 'auth', 'port']:
         if args.get(opt, None):

--- a/packages/ns-api/files/ns.ovpntunnel
+++ b/packages/ns-api/files/ns.ovpntunnel
@@ -239,8 +239,8 @@ def setup_server(u, iname, tunnel):
     u.set("openvpn", iname, "persist_key", "1")
     u.set("openvpn", iname, "keepalive", "10 60")
     u.set("openvpn", iname, "lport", tunnel['port'])
-    u.set('openvpn', iname, 'tun_mtu', '1500')
-    u.set('openvpn', iname, 'mssfix', '1450')
+    u.set('openvpn', iname, 'tun_mtu', tunnel.get('tun_mtu', '1500'))
+    u.set('openvpn', iname, 'mssfix', tunnel.get('mssfix', '1450'))
     if tunnel['proto'] == "tcp":
         u.set("openvpn", iname, "proto", "tcp-server")
     else:
@@ -527,7 +527,9 @@ def get_defaults():
         "ifconfig_local": str(ipaddress.ip_interface(net).network.network_address + 1),
         "ifconfig_remote": str(ipaddress.ip_interface(net).network.network_address + 2),
         'route': ovpn.get_local_networks(u),
-        'remote': ovpn.get_public_addresses(u)
+        'remote': ovpn.get_public_addresses(u),
+        'tun_mtu': '1500',
+        'mssfix': '1450'
     }
 
     return defaults
@@ -624,8 +626,8 @@ def setup_client(u, iname, args):
     u.set('openvpn', iname, 'passtos', '1')
     u.set('openvpn', iname, 'verb', '3')
     u.set('openvpn', iname, 'keepalive', '10 60')
-    u.set('openvpn', iname, 'tun_mtu', '1500')
-    u.set('openvpn', iname, 'mssfix', '1450')
+    u.set('openvpn', iname, 'tun_mtu', args.get('tun_mtu', '1500'))
+    u.set('openvpn', iname, 'mssfix', args.get('mssfix', '1450'))
 
     for opt in ['cipher', 'compress', 'auth', 'port']:
         if args.get(opt, None):
@@ -752,10 +754,10 @@ cmd = sys.argv[1]
 if cmd == 'list':
     print(json.dumps({
         "import-client": {},
-        "add-server": {"ns_name": "server1", "port": "2001", "server": "192.168.4.0/24", "topology": "subnet", "proto": "tcp", "local": ["192.168.100.0/24"], "remote": ["192.168.5.0/24"], "compress": "", "auth": "", "cipher": "", "secret": "", "ifconfig_local": "", "ifconfig_remote": "", "ns_public_ip": ["1.2.3.4"], "tls_version_min": "1.2"},
-        "edit-server": {"id": "ns_server1", "ns_name": "server1", "port": "2001", "server": "192.168.4.0/24", "topology": "subnet", "proto": "tcp", "local": ["192.168.100.0/24"], "remote": ["192.168.5.0/24"], "compress": "", "auth": "", "cipher": "", "secret": "", "ifconfig_local": "", "ifconfig_remote": "", "ns_public_ip": ["1.2.3.4"], "tls_version_min": "1.2"},
-        "add-client": {"ns_name": "client1", "port": "2001", "proto": "tcp", "certificate": "XXX", "dev_type": "tun", "remote": ["192.168.5.0/24"], "compress": "", "auth": "", "cipher": "", "secret": "", "route": [], "username": "", "password": "", "ifconfig_local": "", "ifconfig_remote": ""},
-        "edit-client": {"id": "ns_client1", "ns_name": "client2", "port": "2001", "proto": "tcp", "certificate": "XXX", "dev_type": "tun", "remote": ["192.168.5.0/24"], "compres": "", "auth": "", "cipher": "", "secret": "", "route": [], "username": "", "password": "", "ifconfig_local": "", "ifconfig_remote": ""},
+        "add-server": {"ns_name": "server1", "port": "2001", "server": "192.168.4.0/24", "topology": "subnet", "proto": "tcp", "local": ["192.168.100.0/24"], "remote": ["192.168.5.0/24"], "compress": "", "auth": "", "cipher": "", "secret": "", "ifconfig_local": "", "ifconfig_remote": "", "ns_public_ip": ["1.2.3.4"], "tls_version_min": "1.2","tun_mtu": "1500", "mssfix": "1450"},
+        "edit-server": {"id": "ns_server1", "ns_name": "server1", "port": "2001", "server": "192.168.4.0/24", "topology": "subnet", "proto": "tcp", "local": ["192.168.100.0/24"], "remote": ["192.168.5.0/24"], "compress": "", "auth": "", "cipher": "", "secret": "", "ifconfig_local": "", "ifconfig_remote": "", "ns_public_ip": ["1.2.3.4"], "tls_version_min": "1.2", "tun_mtu": "1500", "mssfix": "1450"},
+        "add-client": {"ns_name": "client1", "port": "2001", "proto": "tcp", "certificate": "XXX", "dev_type": "tun", "remote": ["192.168.5.0/24"], "compress": "", "auth": "", "cipher": "", "secret": "", "route": [], "username": "", "password": "", "ifconfig_local": "", "ifconfig_remote": "", "tun_mtu": "1500", "mssfix": "1450"},
+        "edit-client": {"id": "ns_client1", "ns_name": "client2", "port": "2001", "proto": "tcp", "certificate": "XXX", "dev_type": "tun", "remote": ["192.168.5.0/24"], "compres": "", "auth": "", "cipher": "", "secret": "", "route": [], "username": "", "password": "", "ifconfig_local": "", "ifconfig_remote": "", "tun_mtu": "1500", "mssfix": "1450"},
         "export-client": {"name": "ns_client1"},
         "list-tunnels": {},
         "list-cipher": {},

--- a/packages/ns-openvpn/Makefile
+++ b/packages/ns-openvpn/Makefile
@@ -62,6 +62,7 @@ define Package/ns-openvpn/install
 	$(INSTALL_BIN) ./files/80-save-disconnection $(1)/usr/libexec/ns-openvpn/disconnect-scripts
 	$(INSTALL_BIN) ./files/99_ns-openvpn $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/99_ns-openvpn-renew-crl $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/99_ns-openvpn-mtu-mssfix-defaults $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/openvpn-status $(1)/usr/bin
 	$(INSTALL_BIN) ./files/openvpn-kill $(1)/usr/bin
 endef

--- a/packages/ns-openvpn/files/99_ns-openvpn-mtu-mssfix-defaults
+++ b/packages/ns-openvpn/files/99_ns-openvpn-mtu-mssfix-defaults
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# extract all openvpn section names starting with ns_
+ns_instances=$(uci show openvpn 2>/dev/null | grep '=openvpn$' | grep -o 'ns_[^.=]*' | sort -u)
+
+for name in $ns_instances; do
+    # skip instances using a custom config file
+    [ -n "$(uci -q get openvpn."${name}".config)" ] && continue
+
+    if [ -z "$(uci -q get openvpn."${name}".tun_mtu)" ]; then
+        uci set openvpn."${name}".tun_mtu='1500'
+    fi
+    if [ -z "$(uci -q get openvpn."${name}".mssfix)" ]; then
+        uci set openvpn."${name}".mssfix='1450'
+    fi
+done
+
+uci commit openvpn
+
+exit 0


### PR DESCRIPTION
This pull request adds support for managing and defaulting the `tun_mtu` and `mssfix` parameters for OpenVPN Roadwarrior and server/client tunnels across the codebase. These parameters are now consistently set, exported, and included in configuration and API responses, ensuring improved interoperability and reducing MTU-related connection issues. The changes also introduce a new script to backfill these defaults for existing instances.

**OpenVPN MTU and MSSFix Support**

* Default values for `tun_mtu` (1500) and `mssfix` (1450) are now set when creating or importing OpenVPN instances, both for server/client tunnels and RoadWarrior Servers.
* These parameters are included in exported client/server configurations and are now part of the API responses and example payloads for tunnel management endpoints
* The OpenVPN user configuration file now includes `tun-mtu` and `mssfix` directives, using either the configured or default values.
* The `set_configuration` logic now allows updating `tun_mtu` and `mssfix` values for an instance if changed. 
* A new initialization script (`99_ns-openvpn-mtu-mssfix-defaults`) is added to ensure all existing OpenVPN instances have `tun_mtu` and `mssfix` set to defaults if missing. 

Closes: https://github.com/NethServer/nethsecurity/issues/1192, https://github.com/NethServer/nethsecurity/issues/1427