### PR TITLE
fix(ns-ha): move HA rsync staging to tmpfs, sync every 10 minutes

### DIFF
--- a/packages/keepalived/Makefile
+++ b/packages/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.3.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
@@ -334,7 +334,7 @@ endef
 
 USER=keepalived
 USER_ID=60001
-USER_HOME=/usr/share/keepalived/rsync
+USER_HOME=/tmp/ha
 SUDO_DIR=/etc/sudoers.d
 SUDO_FILE=$(SUDO_DIR)/$(USER)
 KEYS_DIR=/etc/keepalived/keys
@@ -358,10 +358,6 @@ fi
 if ! grep -q "^$(USER):" /etc/passwd; then
 	user_add "$(USER)" "$(USER_ID)" "$(USER_ID)" "$(USER)" "$(USER_HOME)" "/bin/ash"
 fi
-
-mkdir -m 700 -p "$(USER_HOME)"
-mkdir -m 700 -p "$(USER_HOME)/.ssh"
-chown "$(USER)":"$(USER)" "$(USER_HOME)" -R
 
 [ ! -d "$(SUDO_DIR)" ] && mkdir "$(SUDO_DIR)"
 echo "$(USER) ALL= NOPASSWD:/usr/bin/rsync" > "$(SUDO_FILE)"

--- a/packages/keepalived/files/etc/hotplug.d/keepalived/02-rsync
+++ b/packages/keepalived/files/etc/hotplug.d/keepalived/02-rsync
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Sync selected entries from /usr/share/keepalived/rsync to root paths.
+# Sync selected entries from /tmp/ns-ha to root paths.
 #
 # Behavior:
 # - Reads a list of paths (one per line) from /tmp/restore_list.
@@ -9,15 +9,15 @@
 #   paths are treated as root-relative.
 # - Paths containing '..' are rejected to avoid directory traversal.
 # - If an entry refers to a directory: rsync -avr --delete
-#   /usr/share/keepalived/rsync/<dir>/ /<dir>/
+#   /tmp/ns-ha/<dir>/ /<dir>/
 # - If an entry refers to a regular file: rsync -avr
-#   /usr/share/keepalived/rsync/<file> /<file>
+#   /tmp/ns-ha/<file> /<file>
 # - If a listed entry does not exist in the source dir, a warning is logged
 #   and the entry is skipped.
 
 . /lib/functions/keepalived/common.sh
 
-SRC_DIR="/usr/share/keepalived/rsync"
+SRC_DIR="/tmp/ns-ha"
 RESTORE_LIST="$SRC_DIR/tmp/restore_list"
 
 # Do not execute on backup/master switch

--- a/packages/ns-api/Makefile
+++ b/packages/ns-api/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-api
 PKG_VERSION:=3.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-api-$(PKG_VERSION)
 

