### PR TITLE
fix(ns-api): write /tmp/TZ without a shell

### DIFF
--- a/packages/ns-api/files/post-commit/update-timezone.py
+++ b/packages/ns-api/files/post-commit/update-timezone.py
@@ -27,4 +27,7 @@ if 'system' in changes:
         subprocess.run(["/bin/ln", "-sf", f"/usr/share/zoneinfo/{zonename_normalized}", "/etc/localtime"], check=True, capture_output=True)
     
     if timezone_value:
-        subprocess.run(["/bin/sh", "-c", f"echo '{timezone_value}' > /tmp/TZ"], check=True, capture_output=True)
+        # Write the file directly instead of going through a shell: the value comes
+        # from UCI and must never be interpreted as a command.
+        with open('/tmp/TZ', 'w') as tz_file:
+            tz_file.write(timezone_value + '\n')


### PR DESCRIPTION
The timezone post-commit hook passed the UCI timezone value through "sh -c echo '<value>' > /tmp/TZ", so a value containing a single quote broke out of the quoting and the rest was executed as a command. Write the file directly with Python instead: no shell is involved, and the resulting content is unchanged.

Assisted-by: Claude Code:claude-opus-5[1m]