### PR TITLE
Raise fw4 open-file limit

### DIFF
--- a/patches/package/network/config/firewall4/20-raise-nofile-ulimit.patch
+++ b/patches/package/network/config/firewall4/20-raise-nofile-ulimit.patch
@@ -1,0 +1,36 @@
+# Raise fw4's open-file limit so large rulesets can be applied.
+# PKG_RELEASE is bumped so this ships as a package update, without a new image.
+# https://github.com/NethServer/nethsecurity/issues/1869
+--- firewall4.ori/Makefile
++++ firewall4/Makefile
+@@ -5,7 +5,7 @@
+ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=firewall4
+-PKG_RELEASE:=2
++PKG_RELEASE:=3
+ 
+ PKG_SOURCE_PROTO:=git
+ PKG_SOURCE_URL=$(PROJECT_GIT)/project/firewall4.git
+--- firewall4.ori/patches/20-raise-nofile-ulimit.patch	1970-01-01 00:00:00.000000000 +0000
++++ firewall4/patches/20-raise-nofile-ulimit.patch	1970-01-01 00:00:00.000000000 +0000
+@@ -0,0 +1,19 @@
++Raise the open-file limit before rendering the ruleset.
++
++Each template include() holds its file descriptor until the whole render
++ends, so a large ruleset exhausts the 1024 soft limit and the render
++aborts, leaving the new ruleset unapplied. Proper fix belongs in ucode.
++
++--- a/root/sbin/fw4
+++++ b/root/sbin/fw4
++@@ -2,6 +2,10 @@
++ 
++ set -o pipefail
++ 
+++# Each template include() holds its fd until the render ends, so a large
+++# ruleset exceeds the default 1024 limit. See NethSecurity issue #1869.
+++ulimit -HSn 8192 2>/dev/null
+++
++ MAIN=/usr/share/firewall4/main.uc
++ LOCK=/var/run/fw4.lock
++ STATE=/var/run/fw4.state


### PR DESCRIPTION
## Summary

On firewalls with many port forwards and zones, applying the firewall
configuration failed part way through. The incomplete rules were then
discarded, so the firewall kept its previous rules while the command still
reported success — changes appeared to work but did not take effect.

Building the rules holds one file open per rule template until the whole set
is finished, which exceeds the limit of 1024 open files. The patch raises that
limit in `/sbin/fw4`, the single place every reload goes through (boot,
hotplug, API, manual runs).

`PKG_RELEASE` is bumped too, so the rebuilt package counts as an upgrade and
can be shipped to existing installations without releasing a new image.

Related issue: https://github.com/NethServer/nethsecurity/issues/1869

## How to test

Issue #1869 has a script that builds a firewall configuration large enough to
trigger the problem. On a test machine, run it and then `fw4 reload`:

- current release: fails with `No file descriptors available`, and the new
  rules are not applied (`nft list table inet fw4 | grep -c "dnat ip to"` is
  unchanged)
- with this patch: completes, and all 264 rules are loaded

Note `fw4 reload` exits 0 in both cases, so check the printed output rather
than the exit status.

To test on a real machine:
```
cat > /etc/apk/repositories.d/98-overrides.list << "EOF"
set -default repo_channel=pr1870
set -default version=8.8.0-pr1870.342.20260806142738.91c2eae
EOF
apk update
apk upgrade firewall4
fw4 reload <- error must be gone
```


## Still to confirm

Whether the `distfeed.nethesis.it` subscription mirror carries the `base`
feed. If it only mirrors `nethsecurity`, subscription units would need a new
image and this should get the `needs image` label.