### PR TITLE
fix(ovpn-rw): correct command for client certificate name extraction

### DIFF
--- a/packages/ns-openvpn/files/ns-openvpn-renew-ca
+++ b/packages/ns-openvpn/files/ns-openvpn-renew-ca
@@ -29,7 +29,7 @@ if [ -f /etc/openvpn/$instance/pki/ca.crt ]; then
         EASYRSA_REQ_CN=$cn /usr/bin/easyrsa build-server-full server nopass
         /usr/bin/easyrsa gen-crl
         for f in $(find /etc/openvpn/$instance/pki/issued -name \*.crt ! -name server.crt); do
-            name=$(basename $f | cut -d '.' -f 1)
+            name=$(basename "$f" .crt)
             /usr/bin/easyrsa revoke-issued "$name"
             /usr/bin/easyrsa build-client-full "$name" nopass
         done


### PR DESCRIPTION
This PR fixes the issue that occurs when a user tries to regenerate the entire PKI of a RoadWarrior server with one or more users whose names contain a `.` character (e.g. `mario.rossi`, `franco.verdi`).

Before the fix, during regeneration a new certificate was created using the part of the name before the first `.`. Meanwhile, the certificate to be renewed kept its original name and remained revoked (e.g. for `mario.rossi.crt`, a new valid and renewed certificate was created with the name `mario.crt`).

This fix resolves the issue by using the UNIX **basename** command and removing the **.crt** suffix.