### PR TITLE
fix(ns-api-server): guard file endpoints against path traversal

### DIFF
--- a/packages/ns-api-server/files/src/methods/files.go
+++ b/packages/ns-api-server/files/src/methods/files.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/NethServer/nethsecurity-api/configuration"
 	"github.com/NethServer/nethsecurity-api/response"
@@ -22,6 +23,16 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
+
+// safeFilePath joins baseDir and the user-supplied name, then verifies the
+// cleaned result stays within baseDir. Returns false on traversal attempts.
+func safeFilePath(baseDir, name string) (string, bool) {
+	filePath := filepath.Join(baseDir, name) // Join cleans "../" segments
+	if !strings.HasPrefix(filePath, baseDir+string(os.PathSeparator)) {
+		return "", false
+	}
+	return filePath, true
+}
 
 func UploadFile(c *gin.Context) {
 	//check limit size
@@ -70,8 +81,16 @@ func DownloadFile(c *gin.Context) {
 	// get filename
 	fileName := c.Param("filename")
 
-	// compose filepath
-	filePath := filepath.Join(configuration.Config.DownloadFilePath, fileName)
+	// compose filepath and reject path traversal attempts
+	filePath, ok := safeFilePath(configuration.Config.DownloadFilePath, fileName)
+	if !ok {
+		c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
+			Code:    400,
+			Message: "invalid filename",
+			Data:    fileName,
+		}))
+		return
+	}
 
 	// open file
 	fileData, err := os.Open(filePath)
@@ -122,8 +141,16 @@ func DeleteFile(c *gin.Context) {
 	// get filename
 	fileName := c.Param("filename")
 
-	// compose filepath
-	filePath := filepath.Join(configuration.Config.DownloadFilePath, fileName)
+	// compose filepath and reject path traversal attempts
+	filePath, ok := safeFilePath(configuration.Config.DownloadFilePath, fileName)
+	if !ok {
+		c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
+			Code:    400,
+			Message: "invalid filename",
+			Data:    fileName,
+		}))
+		return
+	}
 
 	// remove file
 	err := os.Remove(filePath)

--- a/packages/ns-api-server/files/src/methods/files_test.go
+++ b/packages/ns-api-server/files/src/methods/files_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Nethesis S.r.l.
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+package methods
+
+import "testing"
+
+func TestSafeFilePath(t *testing.T) {
+	base := "/var/run/ns-api-server/downloads"
+	cases := []struct {
+		name    string
+		input   string
+		wantOK  bool
+		wantOut string
+	}{
+		{"legit", "upload-abc", true, base + "/upload-abc"},
+		{"subdir", "sub/file", true, base + "/sub/file"},
+		{"parent", "..", false, ""},
+		{"parent slash", "../secret_jwt", false, ""},
+		{"deep traversal", "../../../etc/shadow", false, ""},
+		{"absolute contained", "/etc/shadow", true, base + "/etc/shadow"},
+		{"prefix sibling", "../downloads-evil", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, ok := safeFilePath(base, tc.input)
+			if ok != tc.wantOK {
+				t.Fatalf("safeFilePath(%q) ok=%v, want %v (out=%q)", tc.input, ok, tc.wantOK, out)
+			}
+			if ok && out != tc.wantOut {
+				t.Fatalf("safeFilePath(%q) out=%q, want %q", tc.input, out, tc.wantOut)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds explicit path-containment validation to `DownloadFile` and `DeleteFile` in `packages/ns-api-server/files/src/methods/files.go`. A new `safeFilePath()` helper resolves the path with `filepath.Join` and verifies it stays under the configured download directory (trailing-separator prefix check); traversal attempts now return HTTP 400. `UploadFile` is unchanged (it already ignores the client-supplied name and generates a UUID).

## SonarCloud issues addressed

Clears three BLOCKER findings (rule `gosecurity:S2083`, CWE-22), all on `files.go`:

- `AZ9aszoIS1IsCbTKZ7OU` — line 77 (`os.Open`)
- `AZ9aszoIS1IsCbTKZ7OS` — line 118 (`c.File`)
- `AZ9aszoIS1IsCbTKZ7OT` — line 129 (`os.Remove`)

## ⚠️ This is NOT a real exploitable vulnerability

This is **defense-in-depth hardening**, not a security incident:

- The routes are **administrator-authenticated** (JWT, `/files/:filename` inside `authGroup`). An attacker would already need an admin token — and an admin has root-equivalent control by other means.
- gin's **default path cleaning** collapses `../` and decoded `%2f` before the handler runs. On a live device every crafted traversal request (`..%2fsecret_jwt`, `../../../etc/shadow`, double-encoded variants, direct-to-backend on `127.0.0.1:8090`) returned **404/400** — no traversal was reachable through the nginx + gin stack.
- Realistic CVSS 3.1: base ~7.1 (High) on the code alone, but adjusted for the mitigations (`E:U`, admin-only) it drops to **~2–4 (Low)**.

The value of the change is removing the reliance on undocumented framework behavior: a future gin upgrade, `UseRawPath` toggle, or route refactor could otherwise re-expose the sink. It also clears the static-analysis blocker.

## Verification

- `gofmt` clean, `go vet` clean.
- New unit test `methods/files_test.go` (`go test ./methods/` → ok): rejects `..`, `../secret_jwt`, `../../../etc/shadow`, `../downloads-evil` (prefix-sibling); allows legit / subdir / contained-absolute names.
- Live device: legit download (backend + via nginx) and delete still work — no regression. Device restored to its original binary afterwards.
