### PR TITLE
fix(ns-checkmk-utils): sync checkmk-tools v1.7.3 downloads

### DIFF
--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -24,7 +24,7 @@ define Download/check_apk_packages
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_apk_packages.py
 	FILE:=check_apk_packages-$(PKG_VERSION).py
-	HASH:=c6c62cb53d0dc3d909dd4d0c9003dd362f06c9eb0dfaabc3c2f70ac5c15f0cf
+	HASH:=c85fc116edb1e75f59c0596a3e93913cc3cb2fdc30308a5c060c3f5c648bd26b
 endef
 $(eval $(call Download,check_apk_packages))
 
@@ -32,7 +32,7 @@ define Download/check_dhcp_leases
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dhcp_leases.py
 	FILE:=check_dhcp_leases-$(PKG_VERSION).py
-	HASH:=a26fece5b788faf3ee2531b8fd7ef149e8937056cdd28f9d11a79e7a79ce975d
+	HASH:=42dbbd3ad2d9e45f97d9f383afaeae85dcf761ba18a13a7b42fa7f1b2c011b96
 endef
 $(eval $(call Download,check_dhcp_leases))
 
@@ -40,7 +40,7 @@ define Download/check_dns_resolution
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dns_resolution.py
 	FILE:=check_dns_resolution-$(PKG_VERSION).py
-	HASH:=7f3e41ee03eb68e49fdabc495e21462df39c1ae839de62a4a20b8cf8cd3c9d82
+	HASH:=a2f1309d70a142d41a0e9fd3c47ffd7aba52727fd68ec33e1f60311a944792e5
 endef
 $(eval $(call Download,check_dns_resolution))
 
@@ -48,7 +48,7 @@ define Download/check_firewall_connections
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_connections.py
 	FILE:=check_firewall_connections-$(PKG_VERSION).py
-	HASH:=0e916e816843baa6e3b0f14790e40fef6a17d51efeb6c45cfb1f5e965c0f4551
+	HASH:=68e259d3f9649c4c3447b97539d6d474e494e391d3f73b1fffd8a99b184e2eca
 endef
 $(eval $(call Download,check_firewall_connections))
 
@@ -56,7 +56,7 @@ define Download/check_firewall_rules
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_rules.py
 	FILE:=check_firewall_rules-$(PKG_VERSION).py
-	HASH:=238311e66223380fa22cf0360cef631ce65217e25be8c8da2fbf6c8effc22b90
+	HASH:=92e99de0482407a323c692750d265491aa0c62fe37589845cc8ff8cd5f59ddc8
 endef
 $(eval $(call Download,check_firewall_rules))
 
@@ -64,7 +64,7 @@ define Download/check_firewall_traffic
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_traffic.py
 	FILE:=check_firewall_traffic-$(PKG_VERSION).py
-	HASH:=fbb32b89c93dadc1a8a09ca8fee457268f3378b27cc92e7a88b1a01db62bba1e
+	HASH:=8ea2f633b359652496b176b40727bece6726b0be5c5aac08cc6e613f48596295
 endef
 $(eval $(call Download,check_firewall_traffic))
 
@@ -72,7 +72,7 @@ define Download/check_ovpn_host2net
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_ovpn_host2net.py
 	FILE:=check_ovpn_host2net-$(PKG_VERSION).py
-	HASH:=32094f9732ae75f630ad9f75efbc914d9e8d8a87bb10e9a4adbbee32e3c76b03
+	HASH:=3680793726763ff7bd71d1a298d36dadb67be7b6c91831589ae86a70c6a19a94
 endef
 $(eval $(call Download,check_ovpn_host2net))
 
@@ -80,7 +80,7 @@ define Download/check_root_access
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_root_access.py
 	FILE:=check_root_access-$(PKG_VERSION).py
-	HASH:=305fe9ba1bfe4efa50348a3183fbd0666f9bb924c0b6ec08cee30fedd8e79e85
+	HASH:=84806b5dabb6985674caca02153fd022f996948bab20639b27553950cc350f2f
 endef
 $(eval $(call Download,check_root_access))
 
@@ -88,7 +88,7 @@ define Download/check_uptime
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_uptime.py
 	FILE:=check_uptime-$(PKG_VERSION).py
-	HASH:=51995951c2592153d55a6bf5aeb58d76c394dfe3c76c27a1b0c4d32d6e5e2c0c
+	HASH:=388a9a51887248df4248bb604da8059bc746f32732bba9cf8e232292f878cd28
 endef
 $(eval $(call Download,check_uptime))
 
