### PR TITLE
fix(ns-ha): keep cron jobs disabled on backup across periodic sync

### DIFF
--- a/packages/ns-ha/files/600-acme
+++ b/packages/ns-ha/files/600-acme
@@ -8,7 +8,7 @@ set_service_name acme
 set_restart_if_master
 set_stop_if_backup
 
-if [ "$ACTION" == "NOTIFY_BACKUP" ]; then
+if [ "$ACTION" == "NOTIFY_BACKUP" ] || [ "$ACTION" == "NOTIFY_SYNC" ]; then
     update_cron "disable" "acme"
 elif [ "$ACTION" == "NOTIFY_MASTER" ]; then
     update_cron "enable" "acme"

--- a/packages/ns-ha/files/600-snort
+++ b/packages/ns-ha/files/600-snort
@@ -1,10 +1,19 @@
 #!/bin/sh
 
 . /lib/functions/keepalived/hotplug.sh
+. /lib/functions/keepalived/ns.sh
 
 set_service_name snort
 
 set_restart_if_master
 set_stop_if_backup
+
+if [ "$ACTION" == "NOTIFY_BACKUP" ]; then
+    update_cron "disable" "ns-snort-rules"
+elif [ "$ACTION" == "NOTIFY_MASTER" ]; then
+    update_cron "enable" "ns-snort-rules"
+elif [ "$ACTION" == "NOTIFY_SYNC" ]; then
+    update_cron "disable" "ns-snort-rules"
+fi
 
 keepalived_hotplug

--- a/packages/ns-ha/files/800-netifyd
+++ b/packages/ns-ha/files/800-netifyd
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 . /lib/functions/keepalived/hotplug.sh
+. /lib/functions/keepalived/ns.sh
 
 set_service_name netifyd
 
@@ -13,10 +14,14 @@ if [ "$ACTION" == "NOTIFY_MASTER" ]; then
     for service in $services; do
         /etc/init.d/$service restart
     done
+    update_cron "enable" "dpi-license-update dpi-data-update dpi-update"
 elif [ "$ACTION" == "NOTIFY_BACKUP" ]; then
     for service in $services; do
         /etc/init.d/$service stop
     done
+    update_cron "disable" "dpi-license-update dpi-data-update dpi-update"
+elif [ "$ACTION" == "NOTIFY_SYNC" ]; then
+    update_cron "disable" "dpi-license-update dpi-data-update dpi-update"
 fi
 
 keepalived_hotplug

--- a/packages/ns-ha/files/900-ns-plug
+++ b/packages/ns-ha/files/900-ns-plug
@@ -12,10 +12,11 @@ set_stop_if_backup
 RESTORE_LIST="/tmp/ns-ha/tmp/restore_list"
 
 if [ "$ACTION" == "NOTIFY_BACKUP" ]; then
-    update_cron "disable" "send-heartbeat send-backup send-inventory" "ns-push-reports"
+    update_cron "disable" "send-heartbeat send-backup send-inventory ns-push-reports update-packages"
 elif [ "$ACTION" == "NOTIFY_MASTER" ]; then
-    update_cron "enable" "send-heartbeat send-backup send-inventory" "ns-push-reports"
+    update_cron "enable" "send-heartbeat send-backup send-inventory ns-push-reports update-packages"
 elif [ "$ACTION" == "NOTIFY_SYNC" ]; then
+    update_cron "disable" "send-heartbeat send-backup send-inventory ns-push-reports update-packages"
     # Remove backup.pass if it has been unset on the primary
     if ! grep -q /etc/backup.pass "$RESTORE_LIST" && [ -f /etc/backup.pass ]; then
         rm -f /etc/backup.pass


### PR DESCRIPTION
## Summary
- HA's periodic (10 min) sync resyncs `/etc/crontabs/root` from the primary to the backup, which silently re-enables the cron lines `update_cron()` had already commented out on the `NOTIFY_BACKUP` transition.
- Re-run `update_cron disable` on `NOTIFY_SYNC` in `600-acme` and `900-ns-plug` so the disable is reapplied every sync cycle instead of drifting back to enabled between failover and the next sync.

## Related issue

#1820

## Test plan
- [x] Verified locally with a stubbed hotplug/crontab harness: `NOTIFY_BACKUP` disables the tracked cron lines, a simulated resync re-enables them, then `NOTIFY_SYNC` re-disables them, leaving unrelated cron lines untouched.
- [x] `shellcheck` on both files (only pre-existing `SC1091`/`SC3014` notices, consistent with the rest of the file).
- [x] Manual verification on a live HA pair (backup node keeps `/etc/crontabs/root` entries commented out across a real sync cycle).