### PR TITLE
feat(rsyslog): allow arbitrary selection of the listening ip

### DIFF
--- a/packages/ns-storage/files/30_ns-storage
+++ b/packages/ns-storage/files/30_ns-storage
@@ -5,9 +5,11 @@
 uci -q import rsyslog << EOI
 config syslog 'syslog'
 	option tcp_input_port '514'
+	option tcp_input_address '127.0.0.1'
 	option udp_input '1'
 	option tcp_input '0'
 	option udp_input_port '514'
+	option udp_input_address '127.0.0.1'
 	option default_template 'RSYSLOG_TraditionalFileFormat'
 	list modules 'imuxsock'
 	list modules 'imklog'

--- a/packages/rsyslog/files/20_rsyslog
+++ b/packages/rsyslog/files/20_rsyslog
@@ -6,9 +6,11 @@ grep -qv -e '^\s*#' -e '^\s*$' /etc/rsyslog.conf 2>/dev/null && exit 0
 uci -q import rsyslog << EOI
 config syslog 'syslog'
 	option tcp_input_port '514'
+	option tcp_input_address '127.0.0.1'
 	option udp_input '1'
 	option tcp_input '0'
 	option udp_input_port '514'
+	option udp_input_address '127.0.0.1'
 	option default_template 'RSYSLOG_TraditionalFileFormat'
 	list modules 'imuxsock'
 	list modules 'imklog'

--- a/packages/rsyslog/files/rsyslog.init
+++ b/packages/rsyslog/files/rsyslog.init
@@ -73,14 +73,16 @@ expand_config() {
 	if [ "${tcp_input}" -eq 1 ]; then
 		modules="${modules} imtcp"
 		config_get tcp_port syslog tcp_input_port
-		input_t="input(type=\"imtcp\" port=\"${tcp_port}\")"
+		config_get tcp_addr syslog tcp_input_address "127.0.0.1"
+		input_t="input(type=\"imtcp\" port=\"${tcp_port}\" address=\"${tcp_addr}\")"
 	fi
 
 	config_get_bool udp_input syslog udp_input
 	if [ "${udp_input}" -eq 1 ]; then
 		modules="${modules} imudp"
 		config_get udp_port syslog udp_input_port
-		input_u="input(type=\"imudp\" port=\"${udp_port}\")"
+		config_get udp_addr syslog udp_input_address "127.0.0.1"
+		input_u="input(type=\"imudp\" port=\"${udp_port}\" address=\"${udp_addr}\")"
 
 	fi
 	config_get template syslog default_template


### PR DESCRIPTION
Locks up rsyslog access, with optional uci prop to open it.


related docs: https://github.com/NethServer/nethsecurity-docs/pull/284

 