### PR TITLE
fix(api-server): add trusted proxies (#22)

### DIFF
--- a/packages/ns-api-server/files/src/main.go
+++ b/packages/ns-api-server/files/src/main.go
@@ -59,6 +59,9 @@ func main() {
 	// add default compression
 	router.Use(gzip.Gzip(gzip.DefaultCompression))
 
+	// accept headers only from localhost
+	router.SetTrustedProxies([]string{"127.0.0.1", "::1"})
+
 	// cors configuration only in debug mode GIN_MODE=debug (default)
 	if gin.Mode() == gin.DebugMode {
 		// gin gonic cors conf


### PR DESCRIPTION
Accept trusted proxies only for localhost.
Avoid polluting headers if the API server
is behind another proxy.