### PR TITLE
feat(inventory): send number of ARP entries

### DIFF
--- a/packages/ns-plug/files/inventory
+++ b/packages/ns-plug/files/inventory
@@ -29,7 +29,8 @@ for func in dir(inventory):
 del features['network']['configuration']
 
 data = {
-    "arp_macs": _run('cat /proc/net/arp | grep -v IP | wc -l'),
+    # keep the value as a string, like the other numeric fields of this payload
+    "arp_macs": str(inventory.info_arp_macs(uci)),
     "dmi": { "product": { "name": product, "uuid": _run("cat /sys/class/dmi/id/product_uuid") }, "bios": { "version": _run("cat /sys/devices/virtual/dmi/id/bios_version"), "vendor": _run("cat /sys/devices/virtual/dmi/id/bios_vendor")}, "board": { "product": product, "manufacturer": _run("cat /sys/devices/virtual/dmi/id/sys_vendor") }},
     "virtual": inventory.is_virtual(),
     "kernel": _run('uname'),

--- a/packages/python3-nethsec/src/nethsec/inventory/__init__.py
+++ b/packages/python3-nethsec/src/nethsec/inventory/__init__.py
@@ -857,6 +857,18 @@ def info_uptime_seconds(uci: EUci):
     except:
         return 0
 
+def info_arp_macs(uci: EUci):
+    """Count the MAC addresses currently present in the ARP cache.
+
+    It gives a rough estimate of the number of devices seen on the local networks.
+    """
+    try:
+        with open('/proc/net/arp', 'r') as f:
+            # skip the header line
+            return max(len(f.read().splitlines()) - 1, 0)
+    except:
+        return 0
+
 def info_default_ipv4(uci: EUci):
     # first method: dig -4 TXT +short o-o.myaddr.l.google.com @ns1.google.com
     try:

--- a/packages/python3-nethsec/tests/test_inventory.py
+++ b/packages/python3-nethsec/tests/test_inventory.py
@@ -1022,6 +1022,31 @@ def test_info_uptime_seconds():
 		result = inventory.info_uptime_seconds(u)
 		assert result == 0
 
+def test_info_arp_macs():
+	"""Test info_arp_macs counts the entries of /proc/net/arp"""
+	u = EUci()
+
+	# Test successful read: header line must not be counted
+	mock_arp = (
+		"IP address       HW type     Flags       HW address            Mask     Device\n"
+		"192.168.1.10     0x1         0x2         aa:bb:cc:dd:ee:01     *        br-lan\n"
+		"192.168.1.11     0x1         0x2         aa:bb:cc:dd:ee:02     *        br-lan\n"
+	)
+	with patch('builtins.open', mock_open(read_data=mock_arp)):
+		result = inventory.info_arp_macs(u)
+		assert result == 2
+
+	# Test empty cache: only the header is present
+	header_only = "IP address       HW type     Flags       HW address            Mask     Device\n"
+	with patch('builtins.open', mock_open(read_data=header_only)):
+		result = inventory.info_arp_macs(u)
+		assert result == 0
+
+	# Test exception handling (file not found)
+	with patch('builtins.open', side_effect=FileNotFoundError):
+		result = inventory.info_arp_macs(u)
+		assert result == 0
+
 def test_info_fqdn(tmp_path):
 	"""Test info_fqdn retrieves hostname from UCI"""
 	# Setup system config


### PR DESCRIPTION
The number of ARP entries estimates the number
of devices connected to the LAN.
This value is used to verify that the
Threat Shield license matches the installation size.