### PR TITLE
ci: standardize pull request channel naming to lowercase

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -59,7 +59,7 @@ jobs:
           echo "base_version=${BASE_VERSION}" >> $GITHUB_OUTPUT
 
           if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-            CHANNEL_NAME="PR${{ github.event.number }}"
+            CHANNEL_NAME="pr${{ github.event.number }}"
             BUILD_SEMVER_SUFFIX="-${CHANNEL_NAME}.${RUN_NUMBER}.${TIMESTAMP}.${COMMIT_HASH}"
             FULL_VERSION="${BASE_VERSION}${BUILD_SEMVER_SUFFIX}"
             echo "repo_channel=${CHANNEL_NAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/cleanup-branch.yml
+++ b/.github/workflows/cleanup-branch.yml
@@ -27,7 +27,7 @@ jobs:
         id: repo_channel
         run: |
           if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-            echo "REPO_CHANNEL=PR${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+            echo "REPO_CHANNEL=pr${{ github.event.number }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && -n "${{ github.event.inputs.channel }}" ]]; then
             echo "REPO_CHANNEL=${{ github.event.inputs.channel }}" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
This PR contains a fix for the CI workflow to avoid issues with the `apk` command due to a mismatch in package repository names.