### PR TITLE
fix(ns-storage): drop the ns_data label when releasing the storage

### DIFF
--- a/packages/ns-storage/files/remove-storage
+++ b/packages/ns-storage/files/remove-storage
@@ -10,20 +10,22 @@ set -e
 rom_part=$(lsblk -l --json | jq -r '.blockdevices[] | select(any(.mountpoints[]; . == "/boot")) | .name')
 rom_disk=$(lsblk -lno pkname /dev/$rom_part)
 
+# Both stay empty when no storage is mounted, e.g. on factory reset
 data_part=$(lsblk -l --json | jq -r '.blockdevices[] | select(any(.mountpoints[]; . == "/mnt/data")) | .name')
-data_disk=$(lsblk -lno pkname /dev/$data_part)
+data_disk=''
+[ -n "$data_part" ] && data_disk=$(lsblk -lno pkname "/dev/$data_part")
 
 # Removing auto-mount
-uci delete fstab.ns_data
+uci -q delete fstab.ns_data || :
 uci commit fstab
 
 # Configuring rsyslog
-uci delete rsyslog.ns_data
+uci -q delete rsyslog.ns_data || :
 uci commit rsyslog
 /etc/init.d/rsyslog restart
 
 # Removing sync-data cron job
-crontab -l | grep -v "/usr/sbin/sync-data" | sort | uniq | crontab -
+(crontab -l 2>/dev/null || :) | grep -v "/usr/sbin/sync-data" | sort | uniq | crontab -
 /etc/init.d/cron restart
 
 # Stop process that will prevent umount
@@ -34,13 +36,17 @@ crontab -l | grep -v "/usr/sbin/sync-data" | sort | uniq | crontab -
 sync && sleep 5
 
 # Umounting data device
-umount -f /mnt/data
+if grep -q " /mnt/data " /proc/mounts; then
+    umount -f /mnt/data
+fi
 rm -rf /mnt/data
 
 # Release the partition being removed. Only one partition may carry the
 # ns_data label, otherwise a storage created later would be mounted over
 # /mnt/data alongside this one.
-if [ "$rom_disk" == "$data_disk" ]; then
+if [ -z "$data_part" ]; then
+    : # no storage was mounted, nothing to release
+elif [ "$rom_disk" == "$data_disk" ]; then
     # Partition carved out of the OS disk: give the space back
     parted -s "/dev/${data_disk}" rm "$(cat "/sys/class/block/${data_part}/partition")"
 else

--- a/packages/ns-storage/files/remove-storage
+++ b/packages/ns-storage/files/remove-storage
@@ -37,9 +37,16 @@ sync && sleep 5
 umount -f /mnt/data
 rm -rf /mnt/data
 
-# Removing parition
+# Release the partition being removed. Only one partition may carry the
+# ns_data label, otherwise a storage created later would be mounted over
+# /mnt/data alongside this one.
 if [ "$rom_disk" == "$data_disk" ]; then
-    parted "/dev/${data_disk}" rm 3
+    # Partition carved out of the OS disk: give the space back
+    parted -s "/dev/${data_disk}" rm "$(cat "/sys/class/block/${data_part}/partition")"
+else
+    # Secondary drive: keep the partition so its logs can still be
+    # inspected, just drop the label
+    tune2fs -L "" "/dev/${data_part}" >/dev/null
 fi
 
 # Restore dnsmasq to /tmp before the storage disappears.


### PR DESCRIPTION
## Summary

The persistent storage is auto-mounted by filesystem label (`fstab.ns_data.label=ns_data`), but `remove-storage` only released the old partition when it lived on the OS disk:

```sh
if [ "$rom_disk" == "$data_disk" ]; then
    parted "/dev/${data_disk}" rm 3
fi
```

A storage removed from a **secondary** drive therefore kept its `ns_data` label. Once a new storage was created, two partitions matched the label and `block mount` stacked both onto `/mnt/data` at boot. `ns.storage get-configuration` reported the wrong device for the same reason.

Two commits:

1. **Release the label.** On a secondary drive, clear it with `tune2fs -L ""` and keep the partition, so its logs stay available for later inspection — the behaviour proposed in the issue. On the OS disk the partition is still deleted, but the partition number now comes from `/sys/class/block/<part>/partition` instead of the hardcoded `3`.
2. **Don't abort when nothing is mounted.** Pre-existing, found while testing: with no storage configured, `lsblk -lno pkname /dev/` exits 32 and `set -e` killed the script before any teardown ran. `ns.factoryreset` invokes `remove-storage` unconditionally, so a factory reset silently skipped the storage teardown entirely.

No new dependencies — `parted` and `tune2fs` are already in `DEPENDS`.

## Related issue

#1862

## How to test

On a machine with the OS disk plus a second drive:

1. Delete the storage if one exists, then create a new one on the **secondary** drive.
2. Delete it. Check the label is gone but the partition is not:
   ```
   lsblk -lno KNAME,LABEL   # no ns_data
   lsblk /dev/<second-disk> # partition still there
   ```
3. Create a storage on a partition of the **primary** drive, then reboot.
4. Only one filesystem must be mounted:
   ```
   grep /mnt/data /proc/mounts   # a single line
   storage-status                # ok
   api-cli ns.storage get-configuration   # reports the primary drive partition
   ```

Reverse cycle (primary → delete → secondary) should leave partition 3 gone from the primary drive's GPT and the secondary partition as the only `ns_data`.

For the second commit, run `/usr/sbin/remove-storage` with no storage configured: it must exit 0 and leave dnsmasq, rsyslog, cron and victoria-metrics running.

Verified on a dev VM (OS on `vda` with a `bios_grub` partition 128, secondary `nvme0n1`): all of the above, before and after reboot.

## Known limitation

Systems that are **already** double-mounted are not repaired automatically — `data_part` resolves to two devices there. They need one manual `tune2fs -L "" /dev/<stale-partition>`; afterwards this fix keeps them correct.
