### PR TITLE
fix(openvpn): ensure RW connection database is merged after package installation

### DIFF
--- a/packages/ns-openvpn/Makefile
+++ b/packages/ns-openvpn/Makefile
@@ -76,7 +76,10 @@ endef
 
 define Package/ns-openvpn/postinst
 #!/bin/sh
-/usr/sbin/ns-openvpnrw-extend-crl
+if [ -z "$${IPKG_INSTROOT}" ]; then
+  /usr/sbin/ns-openvpnrw-extend-crl
+  /usr/libexec/ns-openvpn/openvpn-merge-connections-db
+fi
 exit 0
 endef
 


### PR DESCRIPTION
This pull request makes a small change to the `postinst` script for the `ns-openvpn` package. It ensures that commands are only executed when not running in a package installation root environment, which is important for correct installation behavior. 
It also add the execution of an additional command to merge the `/var` database records into the storage one, if present.

- Post-install script improvements:
  * Updated the `postinst` script in `packages/ns-openvpn/Makefile` to run `/usr/sbin/ns-openvpnrw-extend-crl` and `/usr/libexec/ns-openvpn/openvpn-merge-connections-db` only when not in the package installation root, ensuring proper setup after installation.
  * Run the `openvpn-merge-connections-db` script after package installation so that, when the system is updated, records are merged into storage to avoid database read issues (after the update, connection history is read from storage if available).

Closes: https://github.com/NethServer/nethsecurity/issues/1404