### PR TITLE
fix(api): prevent error on dashboard

### DIFF
--- a/packages/ns-api/files/ns.update
+++ b/packages/ns-api/files/ns.update
@@ -102,6 +102,9 @@ def check_system_update():
                 return utils.generic_error("not_found")
             case _:
                 return utils.generic_error("generic_error")
+    except ValueError:
+        # Avoid UI error when checking dev version because it's not a valid semver
+        return data
     except Exception:
         return utils.generic_error("generic_error")
 


### PR DESCRIPTION
Development releases are not valid semver versions, so the API was failing with a `generic-error` always shown inside the dashboard