### PR TITLE
fix(ns-api): set default tun_mtu and mssfix values for OpenVPN configuration

### DIFF
--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -590,8 +590,8 @@ def set_configuration(args):
         return utils.validation_error("ns_auth_mode", "invalid_auth_mode", args["ns_auth_mode"])
 
     # MTU and MSSFix settings
-    u.set("openvpn", ovpninstance, "tun_mtu", args.get("tun_mtu"))
-    u.set("openvpn", ovpninstance, "mssfix", args.get("mssfix"))
+    u.set("openvpn", ovpninstance, "tun_mtu", args.get("tun_mtu", '1500'))
+    u.set("openvpn", ovpninstance, "mssfix", args.get("mssfix", '1450'))
 
     u.save("openvpn")
 

--- a/packages/ns-api/files/ns.ovpntunnel
+++ b/packages/ns-api/files/ns.ovpntunnel
@@ -432,8 +432,8 @@ def list_tunnels():
                 "remote_network": remote,
                 "vpn_network": net,
             }
-            client["tun_mtu"] = vpn.get("tun_mtu", '1500')
-            client["mssfix"] = vpn.get("mssfix", '1450')
+            server["tun_mtu"] = vpn.get("tun_mtu", '1500')
+            server["mssfix"] = vpn.get("mssfix", '1450')
 
             certificates = {}
             if vpn.get('cert'):


### PR DESCRIPTION
This pull request makes improvements to the handling of MTU and MSSFix configuration values in the OpenVPN API code. The changes ensure that default values are consistently applied and correct a bug in the assignment of these values in the tunnel listing logic.

Configuration defaults and bug fix:

* Ensured that the `tun_mtu` and `mssfix` configuration options in `set_configuration` default to `'1500'` and `'1450'` respectively if not provided, improving robustness of the configuration process.
* Fixed a bug in `list_tunnels` where `tun_mtu` and `mssfix` were incorrectly assigned to the `client` dictionary instead of the `server` dictionary, ensuring correct representation of server tunnel settings.

Closes: https://github.com/NethServer/nethsecurity/issues/1427