### PR TITLE
fix: adjusting banIP just to look into specific log files

### DIFF
--- a/packages/ns-threat_shield/Makefile
+++ b/packages/ns-threat_shield/Makefile
@@ -22,7 +22,7 @@ define Package/ns-threat_shield
 	CATEGORY:=NethSecurity
 	TITLE:=Threat shield block list
 	URL:=https://github.com/NethServer/nethsecurity/
-	DEPENDS:=+wget-ssl +adblock +jq +ns-api
+	DEPENDS:=+wget-ssl +adblock +jq +ns-api +rsyslog
 	EXTRA_DEPENDS:=adblock (>=4.5.3), ns-api (>=3.6.2)
 	PKGARCH:=all
 endef
@@ -58,6 +58,9 @@ define Package/ns-threat_shield/install
 	$(INSTALL_BIN) ./files/configure-banip-wans.py $(1)/usr/libexec/ns-api/pre-commit/
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/banip-defaults $(1)/etc/uci-defaults/99-nethsec-banip
+	$(INSTALL_BIN) ./files/35_ns-threat_shield $(1)/etc/uci-defaults/35_ns-threat_shield
+	$(INSTALL_DIR) $(1)/etc/rsyslog.d
+	$(INSTALL_CONF) ./files/rsyslog-banip.conf $(1)/etc/rsyslog.d/banip-services.conf
 	gzip -9n $(1)/usr/share/threat_shield/nethesis-dns.sources
 	gzip -9n $(1)/usr/share/threat_shield/community-dns.sources
 endef
@@ -67,6 +70,7 @@ define Package/ns-threat_shield/postinst
 if [ -z "$${IPKG_INSTROOT}" ]; then
   (. /etc/uci-defaults/20_threat_shield)
   rm -f /etc/uci-defaults/20_threat_shield
+  /etc/init.d/rsyslog restart
   /etc/init.d/cron restart
 fi
 exit 0

--- a/packages/ns-threat_shield/files/35_ns-threat_shield
+++ b/packages/ns-threat_shield/files/35_ns-threat_shield
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+RSYSLOG_CONF="/etc/rsyslog.d/banip-services.conf"
+
+if ! uci -q get rsyslog.syslog.includes | grep -qF "${RSYSLOG_CONF}"; then
+    uci add_list rsyslog.syslog.includes="${RSYSLOG_CONF}"
+    uci commit rsyslog
+fi
+
+uci -q set banip.global.ban_logreadfile="/var/log/banip.log"
+uci commit banip

--- a/packages/ns-threat_shield/files/banip-defaults
+++ b/packages/ns-threat_shield/files/banip-defaults
@@ -6,6 +6,7 @@ set banip.global.ban_logforwardlan="1"
 set banip.global.ban_logprerouting="0"
 set banip.global.ban_loginput="0"
 
+set banip.global.ban_logreadfile="/var/log/banip.log"
 set banip.global.ban_loglimit="100"
 set banip.global.ban_logcount="3"
 set banip.global.ban_nftexpiry="30m"

--- a/packages/ns-threat_shield/files/rsyslog-banip.conf
+++ b/packages/ns-threat_shield/files/rsyslog-banip.conf
@@ -1,0 +1,7 @@
+# Write banIP-relevant service logs to a dedicated file.
+# /var/log/ is tmpfs on OpenWrt/NethSecurity — auto-cleared on reboot.
+if ($programname == "dropbear"
+    or $programname startswith "openvpn"
+    or $programname == "nethsecurity-api") then {
+    action(type="omfile" file="/var/log/banip.log")
+}


### PR DESCRIPTION
Making so that banIP reads only specific logs.

We create a custom log for it using rsyslog and make so that banIP looks just at that file and not all of them.
