### PR TITLE
build: added back snmpd

### DIFF
--- a/config/snmp.conf
+++ b/config/snmp.conf
@@ -1,3 +1,3 @@
 CONFIG_PACKAGE_snmp-mibs=y
-CONFIG_PACKAGE_snmp-utils=y
-CONFIG_PACKAGE_snmpd=y
+CONFIG_PACKAGE_snmp-utils-ssl=y
+CONFIG_PACKAGE_snmpd-ssl=y


### PR DESCRIPTION
Seems the package got renamed? Was missing from final manifest.
Asking review to be sure we're talking about the same package, there's also the `nossl` version in case (unlikely)
