### PR TITLE
build: removing board definition for some models

### DIFF
--- a/files/etc/board.d/70nethesis_boxes
+++ b/files/etc/board.d/70nethesis_boxes
@@ -50,7 +50,7 @@ nethesis-nethbox-z9)
       ucidef_set_network_device_path "eth10" "pci0000:00/0000:00:1d.0/0000:09:00.0" # ethernet
       ucidef_set_network_device_path "eth11" "pci0000:00/0000:00:1d.1/0000:0a:00.0" # ethernet
       ucidef_set_interfaces_lan_wan "eth4" "eth5"
-    elif [ -L "/sys/bus/pci/devices/0000:01:00.1" ]
+    elif [ -L "/sys/bus/pci/devices/0000:01:01.1" ]
     then
       #Intel I210 or I211 network adapter (Z9)
       ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:1c.0/0000:02:00.0" # ethernet
@@ -65,6 +65,22 @@ nethesis-nethbox-z9)
       ucidef_set_network_device_path "eth9" "pci0000:00/0000:00:01.1/0000:01:00.1" # fiber
       ucidef_set_network_device_path "eth10" "pci0000:00/0000:00:01.1/0000:01:00.2" # fiber
       ucidef_set_network_device_path "eth11" "pci0000:00/0000:00:01.1/0000:01:00.3" # fiber
+      ucidef_set_interfaces_lan_wan "eth0" "eth1"
+    elif [ -L "/sys/bus/pci/devices/0000:01:00.0" ]
+    then
+      #Intel I210 or I211 network adapter (Z9 variant)
+      ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:1c.0/0000:02:00.0" # ethernet
+      ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:1c.3/0000:03:00.0" # ethernet
+      ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:1c.4/0000:04:00.0" # ethernet
+      ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:1c.5/0000:05:00.0" # ethernet
+      ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:1c.6/0000:06:00.0" # ethernet
+      ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:1c.7/0000:07:00.0" # ethernet
+      ucidef_set_network_device_path "eth6" "pci0000:00/0000:00:1d.0/0000:08:00.0" # ethernet
+      ucidef_set_network_device_path "eth7" "pci0000:00/0000:00:1d.1/0000:09:00.0" # ethernet
+      ucidef_set_network_device_path "eth8" "pci0000:00/0000:00:01.0/0000:01:00.0" # fiber
+      ucidef_set_network_device_path "eth9" "pci0000:00/0000:00:01.0/0000:01:00.1" # fiber
+      ucidef_set_network_device_path "eth10" "pci0000:00/0000:00:01.0/0000:01:00.2" # fiber
+      ucidef_set_network_device_path "eth11" "pci0000:00/0000:00:01.0/0000:01:00.3" # fiber
       ucidef_set_interfaces_lan_wan "eth0" "eth1"
     fi
   else
@@ -102,4 +118,3 @@ esac
 board_config_flush
 
 exit 0
-

--- a/files/etc/board.d/70nethesis_boxes
+++ b/files/etc/board.d/70nethesis_boxes
@@ -96,32 +96,7 @@ nethesis-nethbox-z7)
     ucidef_set_network_device_path "eth6" "pci0000:00/0000:00:01.0/0000:01:00.0" # fiber
     ucidef_set_network_device_path "eth7" "pci0000:00/0000:00:01.0/0000:01:00.1" # fiber
     ucidef_set_interfaces_lan_wan "eth0" "eth1"
-  else
-    # standard Z7 model
-    ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:1c.0/0000:02:00.0" # ethernet
-    ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:1c.3/0000:03:00.0" # ethernet
-    ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:1c.4/0000:04:00.0" # ethernet
-    ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:1c.5/0000:05:00.0" # ethernet
-    ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:1c.6/0000:06:00.0" # ethernet
-    ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:1c.7/0000:07:00.0" # ethernet
-    ucidef_set_interfaces_lan_wan "eth0" "eth1"
   fi
-  ;;
-nethesis-nethbox-z3)
-  ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:1c.0/0000:01:00.0" # ethernet
-  ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:1c.3/0000:02:00.0" # ethernet
-  ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:1c.4/0000:03:00.0" # ethernet
-  ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:1c.5/0000:04:00.0" # ethernet
-  ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:1c.6/0000:05:00.0" # ethernet
-  ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:1c.7/0000:06:00.0" # ethernet
-  ucidef_set_interfaces_lan_wan "eth0" "eth1"
-  ;;
-nethesis-nethbox-z1)
-  ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:1c.0/0000:01:00.0" # ethernet
-  ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:1c.1/0000:02:00.0" # ethernet
-  ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:1c.2/0000:03:00.0" # ethernet
-  ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:1c.3/0000:04:00.0" # ethernet
-  ucidef_set_interfaces_lan_wan "eth0" "eth1"
   ;;
 esac
 board_config_flush


### PR DESCRIPTION
Due some kernel shenanigans seems that some boxes have their PCI definitions changed. Removing the not needed ones to try to mitigate the issue. 

Closes: https://github.com/NethServer/nethsecurity/issues/1638