### PR TITLE
fix(ns-ui): increase ui calls timeout to 180 seconds

### DIFF
--- a/packages/ns-ui/files/00ns.locations
+++ b/packages/ns-ui/files/00ns.locations
@@ -9,4 +9,5 @@ location /api/ {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_pass http://127.0.0.1:8090/api/;
+        proxy_read_timeout 180s;
 }

--- a/packages/ns-ui/files/ns-ui
+++ b/packages/ns-ui/files/ns-ui
@@ -59,6 +59,7 @@ server {
 		proxy_set_header Host \$host;
 		proxy_set_header X-Real-IP \$remote_addr;
 		proxy_pass http://127.0.0.1:8090/api/;
+		proxy_read_timeout 180s;
 	}
 }
 EOF


### PR DESCRIPTION
This PR updates the nginx timeout for UI call from 60 seconds (nginx default) to 180 seconds.