@@ -96,7 +96,7 @@ define Download/check_vpn_tunnels
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_vpn_tunnels.py
 	FILE:=check_vpn_tunnels-$(PKG_VERSION).py
-	HASH:=8a12d756d7fee87429cd1846359be6a43c2feb57f32c76b9e4c1a6b3e8b5c7f2
+	HASH:=82a4701f041512840d88d54802295537ae6ab73cfbc07a990866684886e00d49
 endef
 $(eval $(call Download,check_vpn_tunnels))
 
@@ -104,7 +104,7 @@ define Download/check_wan_status
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_status.py
 	FILE:=check_wan_status-$(PKG_VERSION).py
-	HASH:=d10f72f902dc58ea9db983a7e50c2a38e2cc0ef72c9bf0a08c5e7b7d6e5f4a3c
+	HASH:=e245549eda4df50703cf98f10ef1f42dfeff3befd4d1a922cc17218521f0f69c
 endef
 $(eval $(call Download,check_wan_status))
 
@@ -112,7 +112,7 @@ define Download/check_wan_throughput
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_throughput.py
 	FILE:=check_wan_throughput-$(PKG_VERSION).py
-	HASH:=6ba86bd3a4c3473ed8055744e47d978f8e31e6aff5c8b7a9e1d0c3b2f5a8d1e
+	HASH:=73326e5b3109e1f008c6f07e6497ec69f1d2886dd89e357b7b51096cc6e8958b
 endef
 $(eval $(call Download,check_wan_throughput))
 

--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ns-checkmk-utils
 # renovate: datasource=github-tags depName=nethesis/checkmk-tools
-PKG_VERSION:=0.0.5
+PKG_VERSION:=1.7.1
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-checkmk-utils-$(PKG_VERSION)

--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -23,7 +23,7 @@ include $(INCLUDE_DIR)/package.mk
 define Download/check_apk_packages
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_apk_packages.py
-	FILE:=check_apk_packages.py
+	FILE:=check_apk_packages-$(PKG_VERSION).py
 	HASH:=c6c62cb53d0dc3d909dd4d0c9003dd362f06c9eb0dfaabc3c2f70ac5c15f0cf
 endef
 $(eval $(call Download,check_apk_packages))
@@ -31,7 +31,7 @@ $(eval $(call Download,check_apk_packages))
 define Download/check_dhcp_leases
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dhcp_leases.py
-	FILE:=check_dhcp_leases.py
+	FILE:=check_dhcp_leases-$(PKG_VERSION).py
 	HASH:=a26fece5b788faf3ee2531b8fd7ef149e8937056cdd28f9d11a79e7a79ce975d
 endef
 $(eval $(call Download,check_dhcp_leases))
@@ -39,7 +39,7 @@ $(eval $(call Download,check_dhcp_leases))
 define Download/check_dns_resolution
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dns_resolution.py
-	FILE:=check_dns_resolution.py
+	FILE:=check_dns_resolution-$(PKG_VERSION).py
 	HASH:=7f3e41ee03eb68e49fdabc495e21462df39c1ae839de62a4a20b8cf8cd3c9d82
 endef
 $(eval $(call Download,check_dns_resolution))
@@ -47,7 +47,7 @@ $(eval $(call Download,check_dns_resolution))
 define Download/check_firewall_connections
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_connections.py
-	FILE:=check_firewall_connections.py
+	FILE:=check_firewall_connections-$(PKG_VERSION).py
 	HASH:=0e916e816843baa6e3b0f14790e40fef6a17d51efeb6c45cfb1f5e965c0f4551
 endef
 $(eval $(call Download,check_firewall_connections))
@@ -55,7 +55,7 @@ $(eval $(call Download,check_firewall_connections))
 define Download/check_firewall_rules
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_rules.py
-	FILE:=check_firewall_rules.py
+	FILE:=check_firewall_rules-$(PKG_VERSION).py
 	HASH:=238311e66223380fa22cf0360cef631ce65217e25be8c8da2fbf6c8effc22b90
 endef
 $(eval $(call Download,check_firewall_rules))
@@ -63,7 +63,7 @@ $(eval $(call Download,check_firewall_rules))
 define Download/check_firewall_traffic
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_traffic.py
-	FILE:=check_firewall_traffic.py
+	FILE:=check_firewall_traffic-$(PKG_VERSION).py
 	HASH:=fbb32b89c93dadc1a8a09ca8fee457268f3378b27cc92e7a88b1a01db62bba1e
 endef
 $(eval $(call Download,check_firewall_traffic))
