### PR TITLE
build: updated signing method for APKs

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -31,8 +31,8 @@ jobs:
       NETHSECURITY_VERSION: ${{ steps.build_vars.outputs.NETHSECURITY_VERSION }}
       REPO_CHANNEL: ${{ steps.build_vars.outputs.REPO_CHANNEL }}
     env:
-      USIGN_PUB_KEY: ${{ secrets.USIGN_PUB_KEY }}
-      USIGN_PRIV_KEY: ${{ secrets.USIGN_PRIV_KEY }}
+      APK_PUB_KEY: ${{ secrets.APK_PUB_KEY }}
+      APK_PRIV_KEY: ${{ secrets.APK_PRIV_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-key-build*
+private-key.pem
+public-key.pem
 /bin
 build-logs
 build.conf

--- a/build-nethsec.sh
+++ b/build-nethsec.sh
@@ -28,9 +28,9 @@ REPO_CHANNEL=${REPO_CHANNEL:-dev}
 TARGET=${TARGET:-x86_64}
 BUILD_SEMVER_SUFFIX=${BUILD_SEMVER_SUFFIX:-}
 
-if [ -f "./key-build" ] && [ -f "./key-build.pub" ]; then
-    USIGN_PRIV_KEY="$(cat ./key-build)"
-    USIGN_PUB_KEY="$(cat ./key-build.pub)"
+if [ -f "./private-key.pem" ] && [ -f "./public-key.pem" ]; then
+    APK_PRIV_KEY="$(cat ./private-key.pem)"
+    APK_PUB_KEY="$(cat ./public-key.pem)"
 fi
 
 
@@ -39,7 +39,6 @@ podman build \
     --layers \
     --file builder/Containerfile \
     --tag nethsecurity-next \
-    --target builder \
     --jobs 0 \
     --build-arg OWRT_VERSION="$OWRT_VERSION" \
     --build-arg REPO_CHANNEL="$REPO_CHANNEL" \
@@ -52,8 +51,8 @@ set +e
 
 status=0
 podman run \
-    --env USIGN_PRIV_KEY="$USIGN_PRIV_KEY" \
-    --env USIGN_PUB_KEY="$USIGN_PUB_KEY" \
+    --env APK_PRIV_KEY="$APK_PRIV_KEY" \
+    --env APK_PUB_KEY="$APK_PUB_KEY" \
     --name nethsecurity-builder \
     --interactive \
     --tty \

--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -35,13 +35,6 @@ RUN apt-get update \
         sudo \
         vim
 
-FROM base AS usign_build
-RUN git clone --depth 1 https://git.openwrt.org/project/usign.git /tmp/usign \
-    && cd /tmp/usign \
-    && cmake . \
-    && make
-
-FROM base AS builder
 RUN groupadd -g 1000 'buildbot' \
     && useradd -m -s '/bin/bash' -u 1000 -g 1000 'buildbot' \
     && echo 'buildbot ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/buildbot \
@@ -58,7 +51,9 @@ WORKDIR /home/buildbot
 ARG OWRT_VERSION
 RUN git clone --branch "${OWRT_VERSION}" https://github.com/openwrt/openwrt.git
 WORKDIR /home/buildbot/openwrt
-RUN sed -i '/telephony/d' feeds.conf.default
+RUN sed -i '/telephony/d' feeds.conf.default \
+    && sed -i '/routing/d' feeds.conf.default \
+    && sed -i '/video/d' feeds.conf.default
 RUN ./scripts/feeds update -a
 COPY --chmod=777 builder/apply-patches.sh /usr/local/bin/apply-patches
 COPY --chown=buildbot:buildbot patches patches
@@ -79,15 +74,14 @@ COPY --chmod=777 builder/configure-build.sh /usr/local/bin/configure-build
 RUN /usr/local/bin/configure-build
 COPY --chmod=777 builder/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
-COPY --from=usign_build /tmp/usign/usign /usr/local/bin/usign
 RUN mkdir -p \
-      .ccache \
-      build_dir \
-      dl \
-      download \
-      staging_dir
+        .ccache \
+        build_dir \
+        dl \
+        download \
+        staging_dir
 VOLUME "/home/buildbot/openwrt/.ccache" \
-    "/home/buildbot/openwrt/build_dir" \
-    "/home/buildbot/openwrt/dl" \
-    "/home/buildbot/openwrt/download" \
-    "/home/buildbot/openwrt/staging_dir"
+        "/home/buildbot/openwrt/build_dir" \
+        "/home/buildbot/openwrt/dl" \
+        "/home/buildbot/openwrt/download" \
+        "/home/buildbot/openwrt/staging_dir"

--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -7,12 +7,9 @@
 
 set -e
 
-if [ -n "$USIGN_PUB_KEY" ] && [ -n "$USIGN_PRIV_KEY" ]; then
-    echo "$USIGN_PUB_KEY" > /home/buildbot/openwrt/key-build.pub
-    echo "$USIGN_PRIV_KEY" > /home/buildbot/openwrt/key-build
-else
-    echo "No signing keys found. Generating dummy keys..."
-    usign -G -s ./key-build -p ./key-build.pub -c "Local build key"
+if [ -n "$APK_PRIV_KEY" ] && [ -n "$APK_PUB_KEY" ]; then
+    echo "$APK_PRIV_KEY" > /home/buildbot/openwrt/private-key.pem
+    echo "$APK_PUB_KEY" > /home/buildbot/openwrt/public-key.pem
 fi
 
 # if command $1 is a file or a executable, run it

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -87,16 +87,16 @@ The `build-nethsec.sh` script behavior can be changed by setting environment var
 - `TARGET`: specify the target to build; if not set default is `x86_64`
 - `REPO_CHANNEL`: specify the channel to publish the image to; if not set default is `dev`
 - `BUILD_SEMVER_SUFFIX`: optional semver suffix appended to the image version only (not the distfeed URL). Use pre-release format (`-rc.1`, `-beta.2`) or metadata format (`+hotfix.1`, `+testing`) or both (`-rc.1+fix.1`).
-- `USIGN_PUB_KEY` and `USIGN_PRIV_KEY`: see [package signing section](#package-signing)
+- `APK_PUB_KEY` and `APK_PRIV_KEY`: see [package signing section](#package-signing)
 
-The `USIGN_PUB_KEY`, `USIGN_PRIV_KEY` variables are always set as secrets inside the CI pipeline, but 
+The `APK_PUB_KEY`, `APK_PRIV_KEY` variables are always set as secrets inside the CI pipeline, but 
 for [security reasons](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#accessing-secrets)
 they are not accessible when building pull requests from forks.
 
 ### Build locally for a release
 
 If you need to build some packages locally for a release, make sure the following environment variables are set:
-- `USIGN_PUB_KEY` and `USIGN_PRIV_KEY`: refer to the [package signing section](#package-signing) for more info
+- `APK_PUB_KEY` and `APK_PRIV_KEY`: refer to the [package signing section](#package-signing) for more info
 
 Then execute the build as described in the [Build locally](#build-locally) section.
 
@@ -272,26 +272,26 @@ To replace an upstream package just create a new package with the same name insi
 
 ### Package signing
 
-All packages are signed with the following public key generated with [OpenBSD signify](nethsecurity-pub.key).
+Packages are signed using an EC prime256v1 key pair (PEM format) via the APK package manager.
 
-Public key fingerprint: `7640d16662de3b89`
-
-Public key content:
+To generate a new signing key pair:
 ```
-untrusted comment: NethSecurity sign key
-RWR2QNFmYt47ieK7g/zEPwgk+MN8bHsA2vFnPThSpnLZ48L7sh6wxB/f
+openssl ecparam -name prime256v1 -genkey -noout -out private-key.pem
+openssl ec -in private-key.pem -pubout -out public-key.pem
 ```
 
-To sign the packages, just execute the `build-nethsec.sh` script with the following environment variables:
-- `USIGN_PUB_KEY`
-- `USIGN_PRIV_KEY`
+To sign the packages, execute the `build-nethsec.sh` script with the following environment variables:
+- `APK_PUB_KEY`
+- `APK_PRIV_KEY`
 
 Usage example:
 ```
-USIGN_PUB_KEY=$(cat nethsecurity-pub.key) USIGN_PRIV_KEY=$(cat nethsecurity-priv.key) ./build-nethsec.sh
+APK_PUB_KEY=$(cat public-key.pem) APK_PRIV_KEY=$(cat private-key.pem) ./build-nethsec.sh
 ```
 
-Or you can have the keys as two files named `key-build` and `key-build.pub` in the root of the repository. They will be automatically used by the build script.
+Or you can place the keys as two files named `private-key.pem` and `public-key.pem` in the root of the repository. They will be automatically used by the build script.
+
+If no keys are provided, OpenWrt will auto-generate a throwaway key pair at build time.
 
 Builds executed inside CI will sign the packages with the correct key.
 


### PR DESCRIPTION
APKs compilation process now uses a different key, if missing the system auto-generates a throwaway.
