### PR TITLE
fix: improve ns-restore-extra-packages resilience and output reliability

### DIFF
--- a/files/usr/sbin/ns-restore-extra-packages
+++ b/files/usr/sbin/ns-restore-extra-packages
@@ -23,13 +23,26 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}' | while read package; do
+# Restore packages and track failures
+failed_packages=""
+
+while IFS= read -r package; do
     if ! apk info -e "$package" > /dev/null 2>&1; then
         apk add "$package"
-        echo "Restored package: $package"
+        if [ $? -eq 0 ]; then
+            echo "Restored package: $package"
+        else
+            echo "Failed to restore package: $package"
+            failed_packages="$failed_packages $package"
+        fi
     fi
-done
+done < <(grep -E '\w+\s+overlay$' /etc/backup/installed_packages.txt | awk '{print $1}')
 
-/etc/init.d/ns-restore-extra-packages stop
-/etc/init.d/ns-restore-extra-packages disable
-exit 0
+if [ -z "$failed_packages" ]; then
+    /etc/init.d/ns-restore-extra-packages stop
+    /etc/init.d/ns-restore-extra-packages disable
+    exit 0
+else
+    echo "Some packages failed to restore, will retry later"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Improve package restoration resilience after system upgrades by implementing two key enhancements:

1. **Resilient retry mechanism**: Script now tracks installation failures and exits with code 1 when packages fail to install. The procd respawn policy (respawn 300 30 10) will automatically retry on the next boot, accounting for WAN initialization delays and transient network failures.

2. **Reliable output reporting**: Only report "Restored package: X" when the package installation actually succeeds (apk exit code 0). Failed installations are reported separately, and the service is not disabled until all packages are successfully restored.

The service now remains enabled after failures, allowing the procd respawn mechanism to retry on subsequent boots until all packages are restored.

## Related issue

#1606

## How to test

1. Create test scenario with packages listed in /etc/backup/installed_packages.txt
2. Test successful restore: All packages install successfully → service disables, exit 0
3. Test partial failure: One package fails → service remains enabled for retry, exit 1
4. Test network failure: Disable WAN → service detects unavailable network, retries on next boot
5. Verify output only shows "Restored package: X" for successful installs

## Changes

- Modified: files/usr/sbin/ns-restore-extra-packages
  - Track failed installations and exit with proper code
  - Only report success when apk install succeeds
  - Service remains enabled for retry on failures