@@ -71,7 +71,7 @@ $(eval $(call Download,check_firewall_traffic))
 define Download/check_ovpn_host2net
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_ovpn_host2net.py
-	FILE:=check_ovpn_host2net.py
+	FILE:=check_ovpn_host2net-$(PKG_VERSION).py
 	HASH:=32094f9732ae75f630ad9f75efbc914d9e8d8a87bb10e9a4adbbee32e3c76b03
 endef
 $(eval $(call Download,check_ovpn_host2net))
@@ -79,7 +79,7 @@ $(eval $(call Download,check_ovpn_host2net))
 define Download/check_root_access
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_root_access.py
-	FILE:=check_root_access.py
+	FILE:=check_root_access-$(PKG_VERSION).py
 	HASH:=305fe9ba1bfe4efa50348a3183fbd0666f9bb924c0b6ec08cee30fedd8e79e85
 endef
 $(eval $(call Download,check_root_access))
@@ -87,7 +87,7 @@ $(eval $(call Download,check_root_access))
 define Download/check_uptime
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_uptime.py
-	FILE:=check_uptime.py
+	FILE:=check_uptime-$(PKG_VERSION).py
 	HASH:=51995951c2592153d55a6bf5aeb58d76c394dfe3c76c27a1b0c4d32d6e5e2c0c
 endef
 $(eval $(call Download,check_uptime))
@@ -95,7 +95,7 @@ $(eval $(call Download,check_uptime))
 define Download/check_vpn_tunnels
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_vpn_tunnels.py
-	FILE:=check_vpn_tunnels.py
+	FILE:=check_vpn_tunnels-$(PKG_VERSION).py
 	HASH:=8a12d756d7fee87429cd1846359be6a43c2feb57f32c76b9e4c1a6b3e8b5c7f2
 endef
 $(eval $(call Download,check_vpn_tunnels))
@@ -103,7 +103,7 @@ $(eval $(call Download,check_vpn_tunnels))
 define Download/check_wan_status
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_status.py
-	FILE:=check_wan_status.py
+	FILE:=check_wan_status-$(PKG_VERSION).py
 	HASH:=d10f72f902dc58ea9db983a7e50c2a38e2cc0ef72c9bf0a08c5e7b7d6e5f4a3c
 endef
 $(eval $(call Download,check_wan_status))
@@ -111,7 +111,7 @@ $(eval $(call Download,check_wan_status))
 define Download/check_wan_throughput
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_throughput.py
-	FILE:=check_wan_throughput.py
+	FILE:=check_wan_throughput-$(PKG_VERSION).py
 	HASH:=6ba86bd3a4c3473ed8055744e47d978f8e31e6aff5c8b7a9e1d0c3b2f5a8d1e
 endef
 $(eval $(call Download,check_wan_throughput))
@@ -133,18 +133,18 @@ endef
 
 define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
-	$(CP) $(DL_DIR)/check_apk_packages.py $(PKG_BUILD_DIR)/check_apk_packages.py
-	$(CP) $(DL_DIR)/check_dhcp_leases.py $(PKG_BUILD_DIR)/check_dhcp_leases.py
-	$(CP) $(DL_DIR)/check_dns_resolution.py $(PKG_BUILD_DIR)/check_dns_resolution.py
-	$(CP) $(DL_DIR)/check_firewall_connections.py $(PKG_BUILD_DIR)/check_firewall_connections.py
-	$(CP) $(DL_DIR)/check_firewall_rules.py $(PKG_BUILD_DIR)/check_firewall_rules.py
-	$(CP) $(DL_DIR)/check_firewall_traffic.py $(PKG_BUILD_DIR)/check_firewall_traffic.py
-	$(CP) $(DL_DIR)/check_ovpn_host2net.py $(PKG_BUILD_DIR)/check_ovpn_host2net.py
-	$(CP) $(DL_DIR)/check_root_access.py $(PKG_BUILD_DIR)/check_root_access.py
-	$(CP) $(DL_DIR)/check_uptime.py $(PKG_BUILD_DIR)/check_uptime.py
-	$(CP) $(DL_DIR)/check_vpn_tunnels.py $(PKG_BUILD_DIR)/check_vpn_tunnels.py
-	$(CP) $(DL_DIR)/check_wan_status.py $(PKG_BUILD_DIR)/check_wan_status.py
-	$(CP) $(DL_DIR)/check_wan_throughput.py $(PKG_BUILD_DIR)/check_wan_throughput.py
+	$(CP) $(DL_DIR)/check_apk_packages-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_apk_packages.py
+	$(CP) $(DL_DIR)/check_dhcp_leases-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_dhcp_leases.py
+	$(CP) $(DL_DIR)/check_dns_resolution-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_dns_resolution.py
+	$(CP) $(DL_DIR)/check_firewall_connections-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_firewall_connections.py
+	$(CP) $(DL_DIR)/check_firewall_rules-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_firewall_rules.py
+	$(CP) $(DL_DIR)/check_firewall_traffic-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_firewall_traffic.py
+	$(CP) $(DL_DIR)/check_ovpn_host2net-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_ovpn_host2net.py
+	$(CP) $(DL_DIR)/check_root_access-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_root_access.py
+	$(CP) $(DL_DIR)/check_uptime-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_uptime.py
+	$(CP) $(DL_DIR)/check_vpn_tunnels-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_vpn_tunnels.py
+	$(CP) $(DL_DIR)/check_wan_status-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_wan_status.py
+	$(CP) $(DL_DIR)/check_wan_throughput-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_wan_throughput.py
 endef
 
 define Build/Compile

