### PR TITLE
fix(banip): prevent unnecessary blocklist mtime updates

### DIFF
--- a/packages/banip/Makefile
+++ b/packages/banip/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/packages/banip/files/banip-functions.sh
+++ b/packages/banip/files/banip-functions.sh
@@ -953,7 +953,9 @@ f_down() {
 					"${ban_awkcmd}" '/^127\./{next}/^(([1-9][0-9]?[0-9]?\.){1}([0-9]{1,3}\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]].*|$)/{printf "%s,\n",$1}' "${ban_blocklist}" >"${tmp_raw}"
 					"${ban_awkcmd}" 'NR==FNR{member[$0];next}!($0 in member)' "${ban_tmpfile}.deduplicate" "${tmp_raw}" 2>/dev/null >"${tmp_split}"
 					"${ban_awkcmd}" 'BEGIN{FS="[ ,]"}NR==FNR{member[$1];next}!($1 in member)' "${ban_tmpfile}.deduplicate" "${ban_blocklist}" 2>/dev/null >"${tmp_raw}"
-					"${ban_catcmd}" "${tmp_raw}" 2>/dev/null >"${ban_blocklist}"
+					if ! cmp -s "${tmp_raw}" "${ban_blocklist}" 2>/dev/null; then
+						"${ban_catcmd}" "${tmp_raw}" 2>/dev/null >"${ban_blocklist}"
+					fi
 				else
 					"${ban_awkcmd}" '/^127\./{next}/^(([1-9][0-9]?[0-9]?\.){1}([0-9]{1,3}\.){2}(1?[0-9][0-9]?|2[0-4][0-9]|25[0-5])(\/(1?[0-9]|2?[0-9]|3?[0-2]))?)([[:space:]].*|$)/{printf "%s,\n",$1}' "${ban_blocklist}" >"${tmp_split}"
 				fi
@@ -968,7 +970,9 @@ f_down() {
 						"${ban_awkcmd}" '/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\/(1?[0-2][0-8]|[0-9][0-9]))?)([[:space:]].*|$)/{printf "%s,\n",tolower($1)}' >"${tmp_raw}"
 					"${ban_awkcmd}" 'NR==FNR{member[$0];next}!($0 in member)' "${ban_tmpfile}.deduplicate" "${tmp_raw}" 2>/dev/null >"${tmp_split}"
 					"${ban_awkcmd}" 'BEGIN{FS="[ ,]"}NR==FNR{member[$1];next}!($1 in member)' "${ban_tmpfile}.deduplicate" "${ban_blocklist}" 2>/dev/null >"${tmp_raw}"
-					"${ban_catcmd}" "${tmp_raw}" 2>/dev/null >"${ban_blocklist}"
+					if ! cmp -s "${tmp_raw}" "${ban_blocklist}" 2>/dev/null; then
+						"${ban_catcmd}" "${tmp_raw}" 2>/dev/null >"${ban_blocklist}"
+					fi
 				else
 					"${ban_awkcmd}" '!/^([0-9A-f]{2}:){5}[0-9A-f]{2}.*/{printf "%s\n",$1}' "${ban_blocklist}" |
 						"${ban_awkcmd}" '/^(([0-9A-f]{0,4}:){1,7}[0-9A-f]{0,4}:?(\/(1?[0-2][0-8]|[0-9][0-9]))?)([[:space:]].*|$)/{printf "%s,\n",tolower($1)}' >"${tmp_split}"


### PR DESCRIPTION
## Summary

Fix issue where banip's deduplication process unconditionally rewrites the blocklist file every night, causing system backups to change even when configuration is unchanged.

## Root cause

The banip package (with `ban_deduplicate=1` default) runs nightly and filters the blocklist against a deduplication index. However, it unconditionally writes the result back to `/etc/banip/banip.blocklist`, updating the file's mtime even when the content is identical. Since `sysupgrade -k -b` includes file mtimes in backup tars, this causes non-deterministic backup generation.

## Changes

- Modified `packages/banip/files/banip-functions.sh`:
  - Added `cmp -s` check before writing the deduped blocklist (IPv4 path, line 955-958)
  - Added `cmp -s` check before writing the deduped blocklist (IPv6 path, line 971-975)
  - Now only writes to the blocklist when content actually changes, preserving mtime
- Bumped `packages/banip/Makefile` PKG_RELEASE from 3 to 4

## Testing

- Build passes (GitHub Actions)
- Banip deduplication logic unchanged — only write behavior affected
- File appending paths (auto-add IPs) unaffected

## Related issue

#1146
