### PR TITLE
fix(coova-chilli): enforce TLS verification for hotspot AAA

### DIFF
--- a/patches/feeds/packages/200-coova-curl-debug.patch
+++ b/patches/feeds/packages/200-coova-curl-debug.patch
@@ -367,3 +367,21 @@ index 000000000..d438ac382
 +     curl_easy_setopt(curl, CURLOPT_USERAGENT, "CoovaChilli " VERSION);
 +     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 +     curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
+diff --git a/net/coova-chilli/patches/080-fix-tls-verify.patch b/net/coova-chilli/patches/080-fix-tls-verify.patch
+new file mode 100644
+index 000000000..0f1e2d3c4
+--- /dev/null
++++ b/net/coova-chilli/patches/080-fix-tls-verify.patch
+@@ -0,0 +1,12 @@
++--- a/src/main-proxy.c
+++++ b/src/main-proxy.c
++@@ -529,7 +529,8 @@
++       curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
++     }
++ 
++-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+++    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+++    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
++     curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_DEFAULT);
++ 
++     curl_easy_setopt(curl, CURLOPT_VERBOSE, /*debug ? 1 :*/ 0);


### PR DESCRIPTION
## Problem

The Dedalo hotspot's `chilli_proxy` sends per-client authentication to the controller over HTTPS (`uamaaaurl`, e.g. `https://my.nethspot.com/wax/aaa`), but `http_aaa_setup` in coova-chilli's `src/main-proxy.c` performs **no TLS verification**:

- `CURLOPT_SSL_VERIFYHOST` is hardcoded to `0`
- `CURLOPT_SSL_VERIFYPEER` ends up `0` because the `ca`/`cert`/`key` locals are declared but never populated from any option, so the `if (ca && strlen(ca))` branch is never taken.

Any machine on the path between firewall and controller can present an arbitrary certificate, impersonate the controller, authorize hotspot clients (auth bypass), and capture the shared-secret digest and hotspot user credentials.

Affects every install that enables the hotspot feature.

## Fix

Adds `080-fix-tls-verify.patch` inside `patches/feeds/packages/200-coova-curl-debug.patch`, forcing verification after the broken logic (curl `setopt` is last-wins):

```c
curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
```

Peer chain and hostname are now verified against the system `ca-bundle` (already an `ns-dedalo` dependency). The default `my.nethspot.com` endpoint is publicly trusted, so verification works out of the box. `CURLOPT_ISSUERCERT` pinning is still honored if a CA is ever supplied.

## Verification

- Simulated the full coova-chilli patch chain (040 → 060 → 070 → 080) against upstream `coova-chilli` 1.7 `main-proxy.c` (matches the openwrt-25.12 feed): `080` applies cleanly at `-F0`, the `VERIFYHOST, 0` line is removed.
- Confirmed on a live device: `chilli_proxy` links `libcurl`, `aaa_url` is HTTPS, no CA configured — reproducing the vulnerable path.

### TODO before merge
- [x] CI image build green
- [x] Test for regressions

Assisted-by: Claude Code:claude-opus-4-8