### PR TITLE
fix(ns-checkmk-utils): bump to checkmk-tools v1.7.6, fix production check set

### DIFF
--- a/packages/ns-checkmk-utils/Makefile
+++ b/packages/ns-checkmk-utils/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ns-checkmk-utils
 # renovate: datasource=github-tags depName=nethesis/checkmk-tools
-PKG_VERSION:=0.0.5
+PKG_VERSION:=1.7.6
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/ns-checkmk-utils-$(PKG_VERSION)
@@ -23,104 +23,80 @@ include $(INCLUDE_DIR)/package.mk
 define Download/check_dhcp_leases
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dhcp_leases.py
-	FILE:=check_dhcp_leases.py
-	HASH:=f168703fa052f84a7f10c5dfceb3f566c18a8accf36767b0ace7eeecb70b5887
+	FILE:=check_dhcp_leases-$(PKG_VERSION).py
+	HASH:=48d4d1d7e77f126af286857987c2214a15eed9fc219f7d5b40a218999d8ebeba
 endef
 $(eval $(call Download,check_dhcp_leases))
 
 define Download/check_dns_resolution
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_dns_resolution.py
-	FILE:=check_dns_resolution.py
-	HASH:=a06de9d22df448800a1faf7cdb0a5580e0d2cfcbd3b20473e275f0ebd9086fcc
+	FILE:=check_dns_resolution-$(PKG_VERSION).py
+	HASH:=fd1ff4f5b7cc854416c0aeabf492097ee00307944e3b3d676a311ecf978d0015
 endef
 $(eval $(call Download,check_dns_resolution))
 
 define Download/check_firewall_connections
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_connections.py
-	FILE:=check_firewall_connections.py
-	HASH:=9aff21e3586cb36e72461f508bf7e4ececcefa1c956b07aa8dbba9d2163d3c48
+	FILE:=check_firewall_connections-$(PKG_VERSION).py
+	HASH:=b02b0d860c8cd4c815509b6fff366d7de3cf7445dd3dff0da747499176c657d8
 endef
 $(eval $(call Download,check_firewall_connections))
 
 define Download/check_firewall_rules
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_rules.py
-	FILE:=check_firewall_rules.py
-	HASH:=db030f004c14955564e57ecc4e60f8b991c8e41ef090eba3b1c066bd4dfb8236
+	FILE:=check_firewall_rules-$(PKG_VERSION).py
+	HASH:=508d626f7effcbf63418c09daf10d3b8de0dc307ad75afac208fc99c19ba3771
 endef
 $(eval $(call Download,check_firewall_rules))
 
 define Download/check_firewall_traffic
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_firewall_traffic.py
-	FILE:=check_firewall_traffic.py
-	HASH:=fd76b8856a709898c05ec5b1468a028df8c5d292cbdc8890d75d47c061970bdd
+	FILE:=check_firewall_traffic-$(PKG_VERSION).py
+	HASH:=59f1a8016292d5ef9feb9d034218ec3bbdd5ef2a33ab0a5390f5fa5836ebfd31
 endef
 $(eval $(call Download,check_firewall_traffic))
-
-define Download/check_martian_packets
-	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
-	URL_FILE:=check_martian_packets.py
-	FILE:=check_martian_packets.py
-	HASH:=577060f8c53f1c43bd216de4be921ac0a06fe91de1052d45b176f6d74805c71a
-endef
-$(eval $(call Download,check_martian_packets))
-
-define Download/check_opkg_packages
-	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
-	URL_FILE:=check_opkg_packages.py
-	FILE:=check_opkg_packages.py
-	HASH:=ea8908e519e557dcd813138ae351becc75a2d6815d04e7a8a6de2479c244219d
-endef
-$(eval $(call Download,check_opkg_packages))
 
 define Download/check_ovpn_host2net
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_ovpn_host2net.py
-	FILE:=check_ovpn_host2net.py
-	HASH:=ecf4f3240276fad68e33f4124c50f41a61fcb4afc4a64914791825a0574f7c57
+	FILE:=check_ovpn_host2net-$(PKG_VERSION).py
+	HASH:=499d8423d5c03c563852383a7574c82bc22fbf3f5d3a6e4281dc41c150e2a612
 endef
 $(eval $(call Download,check_ovpn_host2net))
 
 define Download/check_root_access
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_root_access.py
-	FILE:=check_root_access.py
-	HASH:=086dbbbdb30b4b8bbf77bf3bf0f0c5b7daa07c04bcf1acefb9771ebc79aa9b98
+	FILE:=check_root_access-$(PKG_VERSION).py
+	HASH:=de1825928c5e3879724ea4ea4a17d47ab8a97925cff6c060802a0bcb0e67918e
 endef
 $(eval $(call Download,check_root_access))
