### PR TITLE
fix(adblock): removing authentication from url allowlist

### DIFF
--- a/packages/adblock/Makefile
+++ b/packages/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.5.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/packages/adblock/files/adblock.sh
+++ b/packages/adblock/files/adblock.sh
@@ -1862,6 +1862,7 @@ f_main() {
 		#
 		src_domain="${src_url#*://}"
 		src_domain="${src_domain%%/*}"
+		src_domain="${src_domain##*@}"
 		if [ -n "${src_domain}" ] && [ "${adb_dnsallow}" = "1" ]; then
 			case " ${seen_domains} " in
 			*" ${src_domain} "*) ;;


### PR DESCRIPTION
Adblock created a feature that automatically adds to allowed domains the endpoint used as a source of the blocklists.
This, however doesn't respect the RFC 3986 since it doensn't extract the authentication session, making dnsmasq panic due to malformed domains.
