### PR TITLE
fix(ci): skip DO Spaces publish on fork builds, archive packages

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -98,8 +98,10 @@ jobs:
           path: |
             build-logs
       - name: Setup rclone
+        if: ${{ secrets.DO_SPACE_ACCESS_KEY != '' && secrets.DO_SPACE_SECRET_KEY != '' }}
         uses: AnimMouse/setup-rclone@v1
       - name: Copy Packages to repo
+        if: ${{ secrets.DO_SPACE_ACCESS_KEY != '' && secrets.DO_SPACE_SECRET_KEY != '' }}
         env:
           RCLONE_CONFIG_REPO_PROVIDER: DigitalOcean
           RCLONE_CONFIG_REPO_TYPE: s3
@@ -127,3 +129,12 @@ jobs:
           fi
 
           rclone copy latest_release repo:nethsecurity/${{ inputs.repo_channel }}/ --progress
+      - name: Archive packages (no repo secrets available)
+        if: ${{ secrets.DO_SPACE_ACCESS_KEY == '' || secrets.DO_SPACE_SECRET_KEY == '' }}
+        run: tar -czf packages.tar.gz -C bin packages
+      - name: Upload packages archive
+        if: ${{ secrets.DO_SPACE_ACCESS_KEY == '' || secrets.DO_SPACE_SECRET_KEY == '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: packages-archive
+          path: packages.tar.gz


### PR DESCRIPTION
## Summary
- Fork PR builds never receive `DO_SPACE_ACCESS_KEY`/`DO_SPACE_SECRET_KEY` (GitHub withholds secrets from `pull_request` runs originating from forks, even with `secrets: inherit`), so the "Copy Packages to repo" rclone step fails auth and the whole job dies even though the image built successfully.
- Gate the `Setup rclone` / `Copy Packages to repo` steps on secret presence.
- Add a fallback: when secrets aren't available, tar `bin/packages` and upload it as a `packages-archive` artifact instead of failing.

Fixes: https://github.com/NethServer/nethsecurity/actions/runs/29031501244/job/86297708834