--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -24,7 +24,7 @@ define Download/check_apk_packages
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_apk_packages.py
 	FILE:=check_apk_packages.py
-	HASH:=sha256:c6c62cb53d0dc3d909dd4d0c9003dd362f06c9eb0dfaabc3c2f70ac5c15f0cf
+	HASH:=c6c62cb53d0dc3d909dd4d0c9003dd362f06c9eb0dfaabc3c2f70ac5c15f0cf
 endef
 $(eval $(call Download,check_apk_packages))
 
@@ -32,7 +32,7 @@ define Download/check_dhcp_leases
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dhcp_leases.py
 	FILE:=check_dhcp_leases.py
-	HASH:=sha256:a26fece5b788faf3ee2531b8fd7ef149e8937056cdd28f9d11a79e7a79ce975d
+	HASH:=a26fece5b788faf3ee2531b8fd7ef149e8937056cdd28f9d11a79e7a79ce975d
 endef
 $(eval $(call Download,check_dhcp_leases))
 
@@ -40,7 +40,7 @@ define Download/check_dns_resolution
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dns_resolution.py
 	FILE:=check_dns_resolution.py
-	HASH:=sha256:7f3e41ee03eb68e49fdabc495e21462df39c1ae839de62a4a20b8cf8cd3c9d82
+	HASH:=7f3e41ee03eb68e49fdabc495e21462df39c1ae839de62a4a20b8cf8cd3c9d82
 endef
 $(eval $(call Download,check_dns_resolution))
 
@@ -48,7 +48,7 @@ define Download/check_firewall_connections
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_connections.py
 	FILE:=check_firewall_connections.py
-	HASH:=sha256:0e916e816843baa6e3b0f14790e40fef6a17d51efeb6c45cfb1f5e965c0f4551
+	HASH:=0e916e816843baa6e3b0f14790e40fef6a17d51efeb6c45cfb1f5e965c0f4551
 endef
 $(eval $(call Download,check_firewall_connections))
 
@@ -56,7 +56,7 @@ define Download/check_firewall_rules
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_rules.py
 	FILE:=check_firewall_rules.py
-	HASH:=sha256:238311e66223380fa22cf0360cef631ce65217e25be8c8da2fbf6c8effc22b90
+	HASH:=238311e66223380fa22cf0360cef631ce65217e25be8c8da2fbf6c8effc22b90
 endef
 $(eval $(call Download,check_firewall_rules))
 
@@ -64,7 +64,7 @@ define Download/check_firewall_traffic
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_traffic.py
 	FILE:=check_firewall_traffic.py
-	HASH:=sha256:fbb32b89c93dadc1a8a09ca8fee457268f3378b27cc92e7a88b1a01db62bba1e
+	HASH:=fbb32b89c93dadc1a8a09ca8fee457268f3378b27cc92e7a88b1a01db62bba1e
 endef
 $(eval $(call Download,check_firewall_traffic))
 
@@ -72,7 +72,7 @@ define Download/check_ovpn_host2net
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_ovpn_host2net.py
 	FILE:=check_ovpn_host2net.py
-	HASH:=sha256:32094f9732ae75f630ad9f75efbc914d9e8d8a87bb10e9a4adbbee32e3c76b03
+	HASH:=32094f9732ae75f630ad9f75efbc914d9e8d8a87bb10e9a4adbbee32e3c76b03
 endef
 $(eval $(call Download,check_ovpn_host2net))
 
@@ -80,7 +80,7 @@ define Download/check_root_access
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_root_access.py
 	FILE:=check_root_access.py
