### PR TITLE
fix(build): correctly format .quiltrc

### DIFF
--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -38,12 +38,13 @@ RUN apt-get update \
 RUN groupadd -g 1000 'buildbot' \
     && useradd -m -s '/bin/bash' -u 1000 -g 1000 'buildbot' \
     && echo 'buildbot ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/buildbot \
-    && echo "QUILT_DIFF_ARGS=--no-timestamps --no-index -p ab --color=auto" \
-        "QUILT_REFRESH_ARGS=--no-timestamps --no-index -p ab" \
-        "QUILT_SERIES_ARGS=--color=auto" \
-        "QUILT_PATCH_OPTS=--unified" \
-        "QUILT_DIFF_OPTS=-p" \
-        "EDITOR=vim" \
+    && printf '%s\n' \
+        'QUILT_DIFF_ARGS="--no-timestamps --no-index -p ab --color=auto"' \
+        'QUILT_REFRESH_ARGS="--no-timestamps --no-index -p ab"' \
+        'QUILT_SERIES_ARGS="--color=auto"' \
+        'QUILT_PATCH_OPTS="--unified"' \
+        'QUILT_DIFF_OPTS="-p"' \
+        'EDITOR="vim"' \
         > /home/buildbot/.quiltrc
 USER buildbot
 WORKDIR /home/buildbot


### PR DESCRIPTION
Write .quiltrc as per documentation, using quotes. Put every var on a separate line.

Fixes warning message:
/home/buildbot/.quiltrc: line 1: --no-index: command not found