### PR TITLE
fix: validate VPN/user names and remove shell interpolation

### DIFF
--- a/packages/ns-api/README.md
+++ b/packages/ns-api/README.md
@@ -5809,6 +5809,7 @@ Response example:
 
 May raise the following validation errors:
 - db_already_exists
+- invalid_name if `name` contains characters other than letters, digits and underscores
 
 ### edit-ldap-database
 
@@ -5877,6 +5878,7 @@ Response example:
 
 May raise the following validation errors:
 - db_already_exists
+- invalid_name if `name` contains characters other than letters, digits and underscores
 
 ### edit-local-database
 
@@ -5925,6 +5927,7 @@ Extra fields will be added to user object.
 May raise the following validation errors:
 - user_already_exists
 - db_not_local
+- invalid_name if `name` contains characters other than letters, digits, dots, underscores, at signs and hyphens
 
 ### edit-local-user
 
@@ -5978,6 +5981,7 @@ Extra fields will be added to user object.
 May raise the following validation errors:
 - user_already_exists
 - db_not_remote
+- invalid_name if `name` contains characters other than letters, digits, dots, underscores, at signs and hyphens
 
 ### edit-remote-user
 

--- a/packages/ns-api/files/ns.ovpnrw
+++ b/packages/ns-api/files/ns.ovpnrw
@@ -157,13 +157,28 @@ def list_user_expirations(openvpninstance):
         return ret
     return ret
 
+def user_pki_path(instance, subdir, filename):
+    # resolve a user-derived filename under the instance PKI directory,
+    # rejecting anything that would escape it
+    base = os.path.realpath(f"/etc/openvpn/{instance}/pki/{subdir}")
+    path = os.path.realpath(os.path.join(base, filename))
+    if path != base and not path.startswith(base + os.sep):
+        return None
+    return path
+
 def get_cert_expiration(instance, user):
     # used for migrated certificates not present inside the index
-    p = subprocess.run(f"openssl x509 -enddate -noout -in '/etc/openvpn/{instance}/pki/issued/{user}.crt' | sed 's/notAfter=//'", shell=True, capture_output=True, text=True)
+    crt_path = user_pki_path(instance, "issued", f"{user}.crt")
+    if not crt_path:
+        return 0
     try:
-       dt = datetime.strptime(p.stdout.strip(), "%b %d %H:%M:%S %Y %Z")
-       return dt.timestamp()
-    except:
+        p = subprocess.run(
+            ["openssl", "x509", "-enddate", "-noout", "-in", crt_path],
+            capture_output=True, text=True, check=True
+        )
+        dt = datetime.strptime(p.stdout.strip().removeprefix("notAfter="), "%b %d %H:%M:%S %Y %Z")
+        return dt.timestamp()
+    except Exception:
         return 0
 
 def generate_2fa_secret():
@@ -734,7 +749,10 @@ def add_user(args):
     if user_id == None:
         return utils.validation_error("username", "user_not_in_db", args["username"])
 
-    if os.path.exists(f"/etc/openvpn/{ovpninstance}/pki/issued/{args['username']}.crt"):
+    crt_path = user_pki_path(ovpninstance, "issued", f"{args['username']}.crt")
+    if not crt_path:
+        return utils.validation_error("username", "invalid_username", args["username"])
+    if os.path.exists(crt_path):
         return utils.validation_error("username", "user_certificate_already_exists", args["username"])
     if "ipaddr" in args and args["ipaddr"]:
         valid, error = is_valid_ip(ovpninstance, args["ipaddr"])
@@ -854,9 +872,11 @@ def delete_user(ovpninstance, username):
     
 def regenerate_user_certificate(ovpninstance, user, expiration):
     pki_dir = f"/etc/openvpn/{ovpninstance}/pki"