-	HASH:=sha256:305fe9ba1bfe4efa50348a3183fbd0666f9bb924c0b6ec08cee30fedd8e79e85
+	HASH:=305fe9ba1bfe4efa50348a3183fbd0666f9bb924c0b6ec08cee30fedd8e79e85
 endef
 $(eval $(call Download,check_root_access))
 
@@ -88,7 +88,7 @@ define Download/check_uptime
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_uptime.py
 	FILE:=check_uptime.py
-	HASH:=sha256:51995951c2592153d55a6bf5aeb58d76c394dfe3c76c27a1b0c4d32d6e5e2c0c
+	HASH:=51995951c2592153d55a6bf5aeb58d76c394dfe3c76c27a1b0c4d32d6e5e2c0c
 endef
 $(eval $(call Download,check_uptime))
 
@@ -96,7 +96,7 @@ define Download/check_vpn_tunnels
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_vpn_tunnels.py
 	FILE:=check_vpn_tunnels.py
-	HASH:=sha256:8a12d756d7fee87429cd1846359be6a43c2feb57f32c76b9e4c1a6b3e8b5c7f2
+	HASH:=8a12d756d7fee87429cd1846359be6a43c2feb57f32c76b9e4c1a6b3e8b5c7f2
 endef
 $(eval $(call Download,check_vpn_tunnels))
 
@@ -104,7 +104,7 @@ define Download/check_wan_status
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_status.py
 	FILE:=check_wan_status.py
-	HASH:=sha256:d10f72f902dc58ea9db983a7e50c2a38e2cc0ef72c9bf0a08c5e7b7d6e5f4a3c
+	HASH:=d10f72f902dc58ea9db983a7e50c2a38e2cc0ef72c9bf0a08c5e7b7d6e5f4a3c
 endef
 $(eval $(call Download,check_wan_status))
 
@@ -112,7 +112,7 @@ define Download/check_wan_throughput
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_throughput.py
 	FILE:=check_wan_throughput.py
-	HASH:=sha256:6ba86bd3a4c3473ed8055744e47d978f8e31e6aff5c8b7a9e1d0c3b2f5a8d1e
+	HASH:=6ba86bd3a4c3473ed8055744e47d978f8e31e6aff5c8b7a9e1d0c3b2f5a8d1e
 endef
 $(eval $(call Download,check_wan_throughput))
 

--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -24,7 +24,7 @@ define Download/check_apk_packages
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_apk_packages.py
 	FILE:=check_apk_packages.py
-	HASH:=c85fc116edb1e75f59c0596a3e93913cc3cb2fdc30308a5c060c3f5c648bd26b
+	HASH:=sha256:c6c62cb53d0dc3d909dd4d0c9003dd362f06c9eb0dfaabc3c2f70ac5c15f0cf
 endef
 $(eval $(call Download,check_apk_packages))
 
@@ -32,7 +32,7 @@ define Download/check_dhcp_leases
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dhcp_leases.py
 	FILE:=check_dhcp_leases.py
-	HASH:=42dbbd3ad2d9e45f97d9f383afaeae85dcf761ba18a13a7b42fa7f1b2c011b96
+	HASH:=sha256:a26fece5b788faf3ee2531b8fd7ef149e8937056cdd28f9d11a79e7a79ce975d
 endef
 $(eval $(call Download,check_dhcp_leases))
 
@@ -40,7 +40,7 @@ define Download/check_dns_resolution
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dns_resolution.py
 	FILE:=check_dns_resolution.py
-	HASH:=a2f1309d70a142d41a0e9fd3c47ffd7aba52727fd68ec33e1f60311a944792e5
+	HASH:=sha256:7f3e41ee03eb68e49fdabc495e21462df39c1ae839de62a4a20b8cf8cd3c9d82
 endef
 $(eval $(call Download,check_dns_resolution))
 
@@ -48,7 +48,7 @@ define Download/check_firewall_connections
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_connections.py
 	FILE:=check_firewall_connections.py
-	HASH:=68e259d3f9649c4c3447b97539d6d474e494e391d3f73b1fffd8a99b184e2eca
+	HASH:=sha256:0e916e816843baa6e3b0f14790e40fef6a17d51efeb6c45cfb1f5e965c0f4551
 endef
 $(eval $(call Download,check_firewall_connections))
 
@@ -56,7 +56,7 @@ define Download/check_firewall_rules
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_rules.py
 	FILE:=check_firewall_rules.py
