### PR TITLE
Fix: preserve banip blocklist mtime when dedup content unchanged

### DIFF
--- a/packages/banip/Makefile
+++ b/packages/banip/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/packages/banip/files/banip-functions.sh
+++ b/packages/banip/files/banip-functions.sh
@@ -953,7 +953,9 @@ f_down() {
 					"${ban_awkcmd}" '/^127\./{next}/^(([1-9][0-9]?[0-9]?\.){1}([0-9]{1,3}\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]].*|$)/{printf "%s,\n",$1}' "${ban_blocklist}" >"${tmp_raw}"
 					"${ban_awkcmd}" 'NR==FNR{member[$0];next}!($0 in member)' "${ban_tmpfile}.deduplicate" "${tmp_raw}" 2>/dev/null >"${tmp_split}"
 					"${ban_awkcmd}" 'BEGIN{FS="[ ,]"}NR==FNR{member[$1];next}!($1 in member)' "${ban_tmpfile}.deduplicate" "${ban_blocklist}" 2>/dev/null >"${tmp_raw}"
-					"${ban_catcmd}" "${tmp_raw}" 2>/dev/null >"${ban_blocklist}"
+					if ! cmp -s "${tmp_raw}" "${ban_blocklist}" 2>/dev/null; then
+						"${ban_catcmd}" "${tmp_raw}" 2>/dev/null >"${ban_blocklist}"
+					fi
 				else
 					"${ban_awkcmd}" '/^127\./{next}/^(([1-9][0-9]?[0-9]?\.){1}([0-9]{1,3}\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]].*|$)/{printf "%s,\n",$1}' "${ban_blocklist}" >"${tmp_split}"
 				fi
@@ -968,7 +970,9 @@ f_down() {
 						"${ban_awkcmd}" '/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\/(1?[0-2][0-8]|[0-9][0-9]))?)([[:space:]].*|$)/{printf "%s,\n",tolower($1)}' >"${tmp_raw}"
 					"${ban_awkcmd}" 'NR==FNR{member[$0];next}!($0 in member)' "${ban_tmpfile}.deduplicate" "${tmp_raw}" 2>/dev/null >"${tmp_split}"
 					"${ban_awkcmd}" 'BEGIN{FS="[ ,]"}NR==FNR{member[$1];next}!($1 in member)' "${ban_tmpfile}.deduplicate" "${ban_blocklist}" 2>/dev/null >"${tmp_raw}"
-					"${ban_catcmd}" "${tmp_raw}" 2>/dev/null >"${ban_blocklist}"
+					if ! cmp -s "${tmp_raw}" "${ban_blocklist}" 2>/dev/null; then
+						"${ban_catcmd}" "${tmp_raw}" 2>/dev/null >"${ban_blocklist}"
+					fi
 				else
 					"${ban_awkcmd}" '!/^([0-9A-f]{2}:){5}[0-9A-f]{2}.*/{printf "%s\n",$1}' "${ban_blocklist}" |
 						"${ban_awkcmd}" '/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\/(1?[0-2][0-8]|[0-9][0-9]))?)([[:space:]].*|$)/{printf "%s,\n",tolower($1)}' >"${tmp_split}"


### PR DESCRIPTION
## Summary

This PR addresses the immediate cause of non-deterministic backup generation: **banip blocklist timestamp issue**.

### 1. banip blocklist timestamp (IMPLEMENTED)

When `ban_deduplicate=1` (the default), banip unconditionally rewrites the blocklist file even when content is unchanged. This updates the mtime and causes backup differences. Fixed by wrapping the write with a `cmp -s` check to only write when content actually changes.

**Files changed:**
- `packages/banip/files/banip-functions.sh` — IPv4 and IPv6 dedup paths now use cmp -s check
- `packages/banip/Makefile` — PKG_RELEASE 3→4

### 2. sysupgrade disable_services and installed_packages timestamps (DEFERRED)

OpenWrt's sysupgrade creates `/etc/uci-defaults/10_disable_services` and `/etc/backup/installed_packages.txt` with the current timestamp. This requires patching upstream OpenWrt base-files which is non-trivial for the v24.10.5 release. This will be addressed as part of upgrading to OpenWrt v25 which includes the upstream fix (OpenWrt PR #16146).

## Related issue

#1146

## How to test

1. Deploy the fixed packages
2. Create two backups on consecutive days: `sysupgrade -k -b /tmp/backup1.tar.gz` and `sysupgrade -k -b /tmp/backup2.tar.gz`
3. Compare: `md5sum /tmp/backup?.tar.gz` — they should now be more consistent (banip blocklist won't cause differences)
4. Verify banip still functions normally when content actually changes
5. Verify sysupgrade backup/restore still works correctly