### PR TITLE
chore(monitoring): bumped tool versions

### DIFF
--- a/packages/telegraf/Makefile
+++ b/packages/telegraf/Makefile
@@ -7,15 +7,16 @@ include $(TOPDIR)/rules.mk
  
 PKG_NAME:=telegraf
 # renovate: datasource=github-tags depName=influxdata/telegraf
-PKG_VERSION:=1.38.4
+PKG_VERSION:=1.39.0
 PKG_RELEASE:=1
  
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/influxdata/telegraf.git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_SUBDIR:=telegraf-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+PKG_MIRROR_HASH:=skip
 
-PKG_HASH:=skip
 PKG_MAINTAINER:=Tommaso Bailetti <tommaso.bailetti@nethesis.it>
 PKG_LICENSE:=MIT
 

--- a/packages/victoria-logs/Makefile
+++ b/packages/victoria-logs/Makefile
@@ -7,15 +7,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=victoria-logs
 # renovate: datasource=github-tags depName=VictoriaMetrics/VictoriaLogs
-PKG_VERSION:=1.49.0
+PKG_VERSION:=1.50.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/VictoriaMetrics/VictoriaLogs/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/VictoriaMetrics/VictoriaLogs.git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_SUBDIR:=VictoriaLogs-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+PKG_MIRROR_HASH:=skip
 
-PKG_HASH:=skip
 PKG_MAINTAINER:=Tommaso Bailetti <tommaso.bailetti@nethesis.it>
 PKG_LICENSE:=Apache-2.0
 

--- a/packages/victoria-metrics/Makefile
+++ b/packages/victoria-metrics/Makefile
@@ -7,15 +7,16 @@ include $(TOPDIR)/rules.mk
  
 PKG_NAME:=victoria-metrics
 # renovate: datasource=github-tags depName=VictoriaMetrics/VictoriaMetrics
-PKG_VERSION:=1.139.0
+PKG_VERSION:=1.142.0
 PKG_RELEASE:=1
  
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/VictoriaMetrics/VictoriaMetrics/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/VictoriaMetrics/VictoriaMetrics.git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_SUBDIR:=VictoriaMetrics-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+PKG_MIRROR_HASH:=skip
 
-PKG_HASH:=skip
 PKG_MAINTAINER:=Tommaso Bailetti <tommaso.bailetti@nethesis.it>
 PKG_LICENSE:=Apache-2.0
 

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,21 @@
         "docs/**"
       ],
       "enabled": false
+    },
+    {
+      "description": "Pin telegraf to 1.39.x: minor and major version bumps require verification that they support the Go version shipped with the current OpenWrt version. Patch updates are allowed automatically.",
+      "matchDepNames": ["influxdata/telegraf"],
+      "allowedVersions": "<=1.39"
+    },
+    {
+      "description": "Pin victoria-metrics to 1.142.x: minor and major version bumps require verification that they support the Go version shipped with the current OpenWrt version. Patch updates are allowed automatically.",
+      "matchDepNames": ["VictoriaMetrics/VictoriaMetrics"],
+      "allowedVersions": "<=1.142"
+    },
+    {
+      "description": "Pin victoria-logs to 1.50.x: minor and major version bumps require verification that they support the Go version shipped with the current OpenWrt version. Patch updates are allowed automatically.",
+      "matchDepNames": ["VictoriaMetrics/VictoriaLogs"],
+      "allowedVersions": "<=1.50"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
Bumping tool versions prior to release to have latest updates possible.

Constrained renovate updates since:
- victoria logs has it's versioning all over the place since they've separated the logs from the metrics repo
- all of them might depend on a go toolchain that is not available yet on openwrt, this means renovate will create a PR that fails constantly: https://github.com/NethServer/nethsecurity/pull/1716