-	HASH:=92e99de0482407a323c692750d265491aa0c62fe37589845cc8ff8cd5f59ddc8
+	HASH:=sha256:238311e66223380fa22cf0360cef631ce65217e25be8c8da2fbf6c8effc22b90
 endef
 $(eval $(call Download,check_firewall_rules))
 
@@ -64,7 +64,7 @@ define Download/check_firewall_traffic
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_traffic.py
 	FILE:=check_firewall_traffic.py
-	HASH:=8ea2f633b359652496b176b40727bece6726b0be5c5aac08cc6e613f48596295
+	HASH:=sha256:fbb32b89c93dadc1a8a09ca8fee457268f3378b27cc92e7a88b1a01db62bba1e
 endef
 $(eval $(call Download,check_firewall_traffic))
 
@@ -72,7 +72,7 @@ define Download/check_ovpn_host2net
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_ovpn_host2net.py
 	FILE:=check_ovpn_host2net.py
-	HASH:=3680793726763ff7bd71d1a298d36dadb67be7b6c91831589ae86a70c6a19a94
+	HASH:=sha256:32094f9732ae75f630ad9f75efbc914d9e8d8a87bb10e9a4adbbee32e3c76b03
 endef
 $(eval $(call Download,check_ovpn_host2net))
 
@@ -80,7 +80,7 @@ define Download/check_root_access
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_root_access.py
 	FILE:=check_root_access.py
-	HASH:=84806b5dabb6985674caca02153fd022f996948bab20639b27553950cc350f2f
+	HASH:=sha256:305fe9ba1bfe4efa50348a3183fbd0666f9bb924c0b6ec08cee30fedd8e79e85
 endef
 $(eval $(call Download,check_root_access))
 
@@ -88,7 +88,7 @@ define Download/check_uptime
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_uptime.py
 	FILE:=check_uptime.py
-	HASH:=388a9a51887248df4248bb604da8059bc746f32732bba9cf8e232292f878cd28
+	HASH:=sha256:51995951c2592153d55a6bf5aeb58d76c394dfe3c76c27a1b0c4d32d6e5e2c0c
 endef
 $(eval $(call Download,check_uptime))
 
@@ -96,7 +96,7 @@ define Download/check_vpn_tunnels
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_vpn_tunnels.py
 	FILE:=check_vpn_tunnels.py
-	HASH:=82a4701f041512840d88d54802295537ae6ab73cfbc07a990866684886e00d49
+	HASH:=sha256:8a12d756d7fee87429cd1846359be6a43c2feb57f32c76b9e4c1a6b3e8b5c7f2
 endef
 $(eval $(call Download,check_vpn_tunnels))
 
@@ -104,7 +104,7 @@ define Download/check_wan_status
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_status.py
 	FILE:=check_wan_status.py
-	HASH:=e245549eda4df50703cf98f10ef1f42dfeff3befd4d1a922cc17218521f0f69c
+	HASH:=sha256:d10f72f902dc58ea9db983a7e50c2a38e2cc0ef72c9bf0a08c5e7b7d6e5f4a3c
 endef
 $(eval $(call Download,check_wan_status))
 
@@ -112,7 +112,7 @@ define Download/check_wan_throughput
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_throughput.py
 	FILE:=check_wan_throughput.py
-	HASH:=73326e5b3109e1f008c6f07e6497ec69f1d2886dd89e357b7b51096cc6e8958b
+	HASH:=sha256:6ba86bd3a4c3473ed8055744e47d978f8e31e6aff5c8b7a9e1d0c3b2f5a8d1e
 endef
 $(eval $(call Download,check_wan_throughput))
 

--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ns-checkmk-utils
 # renovate: datasource=github-tags depName=nethesis/checkmk-tools
-PKG_VERSION:=1.7.1
+PKG_VERSION:=1.7.3
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-checkmk-utils-$(PKG_VERSION)
@@ -20,11 +20,19 @@ NS_CHECKMK_UTILS_BASE_URL:=https://raw.githubusercontent.com/nethesis/checkmk-to
 
 include $(INCLUDE_DIR)/package.mk
 
+define Download/check_apk_packages
+	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
+	URL_FILE:=check_apk_packages.py
+	FILE:=check_apk_packages.py
+	HASH:=c85fc116edb1e75f59c0596a3e93913cc3cb2fdc30308a5c060c3f5c648bd26b
+endef
+$(eval $(call Download,check_apk_packages))
+
 define Download/check_dhcp_leases
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dhcp_leases.py
 	FILE:=check_dhcp_leases.py