-
-define Download/check_uptime
-	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
-	URL_FILE:=check_uptime.py
-	FILE:=check_uptime.py
-	HASH:=ad67d9824a598d06f9c8c7f74f1f0ff295645f1e6780ab745a3fd956005d630d
-endef
-$(eval $(call Download,check_uptime))
 
 define Download/check_vpn_tunnels
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_vpn_tunnels.py
-	FILE:=check_vpn_tunnels.py
-	HASH:=992d94c7bf5cc5329e4ef877b5ea0a3c56a247d687d9017c28add069be4886da
+	FILE:=check_vpn_tunnels-$(PKG_VERSION).py
+	HASH:=ce15c3f71c8a1cebb06b74dfe772e5c79baf4339f7eada5f654b7ae84e538e44
 endef
 $(eval $(call Download,check_vpn_tunnels))
 
 define Download/check_wan_status
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_status.py
-	FILE:=check_wan_status.py
-	HASH:=848ee2dc5526be9d193ad5f7aa23dec3f217c8bc93e7eee7a5e0efa71f83535f
+	FILE:=check_wan_status-$(PKG_VERSION).py
+	HASH:=1e721d9f606c44abe2d430e39c7b672e0798d5fc04c19e991c4c2ffbc0eecdfc
 endef
 $(eval $(call Download,check_wan_status))
 
 define Download/check_wan_throughput
 	URL:=$(NS_CHECKMK_UTILS_BASE_URL)
 	URL_FILE:=check_wan_throughput.py
-	FILE:=check_wan_throughput.py
-	HASH:=90b4f106f1a8027cc696217c2da40c35bf6e766aa06b2fc534704824332dfe47
+	FILE:=check_wan_throughput-$(PKG_VERSION).py
+	HASH:=e0e7744e3a3ae2d9ea720980967b7e6d09499c51de722af1e977713e66ec7b56
 endef
 $(eval $(call Download,check_wan_throughput))
 
@@ -139,21 +115,37 @@ define Package/ns-checkmk-utils/description
 	tailored for NethSecurity firewall systems.
 endef
 
+# check_apk_packages, check_opkg_packages, check_martian_packets, and
+# check_uptime are excluded/removed from the production check set (see
+# script-check-nsec8/full/README.md in nethesis/checkmk-tools) but may still
+# be present on disk from a previous package version - clean up both the
+# extensionless legacy names and any .py-suffixed leftovers so an upgrade
+# never leaves stale duplicate CheckMK services behind.
+define Package/ns-checkmk-utils/postinst
+#!/bin/sh
+rm -f /usr/lib/check_mk_agent/local/check_apk_packages
+rm -f /usr/lib/check_mk_agent/local/check_apk_packages.py
+rm -f /usr/lib/check_mk_agent/local/check_opkg_packages
+rm -f /usr/lib/check_mk_agent/local/check_opkg_packages.py
+rm -f /usr/lib/check_mk_agent/local/check_martian_packets
+rm -f /usr/lib/check_mk_agent/local/check_martian_packets.py
+rm -f /usr/lib/check_mk_agent/local/check_uptime
+rm -f /usr/lib/check_mk_agent/local/check_uptime.py
+exit 0
+endef
+
 define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
-	$(CP) $(DL_DIR)/check_dhcp_leases.py $(PKG_BUILD_DIR)/check_dhcp_leases.py
-	$(CP) $(DL_DIR)/check_dns_resolution.py $(PKG_BUILD_DIR)/check_dns_resolution.py
-	$(CP) $(DL_DIR)/check_firewall_connections.py $(PKG_BUILD_DIR)/check_firewall_connections.py
-	$(CP) $(DL_DIR)/check_firewall_rules.py $(PKG_BUILD_DIR)/check_firewall_rules.py
-	$(CP) $(DL_DIR)/check_firewall_traffic.py $(PKG_BUILD_DIR)/check_firewall_traffic.py
-	$(CP) $(DL_DIR)/check_martian_packets.py $(PKG_BUILD_DIR)/check_martian_packets.py
-	$(CP) $(DL_DIR)/check_opkg_packages.py $(PKG_BUILD_DIR)/check_opkg_packages.py
-	$(CP) $(DL_DIR)/check_ovpn_host2net.py $(PKG_BUILD_DIR)/check_ovpn_host2net.py
-	$(CP) $(DL_DIR)/check_root_access.py $(PKG_BUILD_DIR)/check_root_access.py
-	$(CP) $(DL_DIR)/check_uptime.py $(PKG_BUILD_DIR)/check_uptime.py
-	$(CP) $(DL_DIR)/check_vpn_tunnels.py $(PKG_BUILD_DIR)/check_vpn_tunnels.py
-	$(CP) $(DL_DIR)/check_wan_status.py $(PKG_BUILD_DIR)/check_wan_status.py
-	$(CP) $(DL_DIR)/check_wan_throughput.py $(PKG_BUILD_DIR)/check_wan_throughput.py
+	$(CP) $(DL_DIR)/check_dhcp_leases-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_dhcp_leases.py
+	$(CP) $(DL_DIR)/check_dns_resolution-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_dns_resolution.py
+	$(CP) $(DL_DIR)/check_firewall_connections-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_firewall_connections.py
+	$(CP) $(DL_DIR)/check_firewall_rules-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_firewall_rules.py
+	$(CP) $(DL_DIR)/check_firewall_traffic-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_firewall_traffic.py
+	$(CP) $(DL_DIR)/check_ovpn_host2net-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_ovpn_host2net.py
+	$(CP) $(DL_DIR)/check_root_access-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_root_access.py
+	$(CP) $(DL_DIR)/check_vpn_tunnels-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_vpn_tunnels.py
+	$(CP) $(DL_DIR)/check_wan_status-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_wan_status.py
+	$(CP) $(DL_DIR)/check_wan_throughput-$(PKG_VERSION).py $(PKG_BUILD_DIR)/check_wan_throughput.py
 endef
 
 define Build/Compile