-    req_f = f"{pki_dir}/reqs/{user}.req"
-    key_f = f"{pki_dir}/private/{user}.key"
-    crt_f = f"{pki_dir}/issued/{user}.crt"
+    req_f = user_pki_path(ovpninstance, "reqs", f"{user}.req")
+    key_f = user_pki_path(ovpninstance, "private", f"{user}.key")
+    crt_f = user_pki_path(ovpninstance, "issued", f"{user}.crt")
+    if not (req_f and key_f and crt_f):
+        return utils.validation_error("username", "invalid_username", user)
 
     for file_path in [req_f, key_f, crt_f]:
         if os.path.exists(file_path):
@@ -876,9 +896,11 @@ def regenerate_user_certificate(ovpninstance, user, expiration):
 
 def download_user_certificate(ovpninstance, username):
     cert_dir=f"/etc/openvpn/{ovpninstance}/pki"
-    if not os.path.exists(os.path.join(cert_dir, f"issued/{username}.crt")):
+    crt_path = user_pki_path(ovpninstance, "issued", f"{username}.crt")
+    key_path = user_pki_path(ovpninstance, "private", f"{username}.key")
+    if not crt_path or not key_path or not os.path.exists(crt_path):
         return utils.validation_error("user", "user_not_found", username)
-    pem = slurp(os.path.join(cert_dir, "ca.crt")) + slurp(os.path.join(cert_dir, f"issued/{username}.crt")) + slurp(os.path.join(cert_dir, f"private/{username}.key"))
+    pem = slurp(os.path.join(cert_dir, "ca.crt")) + slurp(crt_path) + slurp(key_path)
     return {"data": pem}
 
 def download_all_user_configurations(ovpninstance):
@@ -911,8 +933,9 @@ def download_all_user_configurations(ovpninstance):
 
 def download_user_configuration(ovpninstance, username):
     cert_dir=f"/etc/openvpn/{ovpninstance}/pki"
-    crt_file = os.path.join(cert_dir, f"issued/{username}.crt")
-    if not os.path.exists(crt_file):
+    crt_file = user_pki_path(ovpninstance, "issued", f"{username}.crt")
+    key_file = user_pki_path(ovpninstance, "private", f"{username}.key")
+    if not crt_file or not key_file or not os.path.exists(crt_file):
         return utils.validation_error("username", "user_not_found", username)
     u = EUci()
     config = ''
@@ -939,7 +962,7 @@ def download_user_configuration(ovpninstance, username):
         config = config + f"remote {hostname()}"
     config = config + f'<ca>\n{slurp(os.path.join(cert_dir, "ca.crt"))}\n</ca>\n'
     config = config + f'<cert>\n{slurp(crt_file)}\n</cert>\n'
-    config = config + f'<key>\n{slurp(os.path.join(cert_dir, f"private/{username}.key"))}\n</key>\n'
+    config = config + f'<key>\n{slurp(key_file)}\n</key>\n'
     for option in ["auth", "digest", "compress"]:
         try:
             config = config + f'{option} {u.get("openvpn", ovpninstance, option)}\n'