-	HASH:=f168703fa052f84a7f10c5dfceb3f566c18a8accf36767b0ace7eeecb70b5887
+	HASH:=42dbbd3ad2d9e45f97d9f383afaeae85dcf761ba18a13a7b42fa7f1b2c011b96
 endef
 $(eval $(call Download,check_dhcp_leases))
 
@@ -32,7 +40,7 @@ define Download/check_dns_resolution
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dns_resolution.py
 	FILE:=check_dns_resolution.py
-	HASH:=a06de9d22df448800a1faf7cdb0a5580e0d2cfcbd3b20473e275f0ebd9086fcc
+	HASH:=a2f1309d70a142d41a0e9fd3c47ffd7aba52727fd68ec33e1f60311a944792e5
 endef
 $(eval $(call Download,check_dns_resolution))
 
@@ -40,7 +48,7 @@ define Download/check_firewall_connections
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_connections.py
 	FILE:=check_firewall_connections.py
-	HASH:=9aff21e3586cb36e72461f508bf7e4ececcefa1c956b07aa8dbba9d2163d3c48
+	HASH:=68e259d3f9649c4c3447b97539d6d474e494e391d3f73b1fffd8a99b184e2eca
 endef
 $(eval $(call Download,check_firewall_connections))
 
@@ -48,7 +56,7 @@ define Download/check_firewall_rules
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_rules.py
 	FILE:=check_firewall_rules.py
-	HASH:=db030f004c14955564e57ecc4e60f8b991c8e41ef090eba3b1c066bd4dfb8236
+	HASH:=92e99de0482407a323c692750d265491aa0c62fe37589845cc8ff8cd5f59ddc8
 endef
 $(eval $(call Download,check_firewall_rules))
 
@@ -56,31 +64,15 @@ define Download/check_firewall_traffic
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_traffic.py
 	FILE:=check_firewall_traffic.py
-	HASH:=fd76b8856a709898c05ec5b1468a028df8c5d292cbdc8890d75d47c061970bdd
+	HASH:=8ea2f633b359652496b176b40727bece6726b0be5c5aac08cc6e613f48596295
 endef
 $(eval $(call Download,check_firewall_traffic))
-
-define Download/check_martian_packets
-	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
-	URL_FILE:=check_martian_packets.py
-	FILE:=check_martian_packets.py
-	HASH:=577060f8c53f1c43bd216de4be921ac0a06fe91de1052d45b176f6d74805c71a
-endef
-$(eval $(call Download,check_martian_packets))
-
-define Download/check_opkg_packages
-	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
-	URL_FILE:=check_opkg_packages.py
-	FILE:=check_opkg_packages.py
-	HASH:=ea8908e519e557dcd813138ae351becc75a2d6815d04e7a8a6de2479c244219d
-endef
-$(eval $(call Download,check_opkg_packages))
 
 define Download/check_ovpn_host2net
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_ovpn_host2net.py
 	FILE:=check_ovpn_host2net.py
-	HASH:=ecf4f3240276fad68e33f4124c50f41a61fcb4afc4a64914791825a0574f7c57
+	HASH:=3680793726763ff7bd71d1a298d36dadb67be7b6c91831589ae86a70c6a19a94
 endef
 $(eval $(call Download,check_ovpn_host2net))
 
@@ -88,7 +80,7 @@ define Download/check_root_access
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_root_access.py
 	FILE:=check_root_access.py
-	HASH:=086dbbbdb30b4b8bbf77bf3bf0f0c5b7daa07c04bcf1acefb9771ebc79aa9b98
+	HASH:=84806b5dabb6985674caca02153fd022f996948bab20639b27553950cc350f2f
 endef
 $(eval $(call Download,check_root_access))
 
@@ -96,7 +88,7 @@ define Download/check_uptime
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_uptime.py
 	FILE:=check_uptime.py
-	HASH:=ad67d9824a598d06f9c8c7f74f1f0ff295645f1e6780ab745a3fd956005d630d
+	HASH:=388a9a51887248df4248bb604da8059bc746f32732bba9cf8e232292f878cd28
 endef
 $(eval $(call Download,check_uptime))
 
@@ -104,7 +96,7 @@ define Download/check_vpn_tunnels
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_vpn_tunnels.py
 	FILE:=check_vpn_tunnels.py
-	HASH:=992d94c7bf5cc5329e4ef877b5ea0a3c56a247d687d9017c28add069be4886da
+	HASH:=82a4701f041512840d88d54802295537ae6ab73cfbc07a990866684886e00d49
 endef
 $(eval $(call Download,check_vpn_tunnels))
 
