### PR TITLE
fix(telegraf): improve ping config

### DIFF
--- a/packages/telegraf/files/telegraf-config
+++ b/packages/telegraf/files/telegraf-config
@@ -25,10 +25,11 @@ PING_TEMPLATE = """# Ping input plugin - monitors ICMP ping to configured hosts
 {% if pings -%}
 [[inputs.ping]]
   urls = [{{ pings|map('tojson')|join(', ') }}]
-  method = "native"
+  method = "exec"
   count = 1
-  ping_interval = 1.0
+  ping_interval = 2.0
   deadline = 10
+  log_level = "error"
 
   [inputs.ping.tags]
     influxdb_db = "ping-metrics"

--- a/packages/telegraf/files/telegraf-config
+++ b/packages/telegraf/files/telegraf-config
@@ -28,7 +28,7 @@ PING_TEMPLATE = """# Ping input plugin - monitors ICMP ping to configured hosts
   method = "exec"
   count = 1
   ping_interval = 2.0
-  deadline = 10
+  timeout = "1s"
   log_level = "error"
 
   [inputs.ping.tags]


### PR DESCRIPTION
The native ping method sometime loses ping to the first host inside the configuration.

Improve the config by:

- use exec method so packets for the first host are not lost
- reduce the number of ping
- avoid logging warning messages for the ping plugin