### PR TITLE
fix(ns.dashboard): add bytes sent/received check for ovpn connected client tunnels counter

### DIFF
--- a/packages/ns-api/files/ns.dashboard
+++ b/packages/ns-api/files/ns.dashboard
@@ -330,7 +330,7 @@ def ovpn_tunnels():
 
         if vpn.get("client", "0") == "1" or vpn.get("ns_client", "0") == "1":
             connected = ovpn.list_connected_clients(section, 'p2p')
-            if 'stats' in connected:
+            if 'stats' in connected and connected['stats'].get('bytes_received') > 0 and connected['stats'].get('bytes_sent') > 0 :
                 ret["connected"] += 1
         else:
             connected = ovpn.list_connected_clients(section, vpn.get("topology", "subnet"))


### PR DESCRIPTION
This PR contains a patch for the OpenVPN connected-client count shown on the firewall dashboard.
Previously, the dashboard API only checked whether a socket existed in the `/var/run` directory for a specific client tunnel.
If a client tunnel connected and was later disconnected, the socket could still remain in that directory, causing the dashboard to count that client as still connected.

This patch adds a check for the `bytes_received` and `bytes_sent` properties on the socket. If the client is disconnected, both values are 0.

This is the same mechanism already used in the [OpenVPN Tunnel section](https://github.com/NethServer/nethsecurity/blob/f76953760ee25008ed91441f6fe3b25211bd8aa4/packages/ns-api/files/ns.ovpntunnel#L386) to determine whether a tunnel is connected.

Closes: https://github.com/NethServer/nethsecurity/issues/1688