### PR TITLE
fix(coova-chilli): tag/dedupe syslog lines from chilli reload path

### DIFF
--- a/patches/feeds/packages/210-coova-chilli-syslog-tag.patch
+++ b/patches/feeds/packages/210-coova-chilli-syslog-tag.patch
@@ -1,0 +1,40 @@
+diff --git a/net/coova-chilli/patches/080-fix-chilli-syslog-tag.patch b/net/coova-chilli/patches/080-fix-chilli-syslog-tag.patch
+new file mode 100644
+index 000000000..a1b2c3d
+--- /dev/null
++++ b/net/coova-chilli/patches/080-fix-chilli-syslog-tag.patch
+@@ -0,0 +1,34 @@
++--- a/src/chilli.c
+++++ b/src/chilli.c
++@@ -7263,8 +7263,13 @@ int chilli_main(int argc, char **argv) {
++
++   syslog_ident = basename(argv[0]);
++
++-  /* Start out also logging to stderr until we load options. */
++-  openlog(syslog_ident, syslog_options|syslog_debug_options, LOG_DAEMON);
+++  /*
+++   * Do not mirror to stderr (LOG_PERROR) even during early options
+++   * processing: under procd (--fg with stdout/stderr captured), stderr
+++   * is itself forwarded into syslog, so LOG_PERROR here would cause
+++   * every message logged before the options are loaded to be doubled.
+++   */
+++  openlog(syslog_ident, syslog_options, LOG_DAEMON);
++
++   options_init();
++
++--- a/src/main-opt.c
+++++ b/src/main-opt.c
++@@ -333,6 +333,13 @@ int main(int argc, char **argv) {
++
++   options_init();
++
+++  /*
+++   * chilli_opt is exec()'d fresh by opt_run() (options.c), so it never
+++   * inherits the parent chilli process's openlog() state. Without this,
+++   * every syslog() call below logs with no ident/tag at all.
+++   */
+++  openlog(basename(argv[0]), LOG_PID, LOG_DAEMON);
+++
++   memset(&args_info, 0, sizeof(args_info));
++
++   if (cmdline_parser2(argc, argv, &args_info, 1, 1, 1) != 0) {

--- a/patches/feeds/packages/210-coova-chilli-syslog-tag.patch
+++ b/patches/feeds/packages/210-coova-chilli-syslog-tag.patch
@@ -1,9 +1,9 @@
 diff --git a/net/coova-chilli/patches/080-fix-chilli-syslog-tag.patch b/net/coova-chilli/patches/080-fix-chilli-syslog-tag.patch
 new file mode 100644
-index 000000000..a1b2c3d
+index 000000000..b2c3d4e
 --- /dev/null
 +++ b/net/coova-chilli/patches/080-fix-chilli-syslog-tag.patch
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,51 @@
 +--- a/src/chilli.c
 ++++ b/src/chilli.c
 +@@ -7263,8 +7263,13 @@ int chilli_main(int argc, char **argv) {
@@ -38,3 +38,20 @@ index 000000000..a1b2c3d
 +   memset(&args_info, 0, sizeof(args_info));
 +
 +   if (cmdline_parser2(argc, argv, &args_info, 1, 1, 1) != 0) {
++--- a/src/main-proxy.c
+++++ b/src/main-proxy.c
++@@ -1073,6 +1073,14 @@ int main(int argc, char **argv) {
++
++   int max_conn_time = 60;
++
+++  /*
+++   * chilli_proxy is its own binary/main() and never called openlog()
+++   * before this, so all its syslog() calls (below, and shared code
+++   * such as options_load()/chilli_signals()'s handlers) logged with
+++   * no ident/tag at all.
+++   */
+++  openlog(basename(argv[0]), LOG_PID, LOG_DAEMON);
+++
++   options_init();
++
++   selfpipe = selfpipe_init();


### PR DESCRIPTION
## Summary
- `chilli`/`dedalo` sometimes logs syslog lines with no program tag, and sometimes doubles the tag (e.g. `chilli[9617]: chilli[9617]: msg`).
- Root cause (verified against coova-chilli 1.6 source, reproduced live on device):
  - **Untagged lines**: `chilli_opt` (`main-opt.c`) is exec'd fresh by `opt_run()` and never calls `openlog()`, so its `syslog()` calls carry no ident.
  - **Doubled lines**: `chilli.c`'s first `openlog()` sets `LOG_PERROR` unconditionally; `process_options()` runs before the later reopen that strips it. Since dedalo/chilli run under procd with `--fg` + `stdout 1`/`stderr 1`, the `/dev/null` redirect that would normally silence `LOG_PERROR`'s stderr echo never runs (it's gated on non-foreground/daemon mode) — procd re-captures that stderr line and logs it again.
- Fix: add `patches/feeds/packages/210-coova-chilli-syslog-tag.patch`, which drops `LOG_PERROR` from the early `openlog()` in `chilli.c` and adds a missing `openlog()` call in `main-opt.c`.

New log example:
```
Jul 14 08:38:08 NethSec chilli[5847]: CoovaChilli shutting down
Jul 14 08:38:09 NethSec [chilli_proxy][8251]: _sigterm(342): SIGTERM: shutdown
Jul 14 08:38:09 NethSec chilli[9131]: (Re)processing options [/var/run/chilli.9131.cfg.bin]
Jul 14 08:38:09 NethSec chilli[9156]: running chilli_opt on /var/run/chilli.9131.cfg.bin
Jul 14 08:38:09 NethSec chilli_opt[9156]: IPv6 disabled 
Jul 14 08:38:09 NethSec chilli_opt[9156]: DHCP Listen: 192.168.182.1
Jul 14 08:38:09 NethSec chilli_opt[9156]: UAM Listen: 192.168.182.1
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain my.nethspot.com
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain facebook.com
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain facebook.net
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain akamaihd.net
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain fbcdn.net
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain linkedin.com
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain licdn.com
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain instagram.com
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain akamaihd.net
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain collection.wifi4eu.ec.europa.eu
Jul 14 08:38:09 NethSec chilli_opt[9156]: uamdomain wifi4eucollectorprod.azurewebsites.net
Jul 14 08:38:09 NethSec chilli_opt[9156]: PID 9156 saving options to /var/run/chilli.9131.cfg.bin
Jul 14 08:38:09 NethSec chilli[9131]: PID 9131 rereading binary file /var/run/chilli.9131.cfg.bin
Jul 14 08:38:09 NethSec chilli[9131]: PID 9131 reloaded binary options file
Jul 14 08:38:09 NethSec chilli[9131]: CoovaChilli 1.7. Copyright 2002-2005 Mondru AB. Licensed under GPL. Copyright 2006-2012 David Bird (Coova Technologies). Licensed under GPL. See http://coova.github.io/ for details.
Jul 14 08:38:09 NethSec chilli[9131]: TX queue length set to 100
Jul 14 08:38:09 NethSec [chilli_proxy][9190]: PID 9190 loading binary options file /var/run/chilli.9131.cfg.bin
Jul 14 08:38:09 NethSec [chilli_proxy][9190]: RADIUS client 0.0.0.0:1812
Jul 14 08:38:09 NethSec [chilli_proxy][9190]: RADIUS client 0.0.0.0:1813
Jul 14 08:38:09 NethSec [chilli_proxy][9190]: PID 9190 rereading binary file /var/run/chilli.9131.cfg.bin
Jul 14 08:38:09 NethSec [chilli_proxy][9190]: PID 9190 reloaded binary options file
```

## Related issue

#1796 

## Test plan
- [x] Patch verified to apply cleanly against `feeds/packages` (outer wrapper) and against real coova-chilli 1.6 source (inner patch), via local dry-run/apply tests.
- [x] Build `coova-chilli` in the build container (`make package/feeds/packages/coova-chilli/{download,compile} V=sc`), flash on a test device.
- [x] Restart `dedalo` and confirm `/var/log/messages` no longer shows untagged or doubled `chilli`/`chilli_opt` lines.