### PR TITLE
feat(monitoring): re-add netdata as module

### DIFF
--- a/config/netdata.conf
+++ b/config/netdata.conf
@@ -1,0 +1,1 @@
+CONFIG_PACKAGE_netdata=y

--- a/patches/feeds/packages/100-netdata-export-promethus.patch
+++ b/patches/feeds/packages/100-netdata-export-promethus.patch
@@ -1,0 +1,12 @@
+diff --git a/admin/netdata/Makefile b/admin/netdata/Makefile
+index e471f27b2..def44a874 100644
+--- a/admin/netdata/Makefile
++++ b/admin/netdata/Makefile
+@@ -62,7 +62,6 @@ CONFIGURE_ARGS += \
+ 	--disable-plugin-freeipmi \
+ 	--disable-plugin-cups \
+ 	--disable-plugin-xenstat \
+-	--disable-backend-prometheus-remote-write \
+ 	--disable-unit-tests \
+ 	--disable-ml \
+ 	--disable-cloud


### PR DESCRIPTION
If anyone has a custom Grafana dashboard on the controller, such dashboard will not break.

Refs https://github.com/NethServer/nethsecurity/issues/1638