--- a/packages/ns-api/files/ns.ha
+++ b/packages/ns-api/files/ns.ha
@@ -488,7 +488,7 @@ def init_local(role, primary_node_ip, backup_node_ip, virtual_ip, lan_interface,
     u.set('keepalived', 'ha_sync', 'vrrp_script')
     u.set('keepalived', 'ha_sync', 'name', 'ha_sync')
     u.set('keepalived', 'ha_sync', 'script', '/usr/libexec/ns-rsync.sh')
-    u.set('keepalived', 'ha_sync', 'interval', '60')
+    u.set('keepalived', 'ha_sync', 'interval', '600')
     u.set('keepalived', 'ha_sync', 'weight', '100')
 
     u.set('keepalived', 'lan_track', 'track_interface')
@@ -513,7 +513,7 @@ def init_local(role, primary_node_ip, backup_node_ip, virtual_ip, lan_interface,
         u.set('keepalived', 'ha_peer', 'address', backup_node_ip)
         u.set('keepalived', 'ha_peer', 'sync', '1')
         u.set('keepalived', 'ha_peer', 'sync_mode', 'send')
-        u.set('keepalived', 'ha_peer', 'sync_dir', '/usr/share/keepalived/rsync')
+        u.set('keepalived', 'ha_peer', 'sync_dir', '/tmp/ns-ha')
         u.set('keepalived', 'ha_peer', 'ssh_port', '65022')
         u.set('keepalived', 'ha_peer', 'ssh_key', '/etc/keepalived/keys/id_rsa')
         u.set('keepalived', 'ha_peer', 'exclude_list', exclude_list)
@@ -563,7 +563,7 @@ def init_local(role, primary_node_ip, backup_node_ip, virtual_ip, lan_interface,
         u.set('keepalived', 'ha_peer', 'address', primary_node_ip)
         u.set('keepalived', 'ha_peer', 'sync', '1')
         u.set('keepalived', 'ha_peer', 'sync_mode', 'receive')
-        u.set('keepalived', 'ha_peer', 'sync_dir', '/usr/share/keepalived/rsync')
+        u.set('keepalived', 'ha_peer', 'sync_dir', '/tmp/ns-ha')
         u.set('keepalived', 'ha_peer', 'ssh_pubkey', pubkey)
   
         u.set('keepalived', 'backup', 'vrrp_instance')
@@ -587,7 +587,7 @@ def init_local(role, primary_node_ip, backup_node_ip, virtual_ip, lan_interface,
             file.write(pubkey + '\n')
 
         # Create the rsync directory if it doesn't exist
-        rsync_dir = '/usr/share/keepalived/rsync/etc/'
+        rsync_dir = '/tmp/ns-ha/etc/'
         os.makedirs(rsync_dir, exist_ok=True)
         # Change permissions of the rsync directory
         os.chmod(rsync_dir, 0o2775)
@@ -1039,9 +1039,10 @@ def reset(role, pubkey = ""):
     subprocess.run(['/etc/init.d/conntrackd', 'stop'], capture_output=True)
     subprocess.run(['/etc/init.d/conntrackd', 'disable'], capture_output=True)
 
-    # Remove files and directories
+    # Remove files and directories, including the legacy staging dir
+    shutil.rmtree('/tmp/ns-ha', ignore_errors=True)
+    shutil.rmtree('/usr/share/keepalived/rsync', ignore_errors=True)
     try:
-        shutil.rmtree('/usr/share/keepalived/rsync')
         os.remove('/etc/conntrackd/conntrackd.conf')
     except:
         pass

--- a/packages/ns-ha/Makefile
+++ b/packages/ns-ha/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-ha
-PKG_VERSION:=0.0.6
+PKG_VERSION:=0.0.7
 PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-ha-$(PKG_VERSION)
@@ -79,6 +79,7 @@ define Package/ns-ha/install
 	$(INSTALL_DATA) ./files/800-dedalo $(1)/etc/hotplug.d/keepalived
 	$(INSTALL_DATA) ./files/900-ns-plug $(1)/etc/hotplug.d/keepalived
 	$(INSTALL_DATA) ./files/900-phonehome $(1)/etc/hotplug.d/keepalived
+	$(INSTALL_DATA) ./files/900-telegraf $(1)/etc/hotplug.d/keepalived
 	$(INSTALL_DATA) ./files/900-msmtp $(1)/etc/hotplug.d/keepalived
 	$(INSTALL_DATA) ./files/900-snmpd $(1)/etc/hotplug.d/keepalived
 	$(INSTALL_DATA) ./files/900-ddns $(1)/etc/hotplug.d/keepalived

--- a/packages/ns-ha/Makefile
+++ b/packages/ns-ha/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
  
 PKG_NAME:=ns-ha
-PKG_VERSION:=0.0.5
+PKG_VERSION:=0.0.6
 PKG_RELEASE:=1
  
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-ha-$(PKG_VERSION)
@@ -29,6 +29,16 @@ define Package/ns-ha/description
 	Support High Availability configuration for NethSecurity
 endef
 
+define Package/ns-ha/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+  if [ "$$(uci -q get keepalived.globals.enabled)" = "1" ]; then
+    /etc/init.d/keepalived reload
+  fi
+fi
+exit 0
+endef
+
 # this is required, otherwise compile will fail
 define Build/Compile
 endef
@@ -41,6 +51,7 @@ define Package/ns-ha/install
 	$(INSTALL_DIR) $(1)/usr/libexec
 	$(INSTALL_DIR) $(1)/etc/keepalived/scripts/
 	$(INSTALL_DIR) $(1)/etc/profile.d/
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/ns-ha-disable $(1)/usr/libexec/
 	$(INSTALL_BIN) ./files/ns-ha-enable $(1)/usr/libexec/
 	$(INSTALL_BIN) ./files/ns-ha-export $(1)/usr/libexec/
@@ -78,6 +89,7 @@ define Package/ns-ha/install
 	$(INSTALL_DATA) ./files/99-ns-ha.sh $(1)/etc/profile.d
 	$(INSTALL_BIN) ./files/conntrackd.sh $(1)/usr/libexec/
 	$(INSTALL_BIN) ./files/ns-rsync.sh $(1)/usr/libexec/
+	$(INSTALL_BIN) ./files/99-ns-ha-tmpfs $(1)/etc/uci-defaults
 endef
 
 $(eval $(call BuildPackage,ns-ha))

--- a/packages/ns-ha/README.md
+++ b/packages/ns-ha/README.md
@@ -430,7 +430,7 @@ Apr 23 09:48:49 NethSec dropbear[8098]: Pubkey auth succeeded for 'root' with ss
 Apr 23 09:48:49 NethSec dropbear[8098]: Exit (root) from <192.168.100.238:37350>: Exited normally
 Apr 23 09:48:49 NethSec dropbear[8100]: Child connection from 192.168.100.238:37356
 Apr 23 09:48:49 NethSec dropbear[8100]: Pubkey auth succeeded for 'root' with ssh-rsa key SHA256:LDIBFC6gFHmIAUqdEWVi62ca/EUxZI7/08m2d76/hcQ from 192.168.100.238:37356
-Apr 23 09:48:49 NethSec sudo:     root : PWD=/root ; USER=root ; COMMAND=/usr/bin/rsync --server -nlogDtprRe.iLfxCIvu --log-format=X . /usr/share/keepalived/rsync
+Apr 23 09:48:49 NethSec sudo:     root : PWD=/root ; USER=root ; COMMAND=/usr/bin/rsync --server -nlogDtprRe.iLfxCIvu --log-format=X . /tmp/ns-ha
 Apr 23 09:48:49 NethSec dropbear[8100]: Exit (root) from <192.168.100.238:37356>: Exited normally
 ```
 
@@ -562,14 +562,14 @@ The primary node runs a specialized rsync script (`/etc/keepalived/scripts/ns-rs
   - Custom files added via the `keepalived.ha_peer.sync_list` UCI option
   - Excludes files listed in the `keepalived.ha_peer.exclude_list` UCI option
   The list is saved inside the file `/tmp/restore_list`
-- Copies files to the backup node's staging area at `/usr/share/keepalived/rsync/`
+- Copies files to the backup node's staging area at `/tmp/ns-ha/` (tmpfs, emptied at reboot)
 - Triggers a hotplug event on the backup node to notify that synchronization is complete
 
 #### Restore phase (hotplug): on the backup node
 
 The backup node doesn't automatically apply all transferred files. Instead, it uses a hotplug event fired
 by the primary node at the end of the rsync process.
-All files and directories inside `/usr/share/keepalived/rsync/tmp/restore_list` are copied to the original locations using `rsync`. For directories, `rsync` is invoked with `--delete` option to ensure exact mirroring.
+All files and directories inside `/tmp/ns-ha/tmp/restore_list` are copied to the original locations using `rsync`. For directories, `rsync` is invoked with `--delete` option to ensure exact mirroring.
 
 #### Adding new files to synchronization
 

--- a/packages/ns-ha/files/900-ns-plug
+++ b/packages/ns-ha/files/900-ns-plug
@@ -9,7 +9,7 @@ set_service_name ns-plug
 set_restart_if_master
 set_stop_if_backup
 
-RESTORE_LIST="/usr/share/keepalived/rsync/tmp/restore_list"
+RESTORE_LIST="/tmp/ns-ha/tmp/restore_list"
 
 if [ "$ACTION" == "NOTIFY_BACKUP" ]; then
     update_cron "disable" "send-heartbeat send-backup send-inventory" "ns-push-reports"
@@ -17,7 +17,7 @@ elif [ "$ACTION" == "NOTIFY_MASTER" ]; then
     update_cron "enable" "send-heartbeat send-backup send-inventory" "ns-push-reports"
 elif [ "$ACTION" == "NOTIFY_SYNC" ]; then
     # Remove backup.pass if it has been unset on the primary
-    if ! grep -q /etc/backup.pass /usr/share/keepalived/rsync/tmp/restore_list && [ -f /etc/backup.pass ]; then
+    if ! grep -q /etc/backup.pass "$RESTORE_LIST" && [ -f /etc/backup.pass ]; then
         rm -f /etc/backup.pass
     fi
 fi

--- a/packages/ns-ha/files/900-telegraf
+++ b/packages/ns-ha/files/900-telegraf
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# The backup node has no Internet access and dnsmasq refuses external queries,
+# so telegraf's internet ping/dns_query inputs flood the log with errors.
+# Disable those inputs while in backup state and re-enable them on master.
+# The drop-in files are moved aside (not deleted) so the config is preserved;
+# UCI is left untouched. telegraf runs with --watch-config and reloads itself.
+# shellcheck source=/dev/null
+. /lib/functions/keepalived/hotplug.sh
+
+set_service_name telegraf
+
+DROPINS="/etc/telegraf.conf.d/ping.conf /etc/telegraf.conf.d/dns.conf"
+
+toggle_internet_inputs() {
+    local action="$1"
+    local f
+    for f in $DROPINS; do
+        if [ "$action" = "disable" ]; then
+            [ -f "$f" ] && mv "$f" "$f.disabled"
+        elif [ "$action" = "enable" ]; then
+            [ -f "$f.disabled" ] && mv "$f.disabled" "$f"
+        fi
+    done
+}
+
+if [ "$ACTION" == "NOTIFY_BACKUP" ]; then
+    toggle_internet_inputs disable
+elif [ "$ACTION" == "NOTIFY_MASTER" ]; then
+    toggle_internet_inputs enable
+fi
+
+keepalived_hotplug

--- a/packages/ns-ha/files/99-ns-ha-tmpfs
+++ b/packages/ns-ha/files/99-ns-ha-tmpfs
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Migrate HA sync staging dir to tmpfs and slow down sync interval
+# https://github.com/NethServer/nethsecurity/issues/1771
+
+if [ "$(uci -q get keepalived.ha_sync.interval)" = "60" ]; then
+    uci set keepalived.ha_sync.interval=600
+fi
+
+if [ "$(uci -q get keepalived.ha_peer.sync_dir)" = "/usr/share/keepalived/rsync" ]; then
+    uci set keepalived.ha_peer.sync_dir=/tmp/ns-ha
+fi
+
+uci commit keepalived
+
+# Drop the legacy staging area from persistent storage
+rm -rf /usr/share/keepalived/rsync
+
+exit 0

--- a/packages/ns-ha/files/ns-rsync.sh
+++ b/packages/ns-ha/files/ns-rsync.sh
@@ -10,7 +10,7 @@
 . /lib/functions/keepalived/ns.sh
 
 RSYNC_USER="root"
-RSYNC_HOME="/usr/share/keepalived/rsync"
+RSYNC_HOME="/tmp/ns-ha"
 
 utc_timestamp() {
 	date -u +%s
@@ -93,7 +93,7 @@ ha_sync_send() {
 	ssh_remote="$RSYNC_USER@$address"
 
 	# shellcheck disable=SC2086
-	timeout 10 ssh $ssh_options $ssh_remote mkdir -m 755 -p "/tmp" || {
+	timeout 10 ssh $ssh_options $ssh_remote mkdir -m 755 -p "$sync_dir" || {
 		log_err "Can not connect to $address. check key or connection"
 		update_last_sync_time "$cfg"
 		update_last_sync_status "$cfg" "SSH Connection Failed"


### PR DESCRIPTION
Fixes #1771

Prevents HA config corruption (null bytes) on failover, and stops the telegraf log flood on the backup node.

## 1. HA rsync staging on tmpfs

- Move rsync staging dir from `/usr/share/keepalived/rsync` (overlayfs) to `/tmp/ns-ha` (tmpfs)
- Reduce sync interval 60s → 600s
- Fix sender `mkdir` so tmpfs staging dir is recreated each run (survives reboot)
- uci-defaults migration for existing installs (both nodes)

## 2. Disable telegraf internet inputs on the HA backup node

The backup node has no Internet access and dnsmasq answers only locally, so telegraf's `inputs.ping` and `inputs.dns_query` flood `/var/log/messages` with `network is unreachable` / DNS `REFUSED` errors.

- New keepalived hotplug `900-telegraf`: on `NOTIFY_BACKUP` move the generated `ping.conf`/`dns.conf` drop-ins aside; on `NOTIFY_MASTER` restore them
- UCI config untouched (nothing lost); master keeps internet monitoring

## Testing

Tested on a live 2-node cluster (primary `192.168.100.238`, backup `192.168.100.239`, VIP `192.168.100.240`), configured via `ns-ha-config` per the ns-ha README.

**tmpfs staging (#1)**
- [x] Config applied: `interval=600`, `sync_dir=/tmp/ns-ha`, `keepalived.conf` vrrp `interval 600` on both nodes; no legacy `/usr/share/keepalived/rsync`
- [x] Sync `Successful`, staging lands in `/tmp/ns-ha` (159 files); dir is on **tmpfs**, staged configs have **zero null bytes**
- [x] NOTIFY_SYNC restore copies staged files to real paths (verified with a custom `sync_list` marker)
- [x] Failover both directions (VIP + master move to backup and back)
- [x] **Reboot backup → `/tmp/ns-ha` wiped by tmpfs → next sync recreates it** (validates the `mkdir "$sync_dir"` fix)

**telegraf inputs on backup (#2)**
- [x] `NOTIFY_BACKUP` → `ping.conf`/`dns.conf` become `*.disabled`; telegraf reloads without those inputs
- [x] Causal check: with inputs enabled the ping/dns errors reappear within seconds; after disable, **zero** new errors
- [x] `NOTIFY_MASTER` restores the active drop-ins
- [x] Real failover: backup→master re-enables inputs, master→backup disables them; primary keeps inputs active throughout