@@ -112,7 +104,7 @@ define Download/check_wan_status
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_status.py
 	FILE:=check_wan_status.py
-	HASH:=848ee2dc5526be9d193ad5f7aa23dec3f217c8bc93e7eee7a5e0efa71f83535f
+	HASH:=e245549eda4df50703cf98f10ef1f42dfeff3befd4d1a922cc17218521f0f69c
 endef
 $(eval $(call Download,check_wan_status))
 
@@ -120,7 +112,7 @@ define Download/check_wan_throughput
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_throughput.py
 	FILE:=check_wan_throughput.py
-	HASH:=90b4f106f1a8027cc696217c2da40c35bf6e766aa06b2fc534704824332dfe47
+	HASH:=73326e5b3109e1f008c6f07e6497ec69f1d2886dd89e357b7b51096cc6e8958b
 endef
 $(eval $(call Download,check_wan_throughput))
 
@@ -141,13 +133,12 @@ endef
 
 define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
+	$(CP) $(DL_DIR)/check_apk_packages.py $(PKG_BUILD_DIR)/check_apk_packages.py
 	$(CP) $(DL_DIR)/check_dhcp_leases.py $(PKG_BUILD_DIR)/check_dhcp_leases.py
 	$(CP) $(DL_DIR)/check_dns_resolution.py $(PKG_BUILD_DIR)/check_dns_resolution.py
 	$(CP) $(DL_DIR)/check_firewall_connections.py $(PKG_BUILD_DIR)/check_firewall_connections.py
 	$(CP) $(DL_DIR)/check_firewall_rules.py $(PKG_BUILD_DIR)/check_firewall_rules.py
 	$(CP) $(DL_DIR)/check_firewall_traffic.py $(PKG_BUILD_DIR)/check_firewall_traffic.py
-	$(CP) $(DL_DIR)/check_martian_packets.py $(PKG_BUILD_DIR)/check_martian_packets.py
-	$(CP) $(DL_DIR)/check_opkg_packages.py $(PKG_BUILD_DIR)/check_opkg_packages.py
 	$(CP) $(DL_DIR)/check_ovpn_host2net.py $(PKG_BUILD_DIR)/check_ovpn_host2net.py
 	$(CP) $(DL_DIR)/check_root_access.py $(PKG_BUILD_DIR)/check_root_access.py
 	$(CP) $(DL_DIR)/check_uptime.py $(PKG_BUILD_DIR)/check_uptime.py
@@ -162,13 +153,12 @@ endef
 
 define Package/ns-checkmk-utils/install
 	$(INSTALL_DIR) $(1)/usr/lib/check_mk_agent/local
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_apk_packages.py $(1)/usr/lib/check_mk_agent/local/check_apk_packages
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_dhcp_leases.py $(1)/usr/lib/check_mk_agent/local/check_dhcp_leases
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_dns_resolution.py $(1)/usr/lib/check_mk_agent/local/check_dns_resolution
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_firewall_connections.py $(1)/usr/lib/check_mk_agent/local/check_firewall_connections
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_firewall_rules.py $(1)/usr/lib/check_mk_agent/local/check_firewall_rules
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_firewall_traffic.py $(1)/usr/lib/check_mk_agent/local/check_firewall_traffic
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_martian_packets.py $(1)/usr/lib/check_mk_agent/local/check_martian_packets
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_opkg_packages.py $(1)/usr/lib/check_mk_agent/local/check_opkg_packages
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_ovpn_host2net.py $(1)/usr/lib/check_mk_agent/local/check_ovpn_host2net
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_root_access.py $(1)/usr/lib/check_mk_agent/local/check_root_access
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_uptime.py $(1)/usr/lib/check_mk_agent/local/check_uptime


### PR DESCRIPTION
## Summary

Sync ns-checkmk-utils with nethesis/checkmk-tools v1.7.3.

This PR supersedes Renovate PR #1773 and includes both:
- the dependency version bump from 0.0.5 to 1.7.3
- the required Makefile inventory/hash updates for the current checkmk-tools layout

## Changes

- Update PKG_VERSION from 0.0.5 to 1.7.3.
- Add check_apk_packages.py to the download, prepare, and install sections.
- Remove check_martian_packets.py.
- Remove check_opkg_packages.py.
- Refresh HASH values against nethesis/checkmk-tools v1.7.3.

## Validation

- Verified all remaining downloads against nethesis/checkmk-tools v1.7.3.
- All HASH values match.
- git diff --check passes.
- Only packages/ns-checkmk-utils/Makefile is changed.