### PR TITLE
fix(ns-dpi): adjusted dpi timings for the auto updates

### DIFF
--- a/packages/ns-dpi/files/20_dpi
+++ b/packages/ns-dpi/files/20_dpi
@@ -27,4 +27,4 @@ config main 'config'
 EOI
 fi
 
-crontab -l | grep -q '/usr/sbin/dpi-update' || echo '8 4 * * * sleep $(( RANDOM % 3600 )); /usr/sbin/dpi-update' >> /etc/crontabs/root
+crontab -l | grep -q '/usr/sbin/dpi-update' || echo '8 4 * * * sleep $(( RANDOM % 36000 )); /usr/sbin/dpi-update' >> /etc/crontabs/root

--- a/packages/ns-dpi/files/99-dpi-data-update-cron.uci-defaults
+++ b/packages/ns-dpi/files/99-dpi-data-update-cron.uci-defaults
@@ -15,7 +15,7 @@ if grep -q '/etc/init.d/dpi-data-update' /etc/crontabs/root; then
 fi
 
 if ! grep -q '/etc/init.d/dpi-data-update' /etc/crontabs/root; then
-  echo '8 4 * * * sleep $(( RANDOM % 1800 )); /etc/init.d/dpi-data-update start' >> /etc/crontabs/root
+  echo '8 4 * * * sleep $(( RANDOM % 36000 )); /etc/init.d/dpi-data-update start' >> /etc/crontabs/root
 fi
 
 # Ensure dpi-data-update service is enabled at boot

--- a/packages/ns-dpi/files/99-dpi-license-update-cron.uci-defaults
+++ b/packages/ns-dpi/files/99-dpi-license-update-cron.uci-defaults
@@ -15,7 +15,7 @@ if grep -q '/etc/init.d/dpi-license-update' /etc/crontabs/root; then
 fi
 
 if ! grep -q '/etc/init.d/dpi-license-update' /etc/crontabs/root; then
-  echo '0 7,14 * * * sleep $(( RANDOM % 1800 )); /etc/init.d/dpi-license-update start' >> /etc/crontabs/root
+  echo '0 7,14 * * * sleep $(( RANDOM % 18000 )); /etc/init.d/dpi-license-update start' >> /etc/crontabs/root
 fi
 
 # Ensure dpi-license-update service is enabled at boot


### PR DESCRIPTION
Even tho distfeed didn't go offline as usual during the peak hours, this
seems to be still an issue with requests timing out due to the server
overwhelmed. This will stretch the update window to allow the firewalls
to not overwhelm the backend.
