### PR TITLE
fix(telegraf): adjustments over configuration, added wireguard and nft plugins

### DIFF
--- a/packages/telegraf/Makefile
+++ b/packages/telegraf/Makefile
@@ -33,8 +33,8 @@ GO_PKG_TAGS:= \
 	inputs.cpu \
 	inputs.disk \
 	inputs.diskio \
-	inputs.ethtool \
 	inputs.dns_query \
+	inputs.ethtool \
 	inputs.exec \
 	inputs.file \
 	inputs.mem \
@@ -45,6 +45,7 @@ GO_PKG_TAGS:= \
 	inputs.processes \
 	inputs.sensors \
 	inputs.system \
+	inputs.wireguard \
 	outputs.influxdb \
 	outputs.prometheus_client \
 	parsers.json_v2

--- a/packages/telegraf/Makefile
+++ b/packages/telegraf/Makefile
@@ -40,6 +40,7 @@ GO_PKG_TAGS:= \
 	inputs.mem \
 	inputs.net \
 	inputs.netstat \
+	inputs.nftables \
 	inputs.nstat \
 	inputs.ping \
 	inputs.processes \

--- a/packages/telegraf/files/telegraf.conf.d/ha.conf
+++ b/packages/telegraf/files/telegraf.conf.d/ha.conf
@@ -3,7 +3,7 @@
 
 [[inputs.exec]]
   name_override = "ha_alert"
-  commands = ["/usr/libexec/telegraf-ha-alert"]
+  commands = [["/usr/libexec/telegraf-ha-alert"]]
   interval = "60s"
   timeout = "5s"
   data_format = "json_v2"

--- a/packages/telegraf/files/telegraf.conf.d/mwan.conf
+++ b/packages/telegraf/files/telegraf.conf.d/mwan.conf
@@ -6,7 +6,7 @@
 
 [[inputs.exec]]
   name_override = "mwan_interface"
-  commands = ["/usr/libexec/telegraf-mwan"]
+  commands = [["/usr/libexec/telegraf-mwan"]]
   interval = "60s"
   timeout = "10s"
   data_format = "json_v2"

--- a/packages/telegraf/files/telegraf.conf.d/os.conf
+++ b/packages/telegraf/files/telegraf.conf.d/os.conf
@@ -76,8 +76,12 @@
     influxdb_db = "os-metrics"
 
 [[inputs.wireguard]]
+  [inputs.wireguard.tags]
+    influxdb_db = "os-metrics"
 
 [[inputs.nftables]]
   tables = ["fw4"]
   include = ["anonymous-counters", "counters", "sets"]
+  [inputs.nftables.tags]
+    influxdb_db = "os-metrics"
 

--- a/packages/telegraf/files/telegraf.conf.d/os.conf
+++ b/packages/telegraf/files/telegraf.conf.d/os.conf
@@ -65,12 +65,9 @@
 
 # Read metrics about disk I/O
 [[inputs.diskio]]
-  ## By default, telegraf will gather stats for all devices.
-  ## Setting devices will restrict the stats to the specified devices.
-  # devices = ["sda", "sdb", "vd*"]
-
-  ## Uncomment the following line if you need disk serial numbers.
-  # skip_serial_number = false
+  ## Suppress "Unable to gather disk name" warnings: some devices (e.g. mmcblk
+  ## partitions) don't expose a resolvable name via gopsutil on this platform.
+  log_level = "error"
   [inputs.diskio.tags]
     influxdb_db = "os-metrics"
 

--- a/packages/telegraf/files/telegraf.conf.d/os.conf
+++ b/packages/telegraf/files/telegraf.conf.d/os.conf
@@ -83,3 +83,5 @@
   dirs = ["/proc/sys/net/netfilter", "/proc/sys/net/netfilter"]
   [inputs.conntrack.tags]
     influxdb_db = "os-metrics"
+
+[[inputs.wireguard]]

--- a/packages/telegraf/files/telegraf.conf.d/os.conf
+++ b/packages/telegraf/files/telegraf.conf.d/os.conf
@@ -62,8 +62,6 @@
   [inputs.nstat.tags]
     influxdb_db = "os-metrics"
 
-
-# Read metrics about disk I/O
 [[inputs.diskio]]
   ## Suppress "Unable to gather disk name" warnings: some devices (e.g. mmcblk
   ## partitions) don't expose a resolvable name via gopsutil on this platform.
@@ -71,8 +69,6 @@
   [inputs.diskio.tags]
     influxdb_db = "os-metrics"
 
-
-# Collect metrics from the nf_conntrack kernel module
 [[inputs.conntrack]]
   files = ["nf_conntrack_count", "nf_conntrack_max"]
   dirs = ["/proc/sys/net/netfilter", "/proc/sys/net/netfilter"]
@@ -80,3 +76,8 @@
     influxdb_db = "os-metrics"
 
 [[inputs.wireguard]]
+
+[[inputs.nftables]]
+  tables = ["fw4"]
+  include = ["anonymous-counters", "counters", "sets"]
+

--- a/packages/telegraf/files/telegraf.conf.d/os.conf
+++ b/packages/telegraf/files/telegraf.conf.d/os.conf
@@ -47,8 +47,6 @@
     influxdb_db = "os-metrics"
 
 [[inputs.net]]
-  ## Skip protocol stats, use inputs.nstat instead (fixes deprecation warning)
-  ignore_protocol_stats = true
   [inputs.net.tags]
     influxdb_db = "os-metrics"
 

--- a/packages/telegraf/files/telegraf.conf.d/os.conf
+++ b/packages/telegraf/files/telegraf.conf.d/os.conf
@@ -80,8 +80,7 @@
     influxdb_db = "os-metrics"
 
 [[inputs.nftables]]
-  tables = ["fw4"]
-  include = ["anonymous-counters", "counters", "sets"]
+  tables = ["inet fw4"]
+  include = ["anonymous-counters", "counters"]
   [inputs.nftables.tags]
     influxdb_db = "os-metrics"
-

--- a/packages/telegraf/files/telegraf.conf.d/services.conf
+++ b/packages/telegraf/files/telegraf.conf.d/services.conf
@@ -6,7 +6,7 @@
 
 [[inputs.exec]]
   name_override = "procd_service"
-  commands = ["/usr/libexec/telegraf-services"]
+  commands = [["/usr/libexec/telegraf-services"]]
   interval = "60s"
   timeout = "10s"
   data_format = "json_v2"

--- a/packages/telegraf/files/telegraf.conf.d/storage.conf
+++ b/packages/telegraf/files/telegraf.conf.d/storage.conf
@@ -3,7 +3,7 @@
 
 [[inputs.exec]]
   name_override = "storage_status"
-  commands = ["/usr/libexec/telegraf-storage-status"]
+  commands = [["/usr/libexec/telegraf-storage-status"]]
   interval = "60s"
   timeout = "5s"
   data_format = "json_v2"


### PR DESCRIPTION
- **feat(telegraf): added wireguard monitoring**
- **fix(telegraf): adjusted deprecation con inputs.exec**
- **fix(telegraf): adjusted deprecation warning on inputs.net**
- **fix(telegraf): removed warning "Unable to gather disk name for X"**
- **feat(telegraf): added nftables support**
