### PR TITLE
fix(openvpn-status): manage real_address format after OpenVPN version update

### DIFF
--- a/packages/ns-openvpn/files/openvpn-status
+++ b/packages/ns-openvpn/files/openvpn-status
@@ -57,7 +57,11 @@ try:
                     if cn == 'UNDEF':
                         continue
 
-                    ip_addr, port_addr = real_address.split(':')
+                    real_address_parts = real_address.split(':')
+                    if len(real_address_parts) == 2:
+                        ip_addr, port_addr = real_address_parts
+                    elif len(real_address_parts) == 3:
+                        ip_addr, port_addr = real_address_parts[1:]
 
                     results[cn] = {
                         'real_address': ip_addr,

--- a/packages/ns-openvpn/files/openvpn-status
+++ b/packages/ns-openvpn/files/openvpn-status
@@ -62,6 +62,8 @@ try:
                         ip_addr, port_addr = real_address_parts
                     elif len(real_address_parts) == 3:
                         ip_addr, port_addr = real_address_parts[1:]
+                    else:
+                        ip_addr, port_addr = real_address, ''
 
                     results[cn] = {
                         'real_address': ip_addr,


### PR DESCRIPTION
This pull request contains updates to manage users' connection status for the OpenVPN RoadWarrior server.

After updating the OpenVPN package from 2.6.14 to 2.7.4, the `real_address` field is now formatted as `[proto]:[ip]:[port]`, which caused an inconsistent state in the OpenVPN RoadWarrior section: a user can appear disconnected even though they are actually connected (a new connection history record is correctly visible in the Connections History table).

The parsing logic that extracts the client's `ip` and `port' has been updated to handle real_address values with two or three parts. If there are two parts, the behavior remains unchanged; if there are three parts, the first part (the proto information) is ignored.

If `real_address` contains only one part or more than three parts, the entire `real_address` is used as the value to avoid problems (the IP address is shown only in the "More info" tooltip).

Closes: https://github.com/NethServer/nethsecurity/issues/1686