### PR TITLE
Include https-dns-proxy with safe defaults

### DIFF
--- a/config/dnsmasq.conf
+++ b/config/dnsmasq.conf
@@ -10,4 +10,4 @@ CONFIG_PACKAGE_dnsmasq_full_conntrack=y
 CONFIG_PACKAGE_dnsmasq_full_noid=y
 # CONFIG_PACKAGE_dnsmasq_full_broken_rtc is not set
 CONFIG_PACKAGE_dnsmasq_full_tftp=y
-CONFIG_PACKAGE_https-dns-proxy=m
+CONFIG_PACKAGE_https-dns-proxy=y

--- a/docs/design/doh.md
+++ b/docs/design/doh.md
@@ -6,18 +6,28 @@ parent: Design
 
 # DoH (DNS over HTTPS)
 
-You can provide the standard DHCP instance with a forward to DNS-over-HTTPs (DOH) servers.
-This is done by using the [`https-dns-proxy`](https://openwrt.org/docs/guide-user/services/dns/doh_dnsmasq_https-dns-proxy).
+You can provide the standard DHCP instance with a forward to DNS-over-HTTPS (DoH) servers.
+This is done by using the [`https-dns-proxy`](https://openwrt.org/docs/guide-user/services/dns/doh_dnsmasq_https-dns-proxy), which is included in the NethSecurity image.
 
-The package can be installed using the following command:
+By default:
+
+- the service is disabled and is not started on boot
+- the proxy listens on `127.0.0.1:5053` and `127.0.0.1:5054` when started
+- `option dnsmasq_config_update '-'` prevents automatic `dnsmasq` changes
+
+The configuration is stored in `/etc/config/https-dns-proxy`. Upstream options are documented at
+[docs.openwrt.melmac.ca/https-dns-proxy](https://docs.openwrt.melmac.ca/https-dns-proxy/).
+
+To integrate the proxy with `dnsmasq`, choose the `dnsmasq_config_update` value you want and then enable the service:
 
 ```bash
-apk update
-apk add https-dns-proxy
+uci set https-dns-proxy.config.dnsmasq_config_update='*'
+uci commit https-dns-proxy
+/etc/init.d/https-dns-proxy enable
+/etc/init.d/https-dns-proxy start
 ```
 
-By default, the proxy listens to the `127.0.0.1:5053` and `127.0.0.1:5054` addresses. The configuration for the service can be found at the
-following [link](https://docs.openwrt.melmac.net/https-dns-proxy).
-
-The tool will edit the dnsmasq configuration automatically, takes care of keeping it up to date, and restart the
-services if any changes happen.
+If `dnsmasq_config_update` stays set to `-`, the first-boot defaults script
+will consider the service disabled and may disable it again after an image
+upgrade. At the moment this is not expected to be a practical problem because
+configuration is supported only from the command line.

--- a/files/etc/uci-defaults/99-nethsec-https-dns-proxy
+++ b/files/etc/uci-defaults/99-nethsec-https-dns-proxy
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+if [ "$(uci -q get https-dns-proxy.config.dnsmasq_config_update)" = "-" ]; then
+    /etc/init.d/https-dns-proxy disable
+fi
+
+exit 0

--- a/patches/feeds/packages/100-https-dns-proxy-safe-defaults.patch
+++ b/patches/feeds/packages/100-https-dns-proxy-safe-defaults.patch
@@ -1,0 +1,7 @@
+diff --git a/net/https-dns-proxy/files/etc/config/https-dns-proxy b/net/https-dns-proxy/files/etc/config/https-dns-proxy
+index 2aa9b210c..9c7e67d91 100644
+--- a/net/https-dns-proxy/files/etc/config/https-dns-proxy
++++ b/net/https-dns-proxy/files/etc/config/https-dns-proxy
+@@ -4 +4 @@ config main 'config'
+-	option dnsmasq_config_update '*'
++	option dnsmasq_config_update '-'


### PR DESCRIPTION
## Summary

- include `https-dns-proxy` in the image
- default `dnsmasq_config_update` to `-`
- keep the service disabled on boot while dnsmasq integration stays disabled
- update the DoH design documentation

## Related issue

Refs: https://github.com/NethServer/nethsecurity/issues/1638

## How to test

1. Build an image from this branch.
2. Verify `/etc/config/https-dns-proxy` exists and defaults `dnsmasq_config_update` to `-`.
3. Verify `/etc/init.d/https-dns-proxy enabled` returns false after first boot.
4. Set `uci set https-dns-proxy.config.dnsmasq_config_update='*'`, commit the config, enable the service, and start it.
5. Verify dnsmasq receives the DoH upstream entries and the proxy keeps running after manual enablement.

## Dependencies

- https://github.com/NethServer/nethsecurity-docs/pull/266

## Known limitation

If `dnsmasq_config_update` remains `-`, the first-boot defaults script can disable `https-dns-proxy` again after an image upgrade. Right now this should not be a practical problem because configuration is supported only from the command line.
