### PR TITLE
Fix backup passphrase sync in HA

### DIFF
--- a/packages/ns-ha/files/900-ns-plug
+++ b/packages/ns-ha/files/900-ns-plug
@@ -9,6 +9,8 @@ set_service_name ns-plug
 set_restart_if_master
 set_stop_if_backup
 
+RESTORE_LIST="/usr/share/keepalived/rsync/tmp/restore_list"
+
 if [ "$ACTION" == "NOTIFY_BACKUP" ]; then
     update_cron "disable" "send-heartbeat send-backup send-inventory" "ns-push-reports"
     cluster_alert "backup"
@@ -17,7 +19,7 @@ elif [ "$ACTION" == "NOTIFY_MASTER" ]; then
     cluster_alert "master"
 elif [ "$ACTION" == "NOTIFY_SYNC" ]; then
     # Remove backup.pass if it has been unset on the primary
-    if [ ! -f /usr/share/keepalived/rsync/tmp/etc/backup.pass ] && [ -f /etc/backup.pass ]; then
+    if ! grep -q /etc/backup.pass /usr/share/keepalived/rsync/tmp/restore_list && [ -f /etc/backup.pass ]; then
         rm -f /etc/backup.pass
     fi
 fi


### PR DESCRIPTION
## Summary

Fix the backup-node `backup.pass` check during `NOTIFY_SYNC`.
`900-ns-plug` now looks for the passphrase under the same
`/usr/share/keepalived/rsync/etc/backup.pass` path restored by
`02-rsync`, so the synced file is not removed immediately after it
is copied.

## Related issue

#1655

## How to test

1. Configure HA with `/etc/backup.pass` present on the primary.
2. Trigger `ACTION=NOTIFY_SYNC /sbin/hotplug-call keepalived` on the
   backup node, or wait for the periodic sync.
3. Verify `/etc/backup.pass` is still present on the backup node
   after sync.
4. Remove `/etc/backup.pass` from the primary, sync again, and
   verify it is removed from the backup node too.

## Dependencies

None.