### PR TITLE
fix(telegraf): skipping down interfaces

### DIFF
--- a/packages/telegraf/files/telegraf.conf.d/os.conf
+++ b/packages/telegraf/files/telegraf.conf.d/os.conf
@@ -38,11 +38,8 @@
     influxdb_db = "os-metrics"
 
 [[inputs.ethtool]]
-  ## List of interfaces to include (default: all up interfaces)
-  # interface_include = ["eth0"]
-  ## List of interfaces to ignore (default: none)
   interface_exclude = ["wg*", "ipsec*", "tun*", "br*", "ifb-*", "pppoe-*", "eth*.*"]
-
+  down_interfaces = "skip"
   [inputs.ethtool.tags]
     influxdb_db = "os-metrics"
 


### PR DESCRIPTION
Addressed issue where during HA backup mode the ethtool would keep warning of down interface.
