### PR TITLE
fix(ns-api): preserve console keymap on upgrade

### DIFF
--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -179,6 +179,7 @@ define Package/ns-api/install
 	$(INSTALL_BIN) ./files/ns.flows $(1)/usr/libexec/rpcd/
 	$(INSTALL_DATA) ./files/ns.flows.json $(1)/usr/share/rpcd/acl.d/
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
+	$(INSTALL_CONF) files/ns-api.keep $(1)/lib/upgrade/keep.d/ns-api
 	$(INSTALL_CONF) files/msmtp.keep $(1)/lib/upgrade/keep.d/msmtp
 	$(INSTALL_CONF) files/nat-helpers.keep $(1)/lib/upgrade/keep.d/nat-helpers
 	$(LN) /usr/bin/msmtp $(1)/usr/sbin/sendmail

--- a/packages/ns-api/files/ns-api.keep
+++ b/packages/ns-api/files/ns-api.keep
@@ -1,0 +1,1 @@
+/etc/keymap


### PR DESCRIPTION
## Summary

Console keymap selection now survives sysupgrade. The `ns-api` package contributes `/etc/keymap` to keep list, preserving the setup-selected keymap across upgrades.

## Related issue

https://github.com/NethServer/nethsecurity/issues/1735

## How to test

- Inspect `packages/ns-api/files/ns-api.keep` and confirm it contains `/etc/keymap`.
- On a device/image with this package, run `cat /lib/upgrade/keep.d/ns-api` and `sysupgrade -l | grep '^/etc/keymap$'`.

## Dependencies

None.
