### PR TITLE
fix(remote-backup): improve backup name

### DIFF
--- a/packages/ns-plug/files/remote-backup
+++ b/packages/ns-plug/files/remote-backup
@@ -59,9 +59,11 @@ case "$cmd" in
        # proxy, same pattern used by send-heartbeat / send-inventory.
        # To be removed once the migration is complete.
        if [ "$TYPE" = "enterprise" ]; then
+           ext=".$(basename $file | cut -d '.' -f2)"
+           date="-$(date +%Y-%m-%d)"
            curl $curl_args -X POST \
                -H "Content-Type: application/octet-stream" \
-               -H "X-Filename: $(basename "$file")" \
+	       -H "X-Filename: backup$date$ext" \
                --data-binary "@$file" https://my.nethesis.it/proxy/backup >/dev/null || :
        fi
        exit $rc

--- a/packages/ns-plug/files/remote-backup
+++ b/packages/ns-plug/files/remote-backup
@@ -63,7 +63,7 @@ case "$cmd" in
            date="-$(date +%Y-%m-%d)"
            curl $curl_args -X POST \
                -H "Content-Type: application/octet-stream" \
-	       -H "X-Filename: backup$date$ext" \
+               -H "X-Filename: backup$date$ext" \
                --data-binary "@$file" https://my.nethesis.it/proxy/backup >/dev/null || :
        fi
        exit $rc


### PR DESCRIPTION
Use a mnemonic name for backup instead of
a random name derived from temporary file.