### PR TITLE
fix(ns-api): ipsectunnels, call swanctl once

### DIFF
--- a/packages/ns-api/files/ns.ipsectunnel
+++ b/packages/ns-api/files/ns.ipsectunnel
@@ -7,13 +7,13 @@
 
 # Manage IPSec tunnels
 
-import os
 import sys
 import json
-import ipaddress
 import subprocess
 from euci import EUci
 from nethsec import utils, firewall, ipsec, ovpn
+
+sas_list = None
 
 ## Utils
 
@@ -47,7 +47,17 @@ def next_id():
             continue
     return max_id + 1
 
-def get_tunnel_status(id):
+def get_swanctl_list_sas():
+    global sas_list
+    if sas_list is None:
+        try:
+            p = subprocess.run(["swanctl", "--list-sas"], capture_output=True, text=True, check=True)
+            sas_list = p.stdout
+        except:
+            sas_list = ''
+    return sas_list.split("\n")
+
+def get_tunnel_status(id, swanctl_output=None):
     """Get tunnel status from swanctl output. Returns dict with status, installed count, tunnel details, and raw output."""
     result = {
         'status': None,
@@ -57,8 +67,7 @@ def get_tunnel_status(id):
         'raw_output': ''  # Raw swanctl output for this remote
     }
     try:
-        p = subprocess.run(["swanctl", "--list-sas"], capture_output=True, text=True, check=True)
-        lines = p.stdout.split("\n")
+        lines = get_swanctl_list_sas() if swanctl_output is None else swanctl_output
         in_remote = False
         remote_lines = []
         
@@ -93,13 +102,14 @@ def get_tunnel_status(id):
     
     return result
 
-def is_connected(id, u):
+def is_connected(id, u, status_info=None):
     """Check tunnel connection status with three states: yes, warning, no.
     - yes: all children installed and status is ESTABLISHED
     - warning: not all children installed but status is ESTABLISHED
     - no: status is not ESTABLISHED
     """
-    status_info = get_tunnel_status(id)
+    if status_info is None:
+        status_info = get_tunnel_status(id)
     
     # Get count of configured tunnels from UCI
     try:
@@ -146,10 +156,11 @@ def uci_set_if_changed(u, config, section, option, value):
 def list_tunnels():
     ret = []
     u = EUci()
+    swanctl_output = get_swanctl_list_sas()
     for r in utils.get_all_by_type(u, 'ipsec', 'remote'):
         local = set()
         remote = set()
-        status_info = get_tunnel_status(r)
+        status_info = get_tunnel_status(r, swanctl_output)
         
         # Build children array with tunnel details
         children = []
@@ -178,7 +189,7 @@ def list_tunnels():
             'name': u.get('ipsec', r, 'ns_name', default=r),
             'enabled': u.get('ipsec', r, 'enabled', default='1'),
             'status': status_info['status'],
-            'connected': is_connected(r, u),
+            'connected': is_connected(r, u, status_info),
             'children': children,
             'raw_output': status_info['raw_output']
         }


### PR DESCRIPTION
The list-tunnels endpoint was calling swanctl
command multiple times, one for each existing tunnel.

If the machine had a list of many tunnels, the page was really slow.

Issue #1660 