### PR TITLE
fix(api-server): increase max upload size

### DIFF
--- a/packages/ns-api-server/Makefile
+++ b/packages/ns-api-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ns-api-server
 # renovate: datasource=github-tags depName=NethServer/nethsecurity-api
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
  
 PKG_SOURCE:=ns-api-server-$(PKG_VERSION).tar.gz
 PKG_BUILD_DIR=$(BUILD_DIR)/nethsecurity-api-$(PKG_VERSION)

--- a/packages/ns-api-server/files/ns-api-server.initd
+++ b/packages/ns-api-server/files/ns-api-server.initd
@@ -13,7 +13,7 @@ WORK_DIR=/var/run/ns-api-server
 TOKENS_DIR=${WORK_DIR}/tokens
 SECRETS_DIR=/etc/ns-api-server
 UPLOAD_FILE_PATH=${WORK_DIR}/uploads
-UPLOAD_FILE_MAX_SIZE=64 # 64MB
+UPLOAD_FILE_MAX_SIZE=128 # 128MB
 
 boot() {
     local boot_delay="$(uci_get ns-ui.config.api_server_delay)"


### PR DESCRIPTION
Images starting from NethSecurity 8.8 can be larger than current 64MB limit.
Increae the limit to 128MB to allow upgrading from the UI.