### PR TITLE
fix(ns-api): wrong call of euci for uci prop in ns.ha

### DIFF
--- a/packages/ns-api/files/ns.ha
+++ b/packages/ns-api/files/ns.ha
@@ -84,7 +84,7 @@ def get_device_from_ip(uci, ipaddr):
     return (None, None)
 
 def get_dhcp_leasefile(uci):
-    return uci.get('dhcp', 'ns_dnsmasq', 'dhcp', 'leasefile', default='/tmp/dhcp.leases')
+    return uci.get('dhcp', 'ns_dnsmasq', 'leasefile', default='/tmp/dhcp.leases')
 
 def get_main_vrrp_interface(uci):
     for section in utils.get_all_by_type(uci, 'keepalived', 'ipaddress'):


### PR DESCRIPTION
Same leftover-arg bug from #1738 (`ns.dhcp`) was still present in `ns.ha`'s `get_dhcp_leasefile()`, which passed an extra stray `'dhcp'` positional arg to `EUci.get()`.

Ref: reported as still broken from here https://community.nethserver.org/t/nethsecurity-8-8-0-beta2-ready-for-testing/28017/3