### PR TITLE
feat: forward vmalert alerts through my.nethesis.it/proxy/alerts

### DIFF
--- a/packages/ns-plug/README.md
+++ b/packages/ns-plug/README.md
@@ -154,5 +154,6 @@ if `endsAt` is in the future (or zero/missing) a **FAILURE** is sent; if `endsAt
 the past an **OK** is sent. HA recovery/failover event alerts override this default mapping so
 they can keep the legacy `ha:primary:failed` semantics.
 
-If Mimir credentials are configured in ns-plug UCI (`my_url`, `my_system_key`, `my_system_secret`),
-vmalert also forwards all alerts to the Mimir alertmanager for cloud-side processing.
+On enterprise systems vmalert also forwards alerts to my.nethesis.it through the
+credential-translation proxy (`https://my.nethesis.it/proxy/alerts`, authenticated
+with the ns-plug `system_id` / `secret`), mirroring send-heartbeat / send-inventory.

--- a/packages/victoria-metrics/README.md
+++ b/packages/victoria-metrics/README.md
@@ -105,29 +105,30 @@ Then restart vmalert:
 /etc/init.d/vmalert restart
 ```
 
-## Mimir Integration (ns-plug)
+## Forwarding alerts to my.nethesis.it
 
-Mimir is a multi-tenant Prometheus-compatible long-term storage and alerting system used by nextgen [my](https://github.com/NethServer/my/) monitoring
-platform.
-When Mimir is configured via ns-plug, vmalert automatically forwards alerts. No manual vmalert configuration needed.
-
-**Enable Mimir forwarding:**
-```bash
-uci set ns-plug.config.my_url='https://mimir.example.com'
-uci set ns-plug.config.my_system_key='your_api_key'
-uci set ns-plug.config.my_system_secret='your_api_secret'
-uci commit ns-plug
-/etc/init.d/vmalert restart
-```
+[my](https://github.com/NethServer/my/) uses Grafana Mimir as a multi-tenant
+alertmanager for cloud-side alert processing. Enterprise systems forward their
+alerts to it automatically, mirroring `send-heartbeat` / `send-inventory`:
+vmalert POSTs alerts to the credential-translation proxy at
+`https://my.nethesis.it/proxy/alerts` using the ns-plug credentials
+(`system_id` / `secret`), which the proxy maps to the new my credentials before
+forwarding them to the Mimir alertmanager. No manual configuration is needed —
+it is enabled whenever `ns-plug.config.type` is `enterprise` and the system is
+registered (`system_id` / `secret` set). vmalert always also notifies the local
+alert-proxy (`http://127.0.0.1:9095`), which handles the legacy path and
+unregistered machines.
 
 **Disable (alert-proxy only mode):**
 ```bash
-uci delete ns-plug.config.my_url
-uci delete ns-plug.config.my_system_key
-uci delete ns-plug.config.my_system_secret
+uci set ns-plug.config.disable_my_alerts='1'
 uci commit ns-plug
 /etc/init.d/vmalert restart
 ```
+
+> Migration note: the my switch-off release will repoint this from
+> `/proxy/alerts` to the native collect endpoint
+> (`/collect/api/services/mimir/alertmanager`) with rotated credentials.
 
 ## References
 

--- a/packages/victoria-metrics/files/vmalert.initd
+++ b/packages/victoria-metrics/files/vmalert.initd
@@ -73,5 +73,5 @@ reload_service() {
 }
 
 service_triggers() {
-    procd_add_reload_trigger vmalert
+    procd_add_reload_trigger vmalert ns-plug
 }

--- a/packages/victoria-metrics/files/vmalert.initd
+++ b/packages/victoria-metrics/files/vmalert.initd
@@ -19,17 +19,25 @@ start_service() {
     config_get datasource_url main datasource_url "http://localhost:8428"
     config_get http_listen_addr main http_listen_addr "127.0.0.1:8081"
     
-    # Check if Mimir integration is configured in ns-plug
-    local mimir_url mimir_key mimir_secret notifier_url
+    # Forward alerts to the new my.nethesis.it during the migration window,
+    # mirroring send-heartbeat / send-inventory: enterprise systems POST to the
+    # credential-translation proxy at my.nethesis.it/proxy/alerts using the
+    # ns-plug credentials (system_id:secret), which the proxy maps to the new my
+    # credentials. vmalert appends /api/v2/alerts to the notifier URL. The my
+    # switch-off release will repoint this to the native collect path.
+    local system_id system_secret system_type alerts_disabled notifier_url notifier_user notifier_pass
     config_load ns-plug 2>/dev/null && {
-        config_get mimir_url config my_url ""
-        config_get mimir_key config my_system_key ""
-        config_get mimir_secret config my_system_secret ""
+        config_get system_id config system_id ""
+        config_get system_secret config secret ""
+        config_get system_type config type ""
+        # opt-out: set ns-plug.config.disable_my_alerts=1 for alert-proxy only mode
+        config_get_bool alerts_disabled config disable_my_alerts 0
     }
-    
-    # If all Mimir credentials are present, configure alert forwarding to Mimir
-    if [ -n "$mimir_url" ] && [ -n "$mimir_key" ] && [ -n "$mimir_secret" ]; then
-        notifier_url="${mimir_url%/}/collect/api/services/mimir/alertmanager"
+
+    if [ "$system_type" = "enterprise" ] && [ -n "$system_id" ] && [ -n "$system_secret" ] && [ "$alerts_disabled" = "0" ]; then
+        notifier_url="https://my.nethesis.it/proxy/alerts"
+        notifier_user="$system_id"
+        notifier_pass="$system_secret"
     else
         notifier_url=""
     fi
@@ -46,11 +54,11 @@ start_service() {
     # Always notify the local alert-proxy (handles unregistered machines gracefully)
     procd_append_param command -notifier.url="http://127.0.0.1:9095"
 
-    # Also forward to Mimir if credentials are configured
+    # Also forward alerts to my.nethesis.it for registered enterprise systems
     if [ -n "$notifier_url" ]; then
         procd_append_param command -notifier.url="$notifier_url"
-        procd_append_param command -notifier.basicAuth.username="$mimir_key"
-        procd_append_param command -notifier.basicAuth.password="$mimir_secret"
+        procd_append_param command -notifier.basicAuth.username="$notifier_user"
+        procd_append_param command -notifier.basicAuth.password="$notifier_pass"
     fi
     
     procd_set_param stdout 1


### PR DESCRIPTION
Aligns alert forwarding with `send-heartbeat` / `send-inventory`: on enterprise
systems vmalert posts alerts to the credential-translation proxy at
`https://my.nethesis.it/proxy/alerts` using the ns-plug `system_id` / `secret`,
which the proxy maps to the new my credentials before forwarding to Mimir.
vmalert appends `/api/v2/alerts` to the notifier URL.

This replaces the `my_url` / `my_system_key` / `my_system_secret` approach added
in #1633: no new subscription fields are required, and it reuses the credentials
the proxy already translates for heartbeat/inventory/backup. The local
alert-proxy notifier is unchanged.

> The my switch-off release will repoint `/proxy/alerts` to the native collect
> endpoint (`/collect/api/services/mimir/alertmanager`) with rotated credentials.

Tested end-to-end: an enterprise system POSTing through `/proxy/alerts` →
credential translation → alert visible on qa.my.nethesis.it scoped to the system.
