### PR TITLE
fix(ns-ha): validate interface name against main VRRP interface

### DIFF
--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -8635,6 +8635,10 @@ Response example:
 
 Adds a LAN interface to the keepalived configuration.
 
+Validation fails with `lan_interface_name_conflicts_with_main_vrrp_interface`
+when the additional interface resolves to `lan` but the main VRRP interface
+was initialized with a different interface name.
+
 Request example:
 ```bash
 api-cli ns.ha call add-lan-interface --data '{

--- a/packages/ns-api/files/ns.ha
+++ b/packages/ns-api/files/ns.ha
@@ -83,6 +83,22 @@ def get_device_from_ip(uci, ipaddr):
             return (n, uci.get('network', n, 'device', default=None))
     return (None, None)
 
+def get_main_vrrp_interface(uci):
+    for section in utils.get_all_by_type(uci, 'keepalived', 'ipaddress'):
+        if uci.get('keepalived', section, 'name', default=None) != 'lan_ha':
+            continue
+
+        ns_link = uci.get('keepalived', section, 'ns_link', default='')
+        if ns_link.startswith('network/'):
+            return ns_link.split('/', 1)[1]
+
+    return None
+
+def validate_additional_ha_interface_name(uci, interface, parameter):
+    main_vrrp_interface = get_main_vrrp_interface(uci)
+    if interface == 'lan' and main_vrrp_interface and main_vrrp_interface != 'lan':
+        raise utils.ValidationError(parameter, 'lan_interface_name_conflicts_with_main_vrrp_interface')
+
 def ssh_execute(command, host, port=22, username='root', password=None, private_key_path=None):
     """
     Execute SSH command using subprocess
@@ -336,7 +352,21 @@ def add_lan_interface(role, primary_node_ip, backup_node_ip, virtual_ip):
     if role == "primary":
         kinstance_name = 'primary'
         (interface, device) = get_device_from_ip(u, primary_node_ip)
+    else:
+        kinstance_name = 'backup'
+        (interface, device) = get_device_from_ip(u, backup_node_ip)
 
+    if interface is None:
+        raise utils.ValidationError(f'{role}_node_ip', 'no_interface_with_static_ip_found')
+    if device is None:
+        raise utils.ValidationError(f'{role}_node_ip', 'no_device_with_static_ip_found')
+
+    validate_additional_ha_interface_name(u, interface, f'{role}_node_ip')
+
+    if len(device) >= 13:
+        raise utils.ValidationError(f'{role}_node_ip', 'device_name_too_long_for_ha')
+
+    if role == "primary":
         validate_command = json.dumps({
             "role": "backup",
             "lan_interface": interface
@@ -348,16 +378,6 @@ def add_lan_interface(role, primary_node_ip, backup_node_ip, virtual_ip):
             result = json.loads(output)
             if not result.get("success"):
                 raise utils.ValidationError('backup_node_invalid_configuration', ','.join(result.get("errors", [])))
-    else:
-        kinstance_name = 'backup'
-        (interface, device) = get_device_from_ip(u, backup_node_ip)
-
-    if interface is None:
-        raise utils.ValidationError(f'{role}_node_ip', 'no_interface_with_static_ip_found')
-    if device is None:
-        raise utils.ValidationError(f'{role}_node_ip', 'no_device_with_static_ip_found')
-    if len(device) >= 13:
-        raise utils.ValidationError(f'{role}_node_ip', 'device_name_too_long_for_ha')
 
     dhcp_errors = validate_dhcp(interface)
     if len(dhcp_errors) > 0:

--- a/packages/ns-api/openapi.yml
+++ b/packages/ns-api/openapi.yml
@@ -90,6 +90,55 @@ security:
   - BearerAuth: []
 
 paths:
+  POST /ubus/ns.ha/add-lan-interface:
+    post:
+      summary: Add a LAN interface to the HA keepalived configuration
+      operationId: ns.ha.add-lan-interface
+      tags:
+        - ha
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - role
+                - primary_node_ip
+                - backup_node_ip
+                - virtual_ip
+              properties:
+                role:
+                  type: string
+                  enum: [primary, backup]
+                  description: Node role executing the operation
+                primary_node_ip:
+                  type: string
+                  description: Static IP of the interface on the primary node
+                  example: 192.168.1.10
+                backup_node_ip:
+                  type: string
+                  description: Static IP of the corresponding interface on the backup node
+                  example: 192.168.1.11
+                virtual_ip:
+                  type: string
+                  description: Virtual IP in CIDR notation
+                  example: 192.168.1.1/24
+      responses:
+        "200":
+          description: Interface added or validation failed
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    required: [success]
+                    properties:
+                      success:
+                        type: boolean
+                        example: true
+                  - $ref: "#/components/schemas/ValidationError"
+                  - $ref: "#/components/schemas/Error"
   POST /ubus/ns.reverseproxy/add-certificate:
     post:
       summary: Add a custom certificate

--- a/packages/ns-ha/README.md
+++ b/packages/ns-ha/README.md
@@ -157,6 +157,8 @@ If the requirements are met, you can initialize the primary node, please note th
 ns-ha-config init-primary-node <primary_node_ip> <backup_node_ip> <virtual_ip> <lan_interface>
 ```
 
+For best compatibility, initialize HA on an interface named `lan`.
+
 The script will:
 
 - initialize keepalived with the virtual IP
@@ -214,6 +216,7 @@ ns-ha-config add-lan-interface <primary_node_ip> <backup_node_ip> <virtual_ip_ad
 
 When adding a LAN interface, the following requirements must be met:
 - the LAN interface must be configured with a static IP address on both nodes
+- the interface must not be named `lan` if the main VRRP interface was initialized with a different name; the command fails validation in that case to avoid Keepalived section collisions
 - if a DHCP server is running
   - the `Force DHCP server start` option must be enabled
   - the DHCP option `3: router` must be set and configured with the virtual IP address (e.g. `192.168.100.240`)


### PR DESCRIPTION
## Summary

Prevent configuration corruption when adding a LAN interface by validating that the interface name does not conflict with the main VRRP interface name.

When a non-lan VRRP interface is configured (e.g., trunk_ha), both the VRRP interface and any additional LAN interface use hardcoded lan_* identifiers in Keepalived configuration, causing corruption if a real 'lan' interface is later added.

## Related issue

#1664

## How to test

1. Set up HA with a non-lan interface (e.g., trunk_ha)
2. Attempt to add a new lan interface using:
   ```bash
   ns-ha-config add-lan-interface <primary_ip> <backup_ip> <virtual_ip>
   ```
3. Verify the API returns validation error:
   `error_code: lan_interface_name_conflicts_with_main_vrrp_interface`

## Changes

- Add `get_main_vrrp_interface()` to detect the primary VRRP interface from keepalived config
- Add `validate_additional_ha_interface_name()` to raise validation error when interface is 'lan' but main VRRP is different
- Move validation into `add_lan_interface()` before device checks
- Update API documentation (README.md and openapi.yml)