@@ -167,11 +159,8 @@ define Package/ns-checkmk-utils/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_firewall_connections.py $(1)/usr/lib/check_mk_agent/local/check_firewall_connections
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_firewall_rules.py $(1)/usr/lib/check_mk_agent/local/check_firewall_rules
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_firewall_traffic.py $(1)/usr/lib/check_mk_agent/local/check_firewall_traffic
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_martian_packets.py $(1)/usr/lib/check_mk_agent/local/check_martian_packets
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_opkg_packages.py $(1)/usr/lib/check_mk_agent/local/check_opkg_packages
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_ovpn_host2net.py $(1)/usr/lib/check_mk_agent/local/check_ovpn_host2net
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_root_access.py $(1)/usr/lib/check_mk_agent/local/check_root_access
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_uptime.py $(1)/usr/lib/check_mk_agent/local/check_uptime
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_vpn_tunnels.py $(1)/usr/lib/check_mk_agent/local/check_vpn_tunnels
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_wan_status.py $(1)/usr/lib/check_mk_agent/local/check_wan_status
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/check_wan_throughput.py $(1)/usr/lib/check_mk_agent/local/check_wan_throughput


### PR DESCRIPTION
## Summary

Bumps `ns-checkmk-utils` from `v0.0.5` to `v1.7.6` (nethesis/checkmk-tools) and
fixes the package's file list to match the actual production check set.

This package was never kept in sync with checkmk-tools after #1777 was closed
unmerged, so it currently ships stale/broken scripts. See
https://github.com/Coverup20/checkmk-tools/releases/tag/v1.7.6 for the full
upstream changelog (nethsec library migration, WAN status/throughput fixes,
root-login detection fix, 108 unit tests, live-verify on a real NethSecurity
8.8.0-dev device).

## Changes

- `PKG_VERSION`: `0.0.5` → `1.7.6`
- Removed `check_martian_packets` and `check_opkg_packages` from
  Download/Prepare/Install — never part of the production set (see
  `script-check-nsec8/full/README.md` in checkmk-tools: "must NOT install
  check_apk_packages.py, check_opkg_packages.py, or check_martian_packets.py")
- Did not re-add `check_apk_packages` — excluded from the package by request,
  not a useful CheckMK signal for this platform
- Removed `check_uptime` — the script itself was deleted from checkmk-tools
  as of this version
- Updated SHA256 hashes for the 10 remaining production checks
  (`check_dhcp_leases`, `check_dns_resolution`, `check_firewall_connections`,
  `check_firewall_rules`, `check_firewall_traffic`, `check_ovpn_host2net`,
  `check_root_access`, `check_vpn_tunnels`, `check_wan_status`,
  `check_wan_throughput`), verified against both the git tag content and the
  live `raw.githubusercontent.com` URLs the Makefile actually fetches
- Added `Package/ns-checkmk-utils/postinst` to remove obsolete files left by
  previous package versions (both extensionless legacy names and any
  `.py`-suffixed leftovers) for all 4 excluded/removed scripts above, so an
  upgrade never leaves stale duplicate CheckMK services in
  `/usr/lib/check_mk_agent/local/`

## Why now

This is what actually deploys the checkmk-tools v1.7.6 fixes to real
NethSecurity 8.8 devices — until this Makefile is updated, devices keep
running the old, buggy local checks regardless of what's released upstream.

## Test plan

- [ ] CI build (`build-staging.yml`/`build-main.yml`) compiles the package
      cleanly with the new hashes
- [ ] Install on a NethSecurity 8.8 test device, confirm all 10 checks appear
      under `/usr/lib/check_mk_agent/local/` with no `check_apk_packages`,
      `check_opkg_packages`, `check_martian_packets`, or `check_uptime`
      artifacts left over
- [ ] Upgrade from a device with a previous package version installed,
      confirm the postinst cleanup removes the obsolete files
