### PR TITLE
fix(alerting): fire alert for disk space

### DIFF
--- a/packages/ns-plug/files/ns-plug-alert-proxy
+++ b/packages/ns-plug/files/ns-plug-alert-proxy
@@ -42,6 +42,7 @@ LISTEN_ADDR = "127.0.0.1"
 LISTEN_PORT = 9095
 
 _DISK_PATH_MAP = {
+    "/overlay": "df:root:percent_bytes:free",
     "/": "df:root:percent_bytes:free",
     "/boot": "df:boot:percent_bytes:free",
 }


### PR DESCRIPTION
The alert was not firing inside the legacy my portal because the /overlay was not mapped to old alert name.