--- a/packages/ns-objects/README.md
+++ b/packages/ns-objects/README.md
@@ -81,6 +81,8 @@ config ldap 'ad1'
 	option schema 'ad'
 ```
 
+The database `name` is used directly as the UCI section id, so when creating a new database it can only contain letters, digits and underscores.
+
 ## Users
 
 A user is a dynamic entity representing a user with all physical and virtual devices belonging to a person like PCs, mobile phones or VPN road warrior accesses.
@@ -92,6 +94,8 @@ Users are saved inside the `/etc/config/users` UCI configuration file with the f
 User objects are identified by a random section name, but they both contain:
 - a field named `database` which is a reference to the associated database, like `main`
 - a special field named `name` which must be unique inside the associated database
+
+When creating a new user, the `name` field can only contain letters, digits, dots (`.`), underscores, at signs (`@`) and hyphens (e.g. `alice`, `bob.smith`, `user@example.com`). The same rule applies to group names and to the members of a group.
 
 ## Local users
 

--- a/packages/python3-nethsec/src/nethsec/users/__init__.py
+++ b/packages/python3-nethsec/src/nethsec/users/__init__.py
@@ -258,6 +258,7 @@ def add_ldap_database(uci, name, uri, schema, base_dn, user_dn, user_attr, user_
   Returns:
     - The database identifier
   '''
+  utils.validate_uci_name(name)
   if uci.get('users', name, default=None):
       raise utils.ValidationError('name', 'db_already_exists', name)
   ldap = uci.set('users', name, 'ldap')
@@ -372,6 +373,7 @@ def add_local_database(uci, name, description=""):
   Returns:
     - The database identifier  
   '''
+  utils.validate_uci_name(name)
   if uci.get('users', name, default=None):
       raise utils.ValidationError('name', 'db_already_exists', name)
   local = uci.set('users', name, 'local')
@@ -482,6 +484,7 @@ def add_local_user(uci, name, password="", description="", database="main", extr
     Returns:
       - The user identifier
     '''
+    utils.validate_username(name)
     if get_user_by_name(uci, name, database):
         raise utils.ValidationError('name', 'user_already_exists', name)
     if get_database_type(uci, database) != "local":
@@ -583,6 +586,9 @@ def add_local_group(uci, name, users=[], description="", database="main"):
     Returns:
       - The group identifier
     '''
+    utils.validate_username(name)
+    for u in users:
+        utils.validate_username(u, 'users')
     if get_group_by_name(uci, name, database):
         raise utils.ValidationError('name', 'group_already_exists', name)
     if get_database_type(uci, database) != "local":
@@ -611,6 +617,8 @@ def edit_local_group(uci, name, users=[], description="", database="main"):
     Returns:
       - The group identifier
     '''
+    for u in users:
+        utils.validate_username(u, 'users')
     group = get_group_by_name(uci, name, database)
     if not group:
         raise utils.ValidationError('name', 'group_not_found', name)
@@ -655,6 +663,7 @@ def add_remote_user(uci, name, database, extra_fields={}):
     Returns:
       - The user identifier
     '''
+    utils.validate_username(name)
     if get_user_by_name(uci, name, database):
         raise utils.ValidationError('name', 'user_already_exists', name)
     if get_database_type(uci, database) != "ldap":

--- a/packages/python3-nethsec/src/nethsec/utils/__init__.py
+++ b/packages/python3-nethsec/src/nethsec/utils/__init__.py
@@ -73,6 +73,39 @@ def sanitize(name):
     name = name.removesuffix('_')
     return name
 
+_VALID_USERNAME = re.compile(r'^[a-zA-Z0-9._@-]+$')
+
+def validate_username(name, parameter='name'):
+    '''
+    Ensure the given user/group name is safe to store and to use as a
+    filesystem/certificate component. Allows dotted and email-style logins
+    (e.g. 'first.last', 'user@example.com') coming from local or LDAP databases.
+
+    Arguments:
+      - name -- the name to validate
+      - parameter -- the parameter name to report in the ValidationError (default: 'name')
+
+    Raises:
+      - ValidationError if the name is empty or contains disallowed characters
+    '''
+    if not name or not _VALID_USERNAME.fullmatch(name):
+        raise ValidationError(parameter, 'invalid_name', name)
+
+def validate_uci_name(name, parameter='name'):
+    '''
+    Ensure the given name is safe to use as a UCI section identifier,
+    i.e. it would not be altered by sanitize().
+
+    Arguments:
+      - name -- the name to validate
+      - parameter -- the parameter name to report in the ValidationError (default: 'name')
+
+    Raises:
+      - ValidationError if the name is empty or would be altered by sanitize()
+    '''
+    if not name or sanitize(name) != name:
+        raise ValidationError(parameter, 'invalid_name', name)
+
 def get_all_by_type(uci, config, utype):
     '''
     Return all sections of the given utype from the given config

--- a/packages/python3-nethsec/tests/test_users.py
+++ b/packages/python3-nethsec/tests/test_users.py
@@ -498,6 +498,91 @@ def test_remove_admin_user(tmp_path):
             found = True
     assert not found
 
+def test_add_local_user_invalid_name(tmp_path):
+    u = _setup_db(tmp_path)
+    for name in ["poc'; touch /tmp/PWNED; '", "a$(id)b", "../../etc/passwd", "a\nb"]:
+        with pytest.raises(utils.ValidationError) as e:
+            users.add_local_user(u, name, password="nethesis", database="second")
+        assert e.value.parameter == 'name'
+        assert e.value.message == 'invalid_name'
+
+def test_add_remote_user_invalid_name(tmp_path):
+    u = _setup_db(tmp_path)
+    for name in ["poc'; touch /tmp/PWNED; '", "a$(id)b", "../../etc/passwd", "a\nb"]:
+        with pytest.raises(utils.ValidationError) as e:
+            users.add_remote_user(u, name, "ldap2")
+        assert e.value.parameter == 'name'
+        assert e.value.message == 'invalid_name'
+
+def test_add_local_user_valid_dotted_name(tmp_path):
+    u = _setup_db(tmp_path)
+    users.add_local_user(u, "bob.smith", password="nethesis", database="second")
+    assert users.get_user_by_name(u, "bob.smith", "second") is not None
+    users.add_local_user(u, "user@example.com", password="nethesis", database="second")
+    assert users.get_user_by_name(u, "user@example.com", "second") is not None
+
+def test_add_remote_user_valid_dotted_name(tmp_path):
+    u = _setup_db(tmp_path)
+    users.add_remote_user(u, "bob.smith", "ldap2")
+    assert users.get_user_by_name(u, "bob.smith", "ldap2") is not None
+    users.add_remote_user(u, "user@example.com", "ldap2")
+    assert users.get_user_by_name(u, "user@example.com", "ldap2") is not None
+
+def test_add_local_group_invalid_name(tmp_path):
+    u = _setup_db(tmp_path)
+    with pytest.raises(utils.ValidationError) as e:
+        users.add_local_group(u, "bad;group", ["goofy"], "mydesc", database="second")
+    assert e.value.parameter == 'name'
+    assert e.value.message == 'invalid_name'
+
+def test_add_local_group_invalid_member(tmp_path):
+    u = _setup_db(tmp_path)
+    with pytest.raises(utils.ValidationError) as e:
+        users.add_local_group(u, "newgroup", ["goofy", "a$(id)b"], "mydesc", database="second")
+    assert e.value.parameter == 'users'
+    assert e.value.message == 'invalid_name'
+
+def test_edit_local_group_invalid_member(tmp_path):
+    u = _setup_db(tmp_path)
+    with pytest.raises(utils.ValidationError) as e:
+        users.edit_local_group(u, "vip", ["goofy", "a\nb"], "mydesc2", database="main")
+    assert e.value.parameter == 'users'
+    assert e.value.message == 'invalid_name'
+
+def test_add_local_database_invalid_name(tmp_path):
+    u = _setup_db(tmp_path)
+    for name in ["my.db", "db@x"]:
+        with pytest.raises(utils.ValidationError) as e:
+            users.add_local_database(u, name, "Some database")
+        assert e.value.message == 'invalid_name'
+
+def test_add_ldap_database_invalid_name(tmp_path):
+    u = _setup_db(tmp_path)
+    for name in ["my.ldap", "ldap@x"]:
+        with pytest.raises(utils.ValidationError) as e:
+            users.add_ldap_database(u, name, "ldap://1.2.3.4", "ad", "dc=test,dc=org", "cn=users,dc=test,dc=org", "cn", "cn")
+        assert e.value.message == 'invalid_name'
+
+def test_edit_delete_local_user_preexisting_dotted_name(tmp_path):
+    # Simulate a pre-existing/migrated user record with a dotted name that
+    # bypasses validate_username (which now blocks such names at creation
+    # time). Editing and deleting such legacy records must keep working.
+    u = _setup_db(tmp_path)
+    u.set('users', 'u_dotted', 'user')
+    u.set('users', 'u_dotted', 'name', 'bob.smith')
+    u.set('users', 'u_dotted', 'database', 'third')
+    u.set('users', 'u_dotted', 'description', 'Legacy dotted user')
+    u.save('users')
+
+    id = users.edit_local_user(u, "bob.smith", password="newpass", description="updated", database="third")
+    assert id == 'u_dotted'
+    user = users.get_user_by_name(u, "bob.smith", "third")
+    assert users.check_password("newpass", user["password"])
+    assert user["description"] == "updated"
+
+    assert users.delete_local_user(u, "bob.smith", database="third")
+    assert users.get_user_by_name(u, "bob.smith", "third") is None
+
 def test_get_database(tmp_path):
     u = _setup_db(tmp_path)
     assert users.get_database(u, "third") == {

--- a/packages/python3-nethsec/tests/test_utils.py
+++ b/packages/python3-nethsec/tests/test_utils.py
@@ -227,3 +227,30 @@ def test_check_password():
     shadow = utils.shadow_password(password)
     assert utils.check_password(password, shadow) == True
     assert utils.check_password("wrong_password", shadow) == False
+
+def test_validate_username_valid():
+    for name in ["alice", "bob.smith", "user@example.com", "a-b_c", "A1"]:
+        utils.validate_username(name)
+
+def test_validate_username_invalid():
+    for name in ["", None, "poc'; touch /tmp/x; '", "a$(id)b", "../../etc/passwd", "a\nb", "a b", "a/b"]:
+        with pytest.raises(utils.ValidationError) as e:
+            utils.validate_username(name)
+        assert e.value.parameter == 'name'
+        assert e.value.message == 'invalid_name'
+
+def test_validate_username_custom_parameter():
+    with pytest.raises(utils.ValidationError) as e:
+        utils.validate_username("bad;name", "users")
+    assert e.value.parameter == 'users'
+    assert e.value.message == 'invalid_name'
+
+def test_validate_uci_name_valid():
+    for name in ["alice", "bob_smith", "A1"]:
+        utils.validate_uci_name(name)
+
+def test_validate_uci_name_invalid():
+    for name in ["bob.smith", "user@example.com", "a-b", "", "a b", "poc'; touch /tmp/x; '", "a$(id)b", "../../etc/passwd", "a\nb"]:
+        with pytest.raises(utils.ValidationError) as e:
+            utils.validate_uci_name(name)
+        assert e.value.message == 'invalid_name'


### PR DESCRIPTION
## Summary
- `ns.ovpnrw`: `get_cert_expiration()` now runs `openssl` via argv instead of `shell=True`, and every user-derived OpenVPN PKI file path is resolved through a helper that rejects anything escaping the instance's PKI directory.
- `python3-nethsec`: new `utils.validate_username()` / `utils.validate_uci_name()` reject unsafe characters in user, group and database names before they are written to UCI. Editing/deleting existing records is unaffected, so pre-existing names keep working; only creation of new records is constrained. Bumped to 1.7.2.
- Docs (`ns-objects/README.md`, `ns-api/README.md`) updated to reflect the new `invalid_name` validation error and allowed character sets.

## Test plan
- [x] `packages/python3-nethsec/test.sh` — 259/259 passed, including new validation/regression tests in `test_users.py` and `test_utils.py`.
- [x] Manual verification on a live device: adding a user/group/database with disallowed characters returns `invalid_name`; existing users with unusual names can still be edited/deleted; OpenVPN cert expiration listing and downloads still work for real users.

Supersedes #1840 (rebased onto `integrate-python3-nethsec` and pushed from `origin` instead of a fork).