### PR TITLE
fix(ns-storage): make no assumptions on partition naming scheme

### DIFF
--- a/packages/ns-storage/files/ns-storage-setup-disk
+++ b/packages/ns-storage/files/ns-storage-setup-disk
@@ -6,7 +6,7 @@
 
 #
 # Create a single ext4 partition on the given device.
-# Paramters:
+# Parameters:
 # - device, like '/dev/sdb'
 #
 
@@ -26,7 +26,15 @@ mount | grep -q "$device" && eerror "Device '$device' is already mounted"
 
 # cleanup partitions
 dd if=/dev/zero of="$device" bs=512 count=1 conv=notrunc 2>/dev/null
-# create a single ext4 partition
+# create a single partition
 parted -s -a optimal "$device" mklabel gpt -- mkpart primary  1 -1 >/dev/null
-mkfs.ext4 -q -F -L ns_data "$device"1 >/dev/null
-echo '{"device": "'${device}1'"}'
+# mkfs on newly created partition number 1
+partition=$(lsblk $device -o KNAME | sed -n \$p)
+partition_no=$(echo $partition | sed -E 's/.*(.)/\1/')
+if [ "$partition_no" -eq 1 ]
+then
+    mkfs.ext4 -q -F -L ns_data /dev/"$partition" >/dev/null
+else
+    eerror "Wrong partition number '$partition_no'"
+fi
+echo '{"device": "/dev/'$partition'"}'

--- a/packages/ns-storage/files/ns-storage-setup-disk
+++ b/packages/ns-storage/files/ns-storage-setup-disk
@@ -28,13 +28,20 @@ mount | grep -q "$device" && eerror "Device '$device' is already mounted"
 dd if=/dev/zero of="$device" bs=512 count=1 conv=notrunc 2>/dev/null
 # create a single partition
 parted -s -a optimal "$device" mklabel gpt -- mkpart primary  1 -1 >/dev/null
-# mkfs on newly created partition number 1
-partition=$(lsblk $device -o KNAME | sed -n \$p)
-partition_no=$(echo $partition | sed -E 's/.*(.)/\1/')
-if [ "$partition_no" -eq 1 ]
-then
-    mkfs.ext4 -q -F -L ns_data /dev/"$partition" >/dev/null
-else
-    eerror "Wrong partition number '$partition_no'"
-fi
+partprobe "$device" >/dev/null 2>&1 || :
+
+# the disk has just been wiped, so the partition we created is number 1:
+# look up its kernel name, without guessing the naming scheme
+disk=$(basename "$device")
+partition=''
+for pfile in /sys/block/"$disk"/*/partition; do
+    [ -e "$pfile" ] || continue
+    if [ "$(cat "$pfile")" -eq 1 ]; then
+        partition=$(basename "$(dirname "$pfile")")
+        break
+    fi
+done
+[ -z "$partition" ] && eerror "Partition 1 not found on '$device'"
+
+mkfs.ext4 -q -F -L ns_data /dev/"$partition" >/dev/null
 echo '{"device": "/dev/'$partition'"}'

--- a/packages/ns-storage/files/ns-storage-setup-partition
+++ b/packages/ns-storage/files/ns-storage-setup-partition
@@ -29,14 +29,16 @@ end=$(echo $free_part | awk -F':' '{print $3}')
 start_new=${start_current::-3}
 # preserve some space for future use
 start_new=$((start_new + preserve))
-
-# handle nvme
-if [[ "$dev" =~ ^/dev/nvme ]]; then
-  part="${dev}p3"
+# create new partition
+parted -s --fix -a optimal ${dev} unit MiB mkpart primary ext4 ${start_new}MiB 100% &>/dev/null
+# mkfs on newly created partition number 3
+part=$(lsblk $dev -o KNAME | sed -n \$p)
+part_no=$(echo $part | sed -E 's/.*(.)/\1/')
+if [ ${part_no} == 3 ]
+then
+    mkfs.ext4 -q -F -L ns_data /dev/${part} >/dev/null
 else
-  part="${dev}3"
+    echo "ERROR: Wrong partition number ${part_no}"
+    exit 1
 fi
-
-parted -s --fix -a optimal ${dev} unit MiB mkpart ext4 ${start_new}MiB 100% &>/dev/null
-mkfs.ext4 -q -F -L ns_data "${part}" &>/dev/null
-echo '{"device": "'${part}'"}'
+echo '{"device": "/dev/'${part}'"}'

--- a/packages/ns-storage/files/ns-storage-setup-partition
+++ b/packages/ns-storage/files/ns-storage-setup-partition
@@ -11,8 +11,15 @@
 set -e
 
 part=$(lsblk -ln | grep "/rom" | uniq | awk '{print $1}')
-dev="/dev/$(lsblk -lno pkname /dev/$part)"
+disk=$(lsblk -lno pkname /dev/$part)
+dev="/dev/$disk"
 preserve=${1:-100}
+
+# List the partition numbers currently present on $dev
+list_partitions()
+{
+    parted -s -m "$dev" print 2>/dev/null | awk -F':' '/^[0-9]+:/ {print $1}' | sort -n
+}
 
 # find free space
 free_part=$(parted -s -m $dev unit MiB print free 2>/dev/null | grep free | tail -n -1)
@@ -30,15 +37,30 @@ start_new=${start_current::-3}
 # preserve some space for future use
 start_new=$((start_new + preserve))
 # create new partition
+before=$(list_partitions)
 parted -s --fix -a optimal ${dev} unit MiB mkpart primary ext4 ${start_new}MiB 100% &>/dev/null
-# mkfs on newly created partition number 3
-part=$(lsblk $dev -o KNAME | sed -n \$p)
-part_no=$(echo $part | sed -E 's/.*(.)/\1/')
-if [ ${part_no} == 3 ]
-then
-    mkfs.ext4 -q -F -L ns_data /dev/${part} >/dev/null
-else
-    echo "ERROR: Wrong partition number ${part_no}"
+partprobe "$dev" >/dev/null 2>&1 || :
+
+# the partition number is assigned by parted, so read back the one that appeared
+part_no=$(printf '%s\n%s\n' "$before" "$(list_partitions)" | sort -n | uniq -u)
+if [ "$(echo "$part_no" | wc -l)" -ne 1 ] || [ -z "$part_no" ]; then
+    echo "ERROR: Cannot identify the partition created on ${dev}"
     exit 1
 fi
+
+# map the partition number to its kernel name, without guessing the naming scheme
+part=''
+for pfile in /sys/block/"$disk"/*/partition; do
+    [ -e "$pfile" ] || continue
+    if [ "$(cat "$pfile")" == "$part_no" ]; then
+        part=$(basename "$(dirname "$pfile")")
+        break
+    fi
+done
+if [ -z "$part" ]; then
+    echo "ERROR: Partition ${part_no} not found on ${dev}"
+    exit 1
+fi
+
+mkfs.ext4 -q -F -L ns_data /dev/${part} >/dev/null
 echo '{"device": "/dev/'${part}'"}'


### PR DESCRIPTION
Instead of guessing the separator, read back the kname of the newly-created partition via lsblk and verify its number matches what was just created.

Refs: #1863 