### PR TITLE
fix(nat): handle missing interface label for devices

### DIFF
--- a/packages/ns-api/files/ns.nat
+++ b/packages/ns-api/files/ns.nat
@@ -50,7 +50,7 @@ elif cmd == 'call':
                 for device in utils.get_all_devices_by_zone(e_uci, zone.get('name')):
                     devices.append({
                         'id': device,
-                        'label': utils.get_interface_from_device(e_uci, device)
+                        'label': utils.get_interface_from_device(e_uci, device) or device
                     })
             json.dump({
                 'devices': devices,


### PR DESCRIPTION
This pull request makes a minor improvement to the device labeling logic in the `call` command. If the interface label for a device cannot be determined, the device ID will now be used as a fallback label, ensuring that every device has a meaningful label.

- Ensure every device has a label by defaulting to the device ID if the interface label is missing in the `call` command logic (`ns.nat`).

Closes: https://github.com/NethServer/nethsecurity/issues/1650